### PR TITLE
feat(adapters): multi-framework support (React/Vue/Angular) via headless core + monorepo

### DIFF
--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -1,0 +1,107 @@
+# Library CI — runs on every push and PR to main.
+#
+# Gate state (Round 1G):
+#   - REQUIRED  : package tests, root vitest
+#   - WARN-ONLY : size:packages, lint:publish, lint:types, build
+#
+# TODO: Promote size/lint:publish/lint:types from warn-only to required once
+# Round 1E lands createChartController and we wire `tsc --build` into the
+# pipeline so every job has a real `dist/` to inspect. See docs/CI_GATES.md.
+
+name: library-ci
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: library-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Pinned to engines field in root package.json:
+        #   "node": "^20.19.0 || >=22.12.0"
+        node: ['20.19', '22.12']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          # No packageManager field in root yet; pin to latest 9.x.
+          # When packageManager is set, action-setup reads it automatically.
+          version: 9
+
+      - name: Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run package tests (pnpm -r test)
+        run: pnpm test:packages
+
+      - name: Run legacy root vitest suite
+        run: ./node_modules/.bin/vitest run
+
+      # ---- WARN-ONLY GATES ----
+      # These all require a built `dist/` per package. Until Round 1E lands
+      # createChartController and we add `tsc --build` to the workflow, these
+      # are intentionally non-blocking. They MUST be promoted to required
+      # before the first npm publish — silent rot is the only failure mode.
+      - name: Bundle size budgets (size-limit) [WARN]
+        run: pnpm size:packages
+        continue-on-error: true
+
+      - name: Publish hygiene (publint --strict) [WARN]
+        run: pnpm lint:publish
+        continue-on-error: true
+
+      - name: Type-resolution check (attw --pack) [WARN]
+        run: pnpm lint:types
+        continue-on-error: true
+
+  build:
+    name: build (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20.19', '22.12']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # WARN-ONLY: each package's build script targets `tsconfig.build.json`,
+      # which does not exist yet. This job currently catches type regressions
+      # in any package that DOES have one. Promote to required once every
+      # publishable package ships a working `tsconfig.build.json`.
+      - name: Build all packages (pnpm -r build) [WARN]
+        run: pnpm -r build
+        continue-on-error: true

--- a/.github/workflows/library-ci.yml
+++ b/.github/workflows/library-ci.yml
@@ -20,6 +20,16 @@ concurrency:
   group: library-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Locale-dependent tests in src/utils/__tests__/dateFormat.spec.ts assume
+  # CST (UTC+8) — they were written by the upstream maintainer against
+  # local time. CI's default UTC causes off-by-one-day failures around the
+  # year boundary. Pin TZ here so the legacy suite matches the maintainer's
+  # original calibration. Long-term fix: rewrite dateFormat helpers + tests
+  # in UTC-explicit terms (tracked as a follow-up; needs maintainer review
+  # because it changes user-visible date strings).
+  TZ: 'Asia/Shanghai'
+
 jobs:
   test:
     name: test (node ${{ matrix.node }})

--- a/docs/CI_GATES.md
+++ b/docs/CI_GATES.md
@@ -1,0 +1,69 @@
+# CI Gates
+
+This file documents the quality gates wired into `.github/workflows/library-ci.yml`
+and their current enforcement state. **Updating this file is part of changing a
+gate's enforcement level** — if you flip a step from `continue-on-error: true` to
+required, update the table here in the same PR.
+
+## Gate matrix
+
+| Gate                          | Tool                          | Scope             | State    | Promotion blocker                                                                |
+|-------------------------------|-------------------------------|-------------------|----------|----------------------------------------------------------------------------------|
+| Package unit tests            | `pnpm -r test` (vitest)       | All workspaces    | REQUIRED | —                                                                                |
+| Legacy root vitest suite      | `./node_modules/.bin/vitest`  | Root `src/`       | REQUIRED | —                                                                                |
+| Bundle size budgets           | `size-limit`                  | core/react/vue/ng | WARN     | Pre-build measurement off `src/index.ts`; needs real `dist/` for accurate gzip.  |
+| Publish hygiene (exports/types/main) | `publint --strict`     | core/react/vue/ng | WARN     | publint needs `dist/` to verify file existence under `pkg.exports`.              |
+| Type-resolution (ESM + CJS)   | `@arethetypeswrong/cli` (attw)| core/react/vue/ng | WARN     | attw runs against `npm pack` output, which is empty until `tsc --build` works.   |
+| Per-package build             | `pnpm -r build` (tsc)         | All workspaces    | WARN     | Each package's `build` script points to `tsconfig.build.json` which doesn't exist yet. |
+| Coverage threshold            | `@vitest/coverage-v8`         | Root              | NOT WIRED| Intentionally deferred until Round 1E lands real engine code worth covering.     |
+
+## Per-package bundle budgets
+
+These are pre-build, source-based measurements (`size-limit` reads from
+`packages/<x>/src/index.ts`). They will be re-measured against `dist/index.js`
+once the build pipeline lands.
+
+| Package | Limit (gzip) | Today's measurement | Rationale                                                                 |
+|---------|--------------|---------------------|---------------------------------------------------------------------------|
+| core    | 30 KB        | ~1.6 KB             | Headroom for signals + controller scaffolding + a minimal indicator set.  |
+| react   | 8 KB         | ~0.8 KB             | Thin wrapper around core (`use*` hooks); peers excluded from the budget.  |
+| vue     | 8 KB         | ~1.1 KB             | Thin composable layer; `vue` excluded from the budget.                    |
+| angular | 10 KB       | ~1.2 KB             | Angular decorator runtime traditionally adds 1–2 KB; extra slack on top.  |
+
+If a limit trips, **do not raise it reflexively** — first check whether a tree
+shake or peer-dep externalization is the right move.
+
+## Publishing readiness (Round 1E target)
+
+When Round 1E lands and we are ready to publish:
+
+1. Add a `tsc --build` step before `size:packages` / `lint:publish` / `lint:types`
+   in `library-ci.yml`.
+2. Flip the three warn-only gates to required (remove `continue-on-error: true`).
+3. Re-baseline the size budgets against the real `dist/index.js`.
+4. Verify `publishConfig.provenance: true` is honored by the publish workflow
+   (it requires `id-token: write` permission and OIDC-enabled runners — already
+   the default on `ubuntu-latest`).
+
+## Top-2 promotion priority (maintainer guidance)
+
+When promoting warn-only gates to required, do them in this order:
+
+1. **`publint --strict`** — cheapest to fix, catches broken `exports`/`main`/
+   `types` paths before a user ever installs the package. Failure here means
+   the package is literally unimportable.
+2. **`size-limit`** — once budgets are baselined against real `dist/`, this is
+   the single best regression alarm for accidental dependency bloat or losing
+   tree-shakability (e.g., a stray side-effectful import).
+
+`attw` is valuable but the hardest of the three to satisfy cleanly; promote it
+third, after `exports` shape has stabilized post-Round-1E.
+
+## Local commands
+
+```bash
+pnpm test:packages     # workspace tests
+pnpm size:packages     # bundle budgets
+pnpm lint:publish      # publint --strict, every publishable package
+pnpm lint:types        # attw --pack, every publishable package
+```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,380 @@
+# @klinechart-quant — 后期详细技术方案
+
+> 范围：v0(core + react/vue/angular 三框架壳 + 5 组件 + npm 发布)已完成。本文档是 v0 之后的详细技术设计，落到具体架构分层、具体轮子选型与替代品取舍、数学模型推导、关键 trade-off。
+>
+> 重心是 P1(WebGPU renderer 与三个差异化组件)，写到可直接动手的深度；P2–P4 给到实现级架构与选型深度。
+
+读者：CTO、渲染引擎负责人(作者)、产品与模型负责人(你)、AI Coding Agent。
+
+---
+
+## 0. 全局架构：core 怎么分层
+
+在展开任何一个阶段之前，我们需要先把 `@klinechart-quant/core` 的内部分层讲清楚，因为后面四个阶段全部是往这张骨架上横向挂东西，而不是动骨架本身。理解了这张骨架，你就能理解为什么每个新能力都能"加进去而不推翻"。
+
+core 内部分成七个子模块，它们之间是单向依赖的。最底下是 `store`，一个框架无关的响应式状态容器，它持有图表的全部状态——可见时间范围、价格范围、指标列表、绘图对象、布局。它之上是 `scale`，负责坐标系——把时间和价格映射到屏幕像素，这是整个图表的数学核心。再往上是 `data`，负责数据的获取、维护(尤其是 order book 这种需要增量维护的结构)和列式存储。`compute` 负责指标和聚合计算，它会用到 `data` 提供的数据。`scene` 是场景图，把图表抽象成一组 layer(K 线层、成交量层、指标层、绘图层、十字光标层)。`render` 是渲染层，定义了一个抽象的 `Renderer` 接口，然后有 `WebGLRenderer` 和(P1 之后的)`WebGPURenderer` 两个实现。最上面是 `interaction`，处理鼠标键盘触摸，把用户操作翻译成对 `store` 的修改。
+
+```
+interaction  (pan / zoom / crosshair / picking)
+     │  改 store
+     ▼
+   store  (响应式状态：可见范围、指标、绘图、布局)
+     │  被订阅
+     ▼
+   scene  (layer 列表：candle / volume / indicator / drawing / crosshair)
+     │  用 scale 算坐标，用 render 画
+     ├──► scale   (TimeScale / PriceScale，linear & log)
+     ├──► data    (DataSource / OrderBook / Arrow 列存)
+     ├──► compute (指标 runtime / GPU 聚合)
+     └──► render  (Renderer 接口 → WebGLRenderer | WebGPURenderer)
+```
+
+这个分层里最关键的设计是：**`render` 是一个接口，不是一个实现**。v0 里它只有 `WebGLRenderer`，P1 加 `WebGPURenderer`，两者实现同一个接口。`scene` 只知道"我有一组 layer，每个 layer 调 renderer 的 `drawInstances`、`drawLines`、`dispatchCompute` 这些方法"，它完全不知道底下是 WebGL 还是 WebGPU。这就是横向扩展能成立的结构基础——换渲染后端，`scene` 以上一行不改。
+
+三个框架壳(react/vue/angular)的职责到这里也就清楚了：它们只做两件事，一是在组件挂载时创建 core 实例并把 DOM 容器交给它，二是当 props 变化时调用 core 的命令式方法。所有逻辑都在 core，壳是几十行的胶水。这一点必须像宪法一样守住，因为一旦有人为了图方便在 React 壳里写了一段业务逻辑，Vue 和 Angular 用户就立刻拿不到这个功能，全生态承诺当场破产。
+
+---
+
+## 1. 坐标系的数学模型(所有图表的地基)
+
+在讲渲染之前必须先把坐标系讲透，因为这是金融图表区别于普通可视化、也是 klinecharts 这类库手感做不好的根本原因。我们先建立直觉，再写公式。
+
+### 1.1 为什么 X 轴用 bar index 而不是时间戳
+
+一个新手会很自然地想：X 轴是时间，那 `x = (t - t_start) / (t_end - t_start) * width` 不就行了吗？这在普通时间序列里对，但在金融图表里错得离谱。原因是金融市场有非交易时段——周末、夜盘休市、停牌、节假日。如果用真实时间戳做线性映射，周五收盘到周一开盘之间会出现一大段空白，K 线之间的间距会忽宽忽窄，交易员看着会很难受，因为他们的肌肉记忆是"每根 K 线等宽"。
+
+所以专业图表的 X 轴实际上是**离散的 bar 序号**，不是连续时间。第 0 根 K 线、第 1 根、第 2 根……等间距排列，时间只是每根 K 线附带的标签。映射公式是：
+
+```
+x(i) = (i - firstVisibleIndex) * barWidth + leftPadding
+```
+
+其中 `i` 是 bar 的全局序号，`firstVisibleIndex` 是当前视口最左边那根 K 线的序号(可以是小数，因为可以滚动到"半根"位置)，`barWidth` 是每根 K 线占的像素宽度(缩放就是改这个值)。这个设计带来一个副作用：时间轴的刻度标签需要反过来从 bar index 查时间戳，而且因为时间不连续，刻度不能均匀分布，要在"自然时间边界"(每天开盘、每周一、每月一号)处打标签。这部分逻辑是时间轴做得专不专业的分水岭，KLineQuant 已经处理了，这是它的隐性资产。
+
+这里有一个 **trade-off** 值得点明：bar-index 方案让 K 线等宽、手感好，但牺牲了"时间是连续维度"这个性质。如果将来要做跨周期对齐(比如把 1 分钟图和日线图按真实时间对齐叠加)，bar-index 就会很别扭，需要额外的时间→索引映射层。对于纯 K 线展示，bar-index 是正确选择；对于多资产时间对齐分析，需要在 `scale` 里额外维护一个 wall-clock 模式。建议 v0 之后保持 bar-index 为默认，把 wall-clock 模式作为 `TimeScale` 的一个可选 mode，而不是替换。
+
+### 1.2 价格轴：线性与对数
+
+Y 轴把价格映射到像素。线性模式很直接，价格 `p` 在可见范围 `[pMin, pMax]` 内的位置是：
+
+```
+y(p) = height - (p - pMin) / (pMax - pMin) * height
+```
+
+注意减法是因为屏幕坐标 Y 向下增长，而价格向上增长，要翻转。
+
+对数模式是金融图表的必备项，因为长期价格图(比如比特币从 100 美元到 10 万美元)在线性轴上早期的波动会被压成一条平线，看不出结构。对数轴让"百分比变化"在视觉上等距：
+
+```
+y(p) = height - (ln(p) - ln(pMin)) / (ln(pMax) - ln(pMin)) * height
+```
+
+KLineQuant 的 changelog 里提到它在 v0.5.6 做了"对数坐标轴像素级均布网格线"，这说明作者已经踩过这里的坑——对数轴的网格线不能均匀分布，要在 `10^k` 这样的自然边界上放刻度，否则网格会乱。这又是一块隐性资产。
+
+### 1.3 缩放锚点的数学(手感的核心)
+
+为什么 TradingView 的缩放手感好，而很多开源库缩放时图表会"跳"？核心在于缩放锚点。当用户在某个鼠标位置 `mouseX` 滚轮缩放时，正确的行为是：**鼠标指向的那个数据点，在缩放前后必须停留在同一个屏幕像素上**。这叫 anchored zoom。
+
+数学上，设缩放前鼠标处对应的 bar index 是 `i_anchor`(通过 1.1 的逆运算求得)，缩放是把 `barWidth` 乘以一个因子 `k`(滚轮上滚 k>1 放大，下滚 k<1 缩小)。缩放后我们要解出新的 `firstVisibleIndex'`，使得 `i_anchor` 仍然落在 `mouseX`：
+
+```
+缩放前：  mouseX = (i_anchor - firstVisibleIndex)  * barWidth  + leftPadding
+缩放后：  mouseX = (i_anchor - firstVisibleIndex') * barWidth' + leftPadding
+其中     barWidth' = barWidth * k
+
+两式相等，解出：
+firstVisibleIndex' = i_anchor - (mouseX - leftPadding) / barWidth'
+```
+
+这个公式保证锚点不动。KLineQuant 的 roadmap 第一条就是"K-line zoom anchor stability"，说明这是作者明确攻克过的点。价格轴的缩放锚点同理。这种细节做不到，用户一缩放就觉得"廉价"，而它恰恰是纯数学问题，没有捷径，只能一个个公式推对。
+
+---
+
+## 2. P1 — WebGPU Renderer(渲染代差)
+
+这是 v0 之后第一个、也是最硬的一块。目标是在保留现有 WebGL renderer 作为 fallback 的前提下，横向加一个 WebGPU renderer，把 WebGL 打不动的极限密度场景(百万级 tick replay、L2 heatmap、footprint)拿下。
+
+### 2.1 为什么 WebGPU 能做 WebGL 做不到的事
+
+要让你和作者都认同"值得花这个力气"，得先讲清楚 WebGPU 的代际优势到底在哪，而不是泛泛地说"更快"。有三个具体的、WebGL 结构上给不了的能力。
+
+第一是 **compute shader**。WebGL 只有 vertex shader 和 fragment shader，它的设计是"渲染管线"，你不能用它做通用并行计算。如果你想在 GPU 上做"把一百万笔成交按价格分桶求和"这种聚合，WebGL 时代的做法是用 fragment shader 玩各种 hack(把数据编码进纹理，用 blending 做累加)，又慢又难维护。WebGPU 有真正的 compute shader，你可以写一个 WGSL kernel，直接对一个 buffer 做并行 reduce。这让 volume profile、heatmap binning、footprint 聚合这些计算从 CPU 卸载到 GPU，这是质变。
+
+第二是 **storage buffer 的灵活读写**。WebGL 的 shader 只能读纹理、读顶点属性，不能随机读写一个大数组。WebGPU 的 compute shader 可以对 storage buffer 随机读写，这让"维护一个百万级的环形 tick buffer 并在 GPU 上处理"成为可能。
+
+第三是 **更低的 draw call 开销和更现代的资源绑定模型**。WebGPU 的 bind group、pipeline 是预编译的，每帧的状态切换成本远低于 WebGL 的命令式状态机。在需要画很多 layer、很多 pass 的复杂图表里，这个差异会累积成可感知的帧率差。
+
+明确这三点之后，P1 的边界也清楚了：**WebGPU renderer 不是要替换 WebGL renderer 在普通 K 线场景的角色**——WebGL 在那里已经 200fps，够了。WebGPU 是专门用来吃那些"需要 GPU 通用计算 + 大 buffer 随机读写"的高密度场景。两个 renderer 各有主场，这正是"横向"的体现。
+
+### 2.2 用什么轮子，以及为什么不用别的
+
+这是你要的"具体轮子"。WebGPU 这一层的选型有几个真实的岔路口。
+
+底层 API 上，**直接用原生 WebGPU API**，不要套 three.js。three.js 是为 3D 场景设计的，它的 Object3D、材质系统、场景图对一个 2D 金融图表是纯粹的负担，会带进来几百 KB 的你用不上的代码，而且它的抽象会挡在你和 GPU 之间，让你想做的底层优化(比如自定义的环形 buffer)很难落地。金融图表本质是大量 2D 实例化矩形和线，直接写 WGSL 反而更简单、更可控。
+
+但原生 WebGPU API 非常啰嗦，创建一个 buffer、写一个 uniform 要写很多样板代码。这里推荐用一个极薄的工具层 **`webgpu-utils`**(greggman 维护的小库)，它把 buffer 创建、uniform 布局、typed array 视图这些样板封装掉，但不引入任何抽象。它的定位类似于"WebGPU 的 lodash"，帮你省样板，但不挡路。替代品 `TypeGPU` 更激进地用 TypeScript 类型描述 GPU 资源，类型安全更好，但它还年轻、API 在变，对一个要长期维护的核心库来说风险偏高，可以观望但 v0 之后这个阶段先不押注。
+
+矩阵和向量运算，2D 图表几乎用不到 4x4 矩阵，坐标变换就是上面 §1 那几个一维线性映射，放在 uniform 里传给 shader 即可，**不需要 gl-matrix**。引入它只会增加心智负担。
+
+颜色映射(heatmap 要用)推荐用 **`d3-interpolate` 和 `d3-scale-chromatic`** 这两个小模块。它们提供了经过视觉科学验证的色阶(比如 viridis、inferno 这种感知均匀的色阶)，自己手调 RGB 插值几乎不可能调得这么好。注意只引入这两个子模块，不要引入整个 d3，d3 是模块化的，可以按需安装 `d3-scale-chromatic` 单独一个包。
+
+**trade-off 总结**：原生 WebGPU + webgpu-utils 的组合，代价是代码量比用 three.js 多、需要团队真正理解 GPU 管线；收益是完全的控制力和最小的包体积。对一个要做到"超越 TradingView 渲染"的核心库，这个控制力是必须的，不能为了省事把命脉交给一个通用 3D 引擎。
+
+### 2.3 K 线的 GPU 渲染：实例化的数学
+
+讲一个具体例子，让架构落地。怎么在 GPU 上画一百万根 K 线？
+
+核心技术是 **instanced rendering(实例化渲染)**。一根 K 线由三部分组成：一个矩形实体(body，从开盘价到收盘价)和上下两根影线(wick，从实体到最高价、最低价)。如果你为每根 K 线生成完整的顶点数据上传，一百万根就是几百万个顶点，内存和带宽都爆炸。实例化的思路是：只定义**一个**单位矩形的几何(四个顶点)，然后告诉 GPU"画这个矩形一百万次，每次用不同的实例数据"。
+
+实例数据是什么？每根 K 线只需要五个数：bar index `i`、开盘 `o`、最高 `h`、最低 `l`、收盘 `c`，外加一个颜色(涨跌)。这些以紧凑的 typed array 上传到一个 instance buffer。vertex shader 在 GPU 上为每个实例计算屏幕位置：
+
+```wgsl
+// 简化的 WGSL vertex shader 思路(注释解释每步在做什么)
+struct Uniforms {
+  firstVisibleIndex: f32,  // 视口最左 bar 序号
+  barWidth: f32,           // 每根 K 线像素宽
+  priceMin: f32,           // 可见价格下界
+  priceMax: f32,           // 可见价格上界
+  viewport: vec2f,         // 画布宽高
+  logScale: f32,           // 0=线性 1=对数
+};
+
+// 把价格映射到屏幕 Y(对应 §1.2 的公式)
+fn priceToY(p: f32, u: Uniforms) -> f32 {
+  var lo = u.priceMin; var hi = u.priceMax; var pp = p;
+  if (u.logScale > 0.5) { lo = log(lo); hi = log(hi); pp = log(p); }
+  let t = (pp - lo) / (hi - lo);
+  return u.viewport.y - t * u.viewport.y;  // 翻转 Y
+}
+
+// 每个实例(每根 K 线)的处理:
+//   instance 提供 (i, o, h, l, c),vertex 提供单位矩形的角点
+//   shader 把单位矩形拉伸到 [open, close] 的价格区间、放到第 i 列
+@vertex
+fn vs(@location(0) corner: vec2f,            // 单位矩形角点 (0..1, 0..1)
+      @location(1) bar: vec4f,               // (i, open, close, 用不到)
+      @location(2) extras: vec2f) -> ... {
+  let i = bar.x;
+  let xCenter = (i - u.firstVisibleIndex) * u.barWidth + u.barWidth * 0.5;
+  let bodyLeft = xCenter - u.barWidth * 0.4;  // 实体占 80% 宽,留间隙
+  let yOpen = priceToY(bar.y, u);
+  let yClose = priceToY(bar.z, u);
+  // corner.x 在 [0,1] 之间插值出左右边,corner.y 插值出上下边
+  let x = bodyLeft + corner.x * (u.barWidth * 0.8);
+  let y = mix(yOpen, yClose, corner.y);
+  // ... 转成 clip space 返回
+}
+```
+
+这段的关键启发是：**所有坐标变换在 GPU 上做，CPU 只负责把原始 OHLC 数据上传一次**。缩放、平移时，CPU 不重新计算任何 K 线位置，只是改几个 uniform 值(`firstVisibleIndex`、`barWidth`、`priceMin/Max`)，GPU 重新算所有位置。这就是为什么 GPU 渲染缩放能丝滑——CPU 几乎没有工作。
+
+影线用类似的实例化处理，或者作为细矩形和实体一起画。
+
+### 2.4 百万 K 线的真相：LOD 与 M4 降采样
+
+这里有一个新手容易误解的点，必须澄清，否则会过度设计。"渲染一百万根 K 线"这个说法本身是有歧义的。屏幕宽度通常就一两千像素，你不可能在一千个像素里画清楚一百万根 K 线——画上去也是一团糊。所以"支持一百万根"真正的含义是：**数据里有一百万根，但任何时刻只渲染视口内可见的那些，且当可见根数超过像素数时做降采样**。
+
+这就引出 **LOD(level of detail)** 和降采样。当用户缩放到"一根 K 线还不到一个像素宽"时(比如视口要显示十万根但只有两千像素)，直接画十万个实例既浪费又糊。正确做法是把多根 K 线聚合成"一个像素列一根"。聚合不能简单取平均，那会丢掉极值，视觉上会变形。金融时间序列降采样的标准算法叫 **M4**：对每个像素列覆盖的那批 K 线，保留四个点——这批里的**最高价(Max)、最低价(Min)、第一根的开盘(first)、最后一根的收盘(last)**。M4 的数学保证是：它能精确保留降采样后折线/K 线图的视觉轮廓(像素级一致)，因为一个像素列的视觉表现完全由这四个极值决定。
+
+所以 P1 的渲染管线实际是：`data` 层持有全量(可能百万根)Arrow 列存 → `scale` 算出当前可见区间和"每像素几根" → 若每像素多于一根，`compute` 用 M4 降采样到可见像素数 → renderer 实例化绘制降采样后的结果。降采样可以在 CPU 做(几千个像素列，量不大)，也可以在 GPU compute 里做。
+
+**trade-off**：M4 完美保留视觉轮廓，但它丢失了"这个像素列里 K 线的实体颜色分布"这类细节；对于 K 线图这无所谓，对于需要每根都精确的场景(放大状态)则不用降采样直接画。这是一个根据缩放级别自动切换的策略，不是非此即彼。
+
+### 2.5 fp64 jitter 问题与 origin-shift 解法(关键 trade-off)
+
+这是一个真实的、会咬人的精度问题，而且业界有两种解法，选错会白费力气，所以单独讲。
+
+问题是这样的：GPU 默认用 32 位单精度浮点(fp32)，它的尾数只有 23 位，大约对应 7 位十进制有效数字。这对很多场景够用，但金融价格会爆掉它。设想比特币价格 67000.12，tick 是 0.01，你需要区分 67000.12 和 67000.13，这需要 7 位有效数字——正好在 fp32 的精度边缘。更糟的是当用户**放大**到很窄的价格区间(比如只看 67000.10 到 67000.20 这 0.1 美元的范围)，fp32 在做 `(p - pMin) / (pMax - pMin)` 这个减法时，两个很接近的大数相减会发生"灾难性抵消"，结果的有效位数骤降，K 线就会在屏幕上抖动、对不齐。这就是 jitter。
+
+业界有两种解法。
+
+第一种是 deck.gl 用的 **fp64 emulation(双精度模拟)**：用两个 fp32 拼出一个伪双精度——`hi = fround(x)` 取最接近的 fp32，`lo = x - hi` 存残差，然后所有加减乘都用带误差补偿的算法(two-sum、two-product)在 shader 里手算。这能在 GPU 上获得接近 fp64 的精度，但代价是每个数变成两个浮点、每个运算变成好几条指令，ALU 开销大约翻两到四倍，shader 也复杂得多。deck.gl 需要它，因为它做的是全球地理可视化，经纬度的绝对值大、跨度也大，逃不掉。
+
+第二种是 **origin-shift(原点平移)**：既然问题出在"大数相减"，那就在 CPU 上(CPU 是 fp64，精度足够)先减掉一个参考值，让 GPU 只处理小范围的相对值。具体做法是，每帧取当前可见价格区间的中点 `pRef = (pMin + pMax) / 2` 作为参考，在 CPU 上把要上传的价格全部减去 `pRef`，GPU 收到的是 `p - pRef` 这种绝对值很小的数(在放大场景下可能只有 0.0几)，fp32 处理这种小数毫无压力。uniform 里的 `priceMin/Max` 也相应改成相对值。GPU 算完得到的是相对屏幕位置，不需要再加回去因为屏幕位置本身就是相对的。
+
+**这是 P1 里一个明确的 trade-off，而且我的建议很坚定**：金融图表用 origin-shift，不要用 fp64 emulation。理由是，金融图表任何时刻的**可见**价格范围都是有限的、相对集中的(你不会同时看 0.0001 美元的山寨币和 67000 美元的比特币在同一个 Y 轴上)，origin-shift 这个"减去参考值"的廉价技巧就能把所有精度问题消灭，而它几乎零成本——只是 CPU 上每帧做一次减法。fp64 emulation 是为"绝对值大且无法局部化"的场景(地理坐标)准备的重武器，在金融图表里是杀鸡用牛刀，白白损失两到四倍的 GPU 算力。这个判断能帮你和作者省下可能好几周的弯路。
+
+### 2.6 流式 tick 的环形 buffer
+
+实时场景下 tick 以每秒成百上千的速度涌入，如果每来一个 tick 就重新分配整个 GPU buffer 并重传，会卡死。正确做法是预分配一个固定大小 N 的 **环形 buffer(ring buffer)**，维护一个写指针，新 tick 写到写指针处然后指针前进、到末尾绕回开头。渲染时根据写指针和 N 算出"最近 N 个 tick"的区间。WebGPU 的 `queue.writeBuffer` 支持写 buffer 的子区域，所以每次只传新来的那一小段，不动其余部分。这是 WebGPU storage buffer 灵活读写能力的直接受益场景，WebGL 在这里会非常别扭。
+
+---
+
+## 3. P1 的三个差异化组件：数据模型与数学
+
+渲染后端搞定后，真正拉开和 TradingView 差距的是三个它没有的组件。这三个组件的难点都不在渲染(渲染交给 §2 的 GPU 能力)，而在**数据模型与聚合数学**——这正是你负责的部分。逐个讲透。
+
+### 3.1 Volume Profile：POC / VAH / VAL 的算法
+
+Volume Profile(成交量分布图)回答一个问题：在某段时间里，各个**价格水平**上分别成交了多少量？它把成交量按价格(而非时间)聚合，画成横向的直方图贴在价格轴上。交易员用它找"成交密集区"，因为这些价位往往是支撑或阻力。
+
+数据模型上，先把可见价格范围切成 N 个等高的价格桶(price bin)，桶高通常等于若干个 tick。然后遍历每根 K 线(或每笔成交)，把它的成交量累加到对应的价格桶。这里有个细节：一根 K 线横跨 high 到 low 一个区间，它的成交量该算到哪个桶？最简单的做法是全部算到典型价 `(high+low+close)/3` 所在的桶；更精确的做法是把这根 K 线的成交量按它覆盖的价格区间均摊到多个桶里。前者快、够用，后者精确、稍慢，这是一个 **trade-off**，建议默认用典型价、提供精确模式作为选项。
+
+聚合出每个桶的总量后，算三个关键值。**POC(Point of Control，控制点)** 是成交量最大的那个桶的价格，一行 argmax 搞定。**Value Area(价值区域)** 是包含总成交量 70%(这是芝商所的传统约定，可配置)的、围绕 POC 的连续价格区间，它的上下边界就是 **VAH(Value Area High)** 和 **VAL(Value Area Low)**。
+
+Value Area 的算法是一个贪心扩张，值得写清楚因为容易写错：
+
+```
+# 求 Value Area 的标准贪心算法(注释解释每步意图)
+1. 找到 POC 桶,把它放进 value area,累计量 = POC 的量
+2. target = 总量 * 0.70
+3. 当 累计量 < target:
+     看 value area 当前上边界的上一个桶(upper)和下边界的下一个桶(lower)
+     比较 upper 和 lower 两个桶的成交量
+     把成交量更大的那一侧并进 value area,累计量加上它
+     (若一侧已到边界,只能并另一侧)
+4. 此时 value area 的最高价 = VAH,最低价 = VAL
+```
+
+这个"向成交量更大的一侧扩张"的贪心策略是行业标准，它的直觉是：价值区域应该顺着成交密集的方向生长。
+
+GPU 加速点：把成交量累加到价格桶，本质是一个 histogram/scatter-add 操作，正是 §2.1 说的 compute shader 的主场。当成交记录是百万级时，GPU 分桶相比 CPU 有数量级加速。但 POC、VAH、VAL 这几步是在 N 个桶(通常几百个)上的串行逻辑，量很小，在 CPU 上做就行，不值得上 GPU。这是一个清晰的"重活上 GPU、轻活留 CPU"的分工。
+
+### 3.2 Order Book Heatmap：L2 流式聚合
+
+这是最有"Bookmap 既视感"、也是最能体现技术深度的组件。它把订单簿的挂单量随时间变化画成热力图——X 轴是时间，Y 轴是价格，每个格子的颜色深浅代表那个时刻、那个价位上挂着多少待成交的量(resting liquidity)。交易员用它看"大单墙"的出现和撤离。
+
+数据模型的难点在于：订单簿数据是**增量(delta)**形式来的。交易所推送的不是"当前完整订单簿"，而是"在价格 P 上，挂单量变成了 S"这样的更新流(S 为 0 表示该价位挂单撤空)。你需要在客户端**维护一个完整的订单簿状态**——一个价格到挂单量的有序映射(买盘一个、卖盘一个)，每来一个 delta 就更新对应价位。这个维护是纯 CPU 的流式逻辑，用一个排序结构(可以是按 tick 量化后的价格为 key 的 Map，配合有序的价格数组)。
+
+维护好实时订单簿后，要把它"录"成热力图。做法是按固定时间间隔(比如每 100 毫秒，对应热力图的一个像素列)对当前订单簿拍一个**快照(snapshot)**，把每个价位的挂单量写进"时间 × 价格"的二维网格的对应一列。随时间推移，网格从左滚到右，形成热力图。
+
+这里有一个重要的 **trade-off 是 snapshot 还是 delta 存储**。每个时间列都存完整快照，内存消耗是 `时间列数 × 价格档数`，如果要保留很长历史会很大。另一种是只存 delta、需要时回放重建，省内存但查询慢。建议：近期窗口(屏幕上能看到的，比如最近几分钟)用快照存在 GPU storage buffer 里直接渲染，更早的历史降采样后存或丢弃。金融实时热力图的价值主要在近期，这个取舍是合理的。
+
+颜色映射要用**对数色阶**，这是另一个关键点。挂单量的分布极度不均——大部分价位挂几手，少数价位挂几千手。如果用线性色阶，那几个大单会让其余全部变成同一种淡色，看不出结构。对数映射 `intensity = (ln(size) - ln(sizeMin)) / (ln(sizeMax) - ln(sizeMin))` 把这种跨数量级的分布拉开，这就是 §2.2 要引入 `d3-scale-chromatic` 的原因——用 viridis 这种感知均匀色阶配合对数标度，大单墙和散单的层次才能同时看清。
+
+渲染上，二维网格天然就是一张纹理或一个 storage buffer，GPU 画热力图是它最擅长的事，每个格子一个 fragment，几乎零成本。
+
+### 3.3 Footprint Chart：逐笔的买卖分类与失衡
+
+Footprint(成交簇图)是专业 order flow 交易员的核心工具，零售图表几乎都没有。它在每根 K 线**内部**展开，显示这根 K 线的每个价格档上，主动买入和主动卖出各成交了多少量。它回答的是"这根 K 线涨上去，是真有买盘推动，还是只是没人卖？"
+
+数据模型的核心难点是 **trade 的买卖方向分类(aggressor side)**。每一笔成交，要判断它是"主动买"(吃掉了卖方挂单，aggressor 是买方)还是"主动卖"(砸了买方挂单)。很多交易所的逐笔数据直接带 aggressor 标志(比如 Binance 的 trade 流有 `isBuyerMaker` 字段)，那直接用。如果数据不带方向，就要用 **tick rule** 或 **Lee-Ready 算法** 推断：tick rule 是"成交价比上一笔高 → 判为主动买，低 → 主动卖，相等 → 沿用上一笔方向"；Lee-Ready 更精确，它先看成交价相对买卖中价的位置，落在中价之上判买、之下判卖，正好在中价才退回用 tick rule。这是一个 **trade-off**：有 aggressor 标志时零误差，没有时 tick rule 简单但在快速行情下有误判，Lee-Ready 准一些但要维护买卖中价。建议优先用交易所给的标志，缺失时用 tick rule 兜底并标注"推断值"。
+
+分类好之后，数据模型是：对每根 K 线(时间桶)× 每个价格档，维护两个累加器——主动买量 `askVol`(吃 ask 的量)和主动卖量 `bidVol`(吃 bid 的量)。基于这两个数算两个交易员关心的指标。**逐档失衡(imbalance)** 衡量某个价位买卖力量谁占优，常用对角线失衡：把某价位的主动买量和**下一档**的主动卖量相比，因为主动买吃的是上方的 ask、主动卖砸的是下方的 bid，对角比较才对齐。一个常见判据是某方向是另一方向的 3 倍以上就标记为失衡。**Delta** 是一根 K 线的主动买量减主动卖量的净值 `delta = ΣaskVol - ΣbidVol`，正值说明买方主导；把每根的 delta 累加得到 **cumulative delta**，这条曲线和价格的背离是 order flow 交易的经典信号。
+
+渲染上，footprint 在每根 K 线内要画很多个小数字格子(每价格档一行，左右分别是买卖量)，密度很高，这正是需要 GPU 实例化文本/矩形的场景，也是 WebGL 在高密度下吃力、WebGPU 更从容的地方。
+
+### 3.4 顺带说一句 Depth Chart
+
+深度图相对简单，作为入场券组件提一下数学。它把订单簿的累积挂单量画成两条阶梯面积：从中价向上，卖盘按价格升序累积 `askDepth(p) = Σ size(p') for all ask p' ≤ p`；向下，买盘按价格降序累积。两条曲线向两侧延展，中间的"谷"就是买卖价差。它用的是 §3.2 维护的同一个订单簿状态，只是换一种聚合(累积和)和呈现(阶梯面积)，数据模型可以复用。
+
+---
+
+## 4. P2 — 可插拔指标 Runtime(打 Pine 的封闭)
+
+P1 把渲染和差异化组件做到超越 TradingView，P2 攻它的另一条护城河：指标系统的封闭性。
+
+### 4.1 架构：指标只产出数据，不碰渲染
+
+整个指标系统的架构基石是一句话：**指标是纯函数，输入是 bar 序列和参数，输出是 plot 数据(线、柱、标记)，它绝不直接画任何东西**。渲染由 core 的 renderer 统一负责。这个解耦带来两个好处：一是同一个指标在 WebGL 和 WebGPU 后端下都能跑(因为它根本不知道后端存在)，二是指标可以在 Web Worker 或 WASM 沙箱里算，不阻塞主线程。
+
+指标接口设计成这样：
+
+```typescript
+// 指标的统一契约:三个生命周期方法
+interface Indicator<P = unknown, S = unknown> {
+  // 用参数初始化,返回指标的内部状态(比如均线要记住窗口)
+  init(params: P): S;
+  // 每来一根新 bar,更新状态并返回这根 bar 上要画的点
+  onBar(state: S, bar: Bar, index: number): Plot[];
+  // (可选)逐笔模式,用于 order flow 类指标
+  onTick?(state: S, tick: Tick): Plot[];
+}
+
+interface Plot {
+  pane: 'main' | 'sub';       // 画在主图还是副图
+  type: 'line' | 'histogram' | 'marker' | 'band';
+  value: number | [number, number];  // band 是上下两值
+  style: PlotStyle;
+}
+```
+
+KLineQuant 现有的内置指标(MA/BOLL/RSI/MACD 等)迁移到这个接口下，作为第一批内置实现，验证接口设计够不够用。
+
+### 4.2 两条扩展路径与它们的 trade-off
+
+让指标"可插拔"有两条路，各有取舍，建议两条都提供，因为它们服务不同人群。
+
+第一条是 **TS/JS 指标**。开发者直接写一个实现上面接口的 TypeScript 对象，注册进 core 就能用。这是最低门槛，前端开发者立刻能上手，适合做产品内的自定义指标。它的代价是没有沙箱——指标代码和你的应用跑在同一个上下文，一个写得烂的指标能拖垮整个页面，而且不能安全地加载陌生人写的指标。所以 TS 指标适合"自己人写的指标"，不适合开放市场。
+
+第二条是 **WASM 指标**，这才是打 Pine 的真正武器。指标用 Rust 或 AssemblyScript 写，编译成 WASM 模块，在沙箱里执行。它的三个 Pine 给不了的优势：一是**可移植**，WASM 模块是个文件，能下载、能在任何实现了同一 ABI 的平台跑，不像 Pine 锁死在 TradingView 服务器；二是**安全**，WASM 沙箱天然隔离，加上能力限制(指标只能读它声明的数据，不能联网、不能碰 DOM、不能持久化)，可以安全加载第三方指标；三是**可签名可复现**，模块有 hash，机构合规要的"这个指标到底算了什么、版本是什么"可以被审计。
+
+轮子选型上，WASM 指标有一个真实的 **trade-off**。理想的未来形态是 **WASM Component Model**(配合 `@bytecodealliance/jco` 在浏览器跑、用 WIT 描述接口)，它面向未来、跨语言、接口规范。但 Component Model 还在成熟中，工具链复杂，2026 年这个时间点对一个要稳定的库偏激进。务实的做法是 v0 之后先用**简单的手写 ABI**——约定好 WASM 模块导出 `init`/`on_bar` 函数、通过线性内存里的约定布局传 bar 数据和 plot 数据，host 用普通的 `WebAssembly.instantiate` 加载。这套简单 ABI 现在就能稳定跑，等 Component Model 工具链成熟了，可以横向加一个 Component Model 的 host 作为第二种加载方式，旧的简单 ABI 不动。这又是一次"先简单、留接口、将来横向加"的体现。
+
+编译工具链：Rust 指标用 `cargo` + `wasm-bindgen`(或更轻的 `wasm-pack`)，AssemblyScript 用 `asc` 编译器。给开发者提供一个指标项目模板，封装掉编译配置。
+
+### 4.3 GPU 指标
+
+可向量化的指标——移动平均、EMA、ATR、布林带、VWAP——本质是对价格序列做滑动窗口运算，这种规则的并行计算适合放进 §2 的 compute shader，直接在 GPU 上算，而且能和渲染共享同一个数据 buffer，省掉 CPU-GPU 往返。这条路径作为性能优化，对那些"指标要实时跟着百万级数据刷新"的场景有意义。它由作者(渲染/性能主场)实现，接口上对开发者透明——开发者写的指标声明自己"可向量化"，core 自动选 GPU 路径。
+
+---
+
+## 5. P3 — 数据层工业化(Arrow + DuckDB-WASM)
+
+P1/P2 假设数据已经在内存里，P3 把数据的获取、存储、查询做成工业级，这是支撑前面所有高密度和未来 AI 能力的地基。
+
+### 5.1 内存格式统一为 Apache Arrow
+
+这是 P3 的核心决策。让所有进入 core 的数据统一成 **Apache Arrow** 的列式格式(轮子是官方的 `apache-arrow` JS 库)。为什么是列式而不是大家习惯的"对象数组"(`[{time, open, high...}, ...]`)？因为对象数组在 JS 里每个对象是一个堆分配，百万根就是百万个堆对象，内存碎片化、GC 压力大、而且要喂给 GPU 时还得逐个拆出来拼成 typed array。Arrow 的列式布局是：所有 time 连续存一个 Float64Array、所有 open 连续存一个、等等。这带来三个直接收益：内存紧凑无对象开销；喂给 GPU 时可以**零拷贝**，因为 Arrow 的列本身就是 typed array，可以直接映射成 GPU buffer(呼应 §2.1)；供给 DuckDB 查询时也是零拷贝。
+
+这个迁移对上层是透明的——三框架壳和组件 API 接受的还是开发者友好的格式，core 在入口处转成 Arrow。
+
+### 5.2 DuckDB-WASM 做浏览器内查询
+
+引入 **`@duckdb/duckdb-wasm`**，让开发者能直接对历史数据写 SQL。这是 TradingView 结构上没有的能力——它的数据是黑盒，你不能问它"找出所有成交量超过均量三倍的 K 线"。DuckDB-WASM 是把整个 DuckDB(一个高性能列式分析数据库)编译成 WASM 跑在浏览器里，能在浏览器内查询百万级行的 Parquet 文件，而且因为它和 Arrow 同宗，数据在 DuckDB 和 core 之间零拷贝流转。
+
+应用场景：用户加载一个币种几年的数据(Parquet 格式，从你的网关或用户自己的存储拉)，DuckDB-WASM 在浏览器里直接 SQL 过滤、聚合，结果以 Arrow 形式喂给图表渲染。这把"数据探索"变成图表库的一等能力。
+
+**trade-off**：DuckDB-WASM 的体积不小(WASM 包加上要加载的数据)，首次加载有成本，所以它应该是**按需懒加载**——只有当用户用到 SQL 查询功能时才加载，普通看图不引入。
+
+### 5.3 数据接入抽象与 UDF 兼容层
+
+定义统一的 `DataSource` 接口，方法形态刻意 **mirror TradingView 的 UDF/Datafeed 协议**(`resolveSymbol`、`getBars`、`subscribeBars`)。这么做有一个战略目的：同时提供一个 `UDFDataSource` 适配器，能直接消费现存的 TradingView UDF 后端。市面上大量交易所、券商已经为接入 TradingView 实现了 UDF 后端，这个兼容层让他们**零成本**把数据接到 @klinechart-quant，这是抢 TradingView 现有集成方的迁移路径，类似 PostgreSQL 兼容 MySQL 协议的意义。
+
+默认内置实现：Binance、Coinbase、Bybit、Deribit 的 WebSocket adapter(crypto 数据免费、无牌照)。本地缓存用浏览器的 **OPFS(Origin Private File System)** 存 Parquet、**IndexedDB** 存元数据，replay 时不重复拉取。
+
+### 5.4 不可回避的硬边界
+
+必须写进文档、写进 README、写进每一次对外沟通：**实时美股、期货数据在结构上不可能免费**。交易所牌照是物理约束——纽交所的数字媒体类许可在每月数万美元量级，纳斯达克 TotalView 起步每专业用户约两千美元每月，芝商所是分级的 distribution license。这不是软件能解决的问题，是法律和商业问题。所以这个组件库/数据层在可预见阶段只覆盖三类数据：crypto(交易所 WebSocket 真免费)、链上数据(Pyth、Bitquery 等开放)、延迟数据(T+15 分钟以后通常无牌照要求，但要遵守各源的服务条款)。实时美股由用户自带牌照接入，组件库本身**永远不打包任何数据 credential**。这条边界讲得越早越清楚，企业销售环节越不会爆雷。
+
+---
+
+## 6. P4 — AI 接入(组件可被 LLM 操控)
+
+P4 是你最早那个"我在 web 里但仍能操控 UI"洞察落到组件库层面的**最小、克制**的形态。这里要特别克制：P4 不做完整的 conversational runtime、不做 agent、不做 event-sourcing，那些是 P5 之后看市场反应才碰的东西。P4 只做三件让组件"AI-ready"的事。
+
+第一，**给每个组件一套干净的命令式 API**。`chart.addIndicator(name, params)`、`chart.setTimeframe(tf)`、`chart.zoomToRange(from, to)`、`chart.annotate(spec)`。这些 API 本来做命令式控制就该有，顺手把它们的 schema 包装成 LLM 能调用的 **function-calling / MCP tool** 描述即可。LLM 不需要理解你的内部状态，它只是调这些 API。
+
+第二，**让组件状态可序列化**。整个图表的状态(当前指标、时间范围、绘图、布局)能 `serialize()` 成 JSON、能 `deserialize()` 恢复。这让 LLM 既能"读懂当前图表是什么样"，也能"生成一份新的图表配置"。一个直接的应用：用户说"给我一个看资金流的布局"，LLM 生成一份 state JSON，组件加载它。这其实就是 generative UI 在组件层面的雏形——LLM 不写渲染代码，只生成对**已有能力**的配置，core 校验后渲染。这个边界(LLM 只编排已有能力、绝不生成裸代码)是安全和可控的关键。
+
+第三，**给组件一个 `describe()` 方法**，返回当前图表的结构化自然语言描述，让 LLM 能回答"现在图上有什么""这个指标在说什么"。配合让 LLM 解读形态，这是 Pine 因封闭做不到的能力。
+
+模型不绑定，Claude/GPT/Gemini/本地都能接，适配器隔离 vendor 差异。
+
+**trade-off 与克制的理由**：P4 完全可以做得更激进(完整 event log、agent 自主操作、多步规划)，但那会让组件库变成一个重型平台，偏离"先把组件做到超越 TradingView"的聚焦。P4 的命令式 API + 状态序列化 + describe 是组件库的**合理延伸**，加完它还是一个组件库，只是这个组件库恰好 AI 能用。真正的 runtime 跃迁留给 P5，而且只在市场拉动时才做。
+
+---
+
+## 7. P5 与之后(条件触发，不默认执行)
+
+P5 是从组件库长成产品(工作台、协作、runtime)，但它**不是默认路线**，是一个由市场信号触发的可选分支。判据很简单：到 P1–P4 走完(约 14 个月)时，如果有可观的开发者采用(GitHub 星标、生产环境使用、付费意向)，才往产品走，那时是市场拉着你做；如果反应平淡，就**停在组件库**——一个被广泛采用的开源金融组件库本身就是一个健康、有价值、可被收购的成果，不必硬往平台推。这个"愿意停下"的纪律，和前面每个阶段都设回退条件是同一个工程价值观：每一步都要可验证、可止损，不为宏大叙事透支。
+
+---
+
+## 8. 全程的工程纪律与分工
+
+把贯穿所有阶段的三条铁律收在这里。第一，**横向加而非推翻**：WebGPU、WASM 指标、Arrow、AI 每一个都是新增的可选层，旧的 WebGL renderer、内置 TS 指标、JSON 数据接入永远作为 fallback 保留，不删。第二，**core 框架无关、壳极薄**：任何新能力先进 core，三个框架壳只做挂载和 props 传递，永不在某个壳里写业务逻辑，否则全生态承诺立刻破产。第三，**license 干净**：core 用 Apache 2.0，避开 AGPL/GPL，未来的商业能力放独立包，不污染核心。
+
+分工沿用已定的格局，作者是渲染与性能的主场，你是产品、API 与数据模型的主场，契约点永远是 core 的 renderer 接口和 store 接口——接口定好，各干各的，不在同一文件打架：
+
+P1 阶段，作者做 WebGPU renderer、compute shader、环形 buffer、origin-shift；你做三个差异化组件的数据模型(volume profile 的 POC/VAH/VAL、order book 的流式维护与快照、footprint 的买卖分类与失衡)和它们的视觉规格。P2 阶段，作者做指标执行框架和 GPU 指标路径；你做指标接口设计、WASM ABI 约定、指标市场形态。P3 阶段，作者做 Arrow 零拷贝管线和 DuckDB 集成；你做 DataSource 协议、UDF 兼容层、缓存策略。P4 阶段，作者保证命令式 API 的性能和状态序列化的完整；你做 tool schema、LLM 接入体验、describe 的语义设计。
+
+---
+
+## 9. 一页速查：每个决策点的 trade-off 结论
+
+为方便你和作者快速对齐，把全文的关键取舍结论汇总。X 轴用 bar-index 而非时间戳，换取 K 线等宽的手感，代价是跨周期时间对齐需额外的映射层。精度问题用 origin-shift 而非 fp64 emulation，因为金融可见价格范围有限，廉价的减参考值技巧就够，省下两到四倍 GPU 算力。底层渲染用原生 WebGPU + webgpu-utils 而非 three.js，换取完全控制力和最小包体积，代价是团队要真懂 GPU 管线。百万 K 线用 M4 降采样而非全量绘制，精确保留视觉轮廓，放大到每根可见时自动切回全量。WebGPU 永远配 WebGL fallback，牺牲一点维护成本换浏览器覆盖率和稳健性。WASM 指标先用简单手写 ABI 而非 Component Model，现在就能稳定跑，将来横向加 Component Model host。order book heatmap 近期窗口用快照存 GPU、远期降采样，在内存和查询速度间取平衡。DuckDB-WASM 按需懒加载，普通看图不付出它的体积成本。指标既给 TS 路径(低门槛、无沙箱、自己人用)又给 WASM 路径(可移植、安全、可开放市场)，分别服务不同人群。AI 接入在 P4 保持克制，只做命令式 API、状态序列化、describe，完整 runtime 留给市场拉动的 P5。
+
+---
+
+*本文档是 v0 之后的工程蓝图，P1 是紧接的下一步，也是最硬的一块。建议以 P1 的 WebGPU renderer 接口设计与三个差异化组件的数据模型作为第一个迭代周期的目标。*

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,68 @@
+# `examples/` — Framework SSR Smoke Tests
+
+These are **not feature demos**. They exist to verify that each adapter
+package (`@klinechart-quant/{react,vue,angular}`) is SSR-safe: the adapter
+modules can be imported on a server (Next.js RSC pass, Nuxt server render,
+Angular Universal prerender) without crashing, and DOM access is gated to
+the client.
+
+## Why a separate directory
+
+Each adapter contract documents an SSR-safety guarantee:
+
+| Adapter | Mount happens in | Server import safe? |
+| --- | --- | --- |
+| React | `useEffect` | yes — no `window` at module init |
+| Vue   | `onMounted` | yes — no `window` at module init |
+| Angular | `ngAfterViewInit` gated by `isPlatformBrowser` | yes |
+
+Unit tests cover the API surface and lifecycle in jsdom, but they cannot
+verify the **build pipeline** of each framework. These examples plug each
+adapter into a real Next.js / Nuxt / Angular SSR build and confirm it does
+not regress.
+
+## Workspace isolation
+
+`examples/*` is **deliberately excluded from the root `pnpm-workspace.yaml`**.
+Reasons:
+
+1. Each example pulls in a full framework's dev toolchain (Next.js + React
+   compiler, Nuxt + Vite, Angular CLI + zone.js). Including them in the root
+   workspace would multiply CI install times and lockfile churn.
+2. Smoke tests are run on-demand, not as part of every PR.
+3. Versions of Next.js / Nuxt / Angular change frequently; pinning them at
+   the root workspace level would couple library CI to framework releases.
+
+Each example is run standalone:
+
+```bash
+cd examples/next-app && pnpm install && pnpm build
+cd examples/nuxt-app && pnpm install && pnpm build
+cd examples/angular-universal && pnpm install && pnpm build  # see angular README first
+```
+
+## What gets verified
+
+| Example | KEY file | What a regression would look like |
+| --- | --- | --- |
+| `next-app/` | `app/page.tsx` | `pnpm build` errors with `ReferenceError: window is not defined` in the SSR prerender |
+| `nuxt-app/` | `pages/index.vue` `<script setup>` | `nuxt build` crashes in the SSR pass on adapter module evaluation |
+| `angular-universal/` | `src/app/app.component.ts` + adapter's `isPlatformBrowser` guard | `ng build` server bundle emits but server execution throws |
+
+## What does NOT get verified
+
+- The chart **engine** itself is not SSR-renderable (canvas / WebGL on the
+  server makes no sense). The contract is "import-safe and mount-safe", not
+  "renders pixels on the server".
+- Visual fidelity, indicator correctness, drawing tools — all covered by
+  unit tests and the legacy demo at `vite.demo.config.ts`.
+
+## Adding a new framework
+
+If a fourth framework needs an adapter (Solid, Svelte, Qwik), follow the
+same pattern:
+
+1. `examples/<framework>-app/` with the minimal setup that runs the
+   framework's SSR pipeline.
+2. Import the adapter at module top level somewhere SSR-evaluated.
+3. A README documenting the KEY assertion file and the build command.

--- a/examples/angular-universal/README.md
+++ b/examples/angular-universal/README.md
@@ -1,0 +1,101 @@
+# Angular 19 SSR Smoke — `@klinechart-quant/angular`
+
+Minimal Angular 19 + `@angular/ssr` app that proves `@klinechart-quant/angular`
+is **SSR-safe**: importing `KLineChartComponent` on the server (during prerender
+or render-on-demand) must not crash, and DOM access must be gated to the client
+via `isPlatformBrowser`.
+
+## What this proves
+
+| Boundary | File | Contract verified |
+| --- | --- | --- |
+| Module import on server | `src/app/app.component.ts` | Adapter loads at top of a standalone component used in an SSR-enabled app |
+| Server-platform guard | `KLineChartComponent` (adapter source) | `ngAfterViewInit` exits early when `isPlatformBrowser(inject(PLATFORM_ID))` is false |
+| Build pipeline | `ng build` | Angular's server bundle compiles and the prerender pass succeeds |
+
+The KEY assertion is in **`src/app/app.component.ts`** — importing
+`KLineChartComponent` at module top level from a component reachable by SSR.
+If the adapter regressed (e.g., touched `document` at import), `ng build`
+would fail during the server bundle's evaluation.
+
+## Versions targeted
+
+| Tool | Version |
+| --- | --- |
+| Angular | 19.x (standalone, no NgModule) |
+| `@angular/ssr` | 19.x |
+| Node | ^20.19 / >=22.12 (matches repo root) |
+| zone.js | 0.15 (used in browser; not active in zoneless mode) |
+
+This example uses **`provideExperimentalZonelessChangeDetection()`** — the
+adapter component is `OnPush` and the signal-based viewport bridge fits the
+zoneless model cleanly.
+
+## How to scaffold + run
+
+Because the full Angular workspace needs `angular.json`, `tsconfig.app.json`,
+`tsconfig.server.json`, `server.ts`, and an `assets/` config — and the
+Angular CLI is the only safe authority on the current schema — this example
+ships the **distinctive files** (the component, the bootstraps, this README)
+and asks you to scaffold the surrounding workspace with the CLI:
+
+```bash
+cd examples/angular-universal
+
+# 1. Use the Angular CLI to scaffold the workspace shell into the current dir.
+#    Answer: routing? no. stylesheet? css. SSR? YES.
+pnpm install
+pnpm dlx @angular/cli@19 new angular-universal \
+  --directory=. \
+  --routing=false \
+  --style=css \
+  --ssr \
+  --skip-git \
+  --skip-install
+
+# 2. Replace the generated src/app/app.component.ts and src/main.{ts,server.ts}
+#    with the ones already in this directory (they are the smoke test).
+#    The CLI's defaults are fine for everything else.
+
+# 3. Build the SSR bundle — this is the smoke test.
+pnpm install
+pnpm build
+
+# 4. (optional) run the SSR server locally
+pnpm start
+```
+
+A successful `pnpm build` is the verification — Angular emits both browser and
+server bundles, prerenders the root route, and the build pipeline does not
+crash on the adapter's server-side import.
+
+## Why this isn't fully self-contained
+
+`@angular/cli` regenerates the workspace shell (angular.json, tsconfigs,
+server.ts) based on the user's CLI version. Hardcoding those files would rot
+quickly across Angular minor releases. The KEY contract the smoke verifies —
+that the adapter's `ngAfterViewInit` uses `isPlatformBrowser` — is owned by
+the files this example DOES ship.
+
+## Current limitations
+
+- The chart engine itself is not visually rendered on the server — the smoke
+  proves import + server bundle build + client hydration.
+- This example is intentionally isolated from `pnpm -r test` so it never
+  blocks unrelated CI runs.
+
+## Files shipped
+
+```
+examples/angular-universal/
+├── src/
+│   ├── app/
+│   │   └── app.component.ts       # standalone; imports KLineChartComponent
+│   ├── main.ts                    # client bootstrap (zoneless)
+│   └── main.server.ts             # server bootstrap (zoneless + platform-server)
+├── package.json                   # private, workspace:* dep on @klinechart-quant/angular
+└── README.md
+```
+
+The Angular CLI fills in `angular.json`, `tsconfig*.json`, `server.ts`,
+`index.html`, and the `assets/` directory when you scaffold per step 1 above.

--- a/examples/angular-universal/package.json
+++ b/examples/angular-universal/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "@klinechart-quant-examples/angular-universal",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Angular 19 SSR (Universal) smoke test for @klinechart-quant/angular.",
+    "type": "module",
+    "scripts": {
+        "ng": "ng",
+        "build": "ng build",
+        "start": "node dist/angular-universal/server/server.mjs"
+    },
+    "dependencies": {
+        "@angular/animations": "^19.0.0",
+        "@angular/common": "^19.0.0",
+        "@angular/compiler": "^19.0.0",
+        "@angular/core": "^19.0.0",
+        "@angular/platform-browser": "^19.0.0",
+        "@angular/platform-browser-dynamic": "^19.0.0",
+        "@angular/platform-server": "^19.0.0",
+        "@angular/router": "^19.0.0",
+        "@angular/ssr": "^19.0.0",
+        "@klinechart-quant/angular": "workspace:*",
+        "@klinechart-quant/core": "workspace:*",
+        "express": "^4.21.0",
+        "rxjs": "^7.8.0",
+        "tslib": "^2.7.0",
+        "zone.js": "^0.15.0"
+    },
+    "devDependencies": {
+        "@angular-devkit/build-angular": "^19.0.0",
+        "@angular/cli": "^19.0.0",
+        "@angular/compiler-cli": "^19.0.0",
+        "@types/express": "^4.17.21",
+        "@types/node": "^22.0.0",
+        "typescript": "~5.6.0"
+    }
+}

--- a/examples/angular-universal/src/app/app.component.ts
+++ b/examples/angular-universal/src/app/app.component.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core'
+/**
+ * KEY ASSERTION: this file imports `@klinechart-quant/angular` at module top
+ * level from a standalone component used by an SSR-enabled Angular app. If
+ * the adapter regressed and accessed `window` / `document` at module init,
+ * the `@angular/ssr` server pass would crash on `ng build`.
+ *
+ * `KLineChartComponent` itself uses `isPlatformBrowser(inject(PLATFORM_ID))`
+ * to gate DOM access inside `ngAfterViewInit`, so server rendering produces
+ * an empty container shell and the client takes over on hydration.
+ */
+import { KLineChartComponent } from '@klinechart-quant/angular'
+import type { KLineData } from '@klinechart-quant/core'
+
+@Component({
+    selector: 'app-root',
+    standalone: true,
+    imports: [KLineChartComponent],
+    template: `
+        <h1>&#64;klinechart-quant/angular — Angular 19 SSR smoke</h1>
+        <p>Chart mounts on the client. SSR pass renders the shell only.</p>
+        <kline-chart
+            [data]="mockData"
+            theme="light"
+            style="display: block; width: 100%; height: 400px; border: 1px solid #ddd;"
+        ></kline-chart>
+    `,
+})
+export class AppComponent {
+    mockData: ReadonlyArray<KLineData> = Array.from({ length: 100 }, (_, i) => ({
+        timestamp: 1_700_000_000_000 + i * 60_000,
+        open: 100 + i * 0.5,
+        high: 101 + i * 0.5,
+        low: 99 + i * 0.5,
+        close: 100.5 + i * 0.5,
+        volume: 1_000 + i * 10,
+    }))
+}

--- a/examples/angular-universal/src/main.server.ts
+++ b/examples/angular-universal/src/main.server.ts
@@ -1,0 +1,13 @@
+import { bootstrapApplication } from '@angular/platform-browser'
+import { provideServerRendering } from '@angular/platform-server'
+import { provideExperimentalZonelessChangeDetection } from '@angular/core'
+import { AppComponent } from './app/app.component'
+
+export default function bootstrap() {
+    return bootstrapApplication(AppComponent, {
+        providers: [
+            provideServerRendering(),
+            provideExperimentalZonelessChangeDetection(),
+        ],
+    })
+}

--- a/examples/angular-universal/src/main.ts
+++ b/examples/angular-universal/src/main.ts
@@ -1,0 +1,7 @@
+import { bootstrapApplication } from '@angular/platform-browser'
+import { provideExperimentalZonelessChangeDetection } from '@angular/core'
+import { AppComponent } from './app/app.component'
+
+bootstrapApplication(AppComponent, {
+    providers: [provideExperimentalZonelessChangeDetection()],
+}).catch((err) => console.error(err))

--- a/examples/next-app/README.md
+++ b/examples/next-app/README.md
@@ -1,0 +1,73 @@
+# Next.js 15 SSR Smoke — `@klinechart-quant/react`
+
+Minimal Next.js 15 App Router app that proves `@klinechart-quant/react` is
+**SSR-safe**: importing the adapter on the server must not crash, and the
+chart must mount only in the browser via `useEffect`.
+
+## What this proves
+
+| Boundary | File | Contract verified |
+| --- | --- | --- |
+| Module import on server | `app/page.tsx` | Adapter loads at top of a **server component** without touching `window` / `document` |
+| Client mount via `useEffect` | `app/chart.tsx` | `useChart(ref, opts)` only touches DOM after commit |
+| Build pipeline | `next build` | No `ReferenceError: window is not defined` in the SSR prerender pass |
+
+The KEY file for the SSR-safety contract is **`app/page.tsx`** — it imports
+`@klinechart-quant/react` at module top level from a server component. If the
+adapter regressed and accessed `window` at module init, this build would
+fail.
+
+## Versions targeted
+
+| Tool | Version |
+| --- | --- |
+| Next.js | 15.x (App Router) |
+| React  | 19.x |
+| Node   | ^20.19 / >=22.12 (matches repo root) |
+
+## How to run
+
+This example is **not** part of the root pnpm workspace (see top-level
+`examples/README.md` for the rationale). Install + build from inside the
+example:
+
+```bash
+cd examples/next-app
+pnpm install
+pnpm build
+```
+
+A successful `pnpm build` is the verification. You do **not** need to run
+`pnpm dev` for the smoke test — the build pass exercises the SSR pipeline.
+
+If you do run `pnpm dev`, the client-side `useChart` hook will throw
+`No ChartControllerFactory registered` until the production factory is
+wired (Phase 1 deliverable per the adapter source). That is expected and
+**does not invalidate the SSR smoke**.
+
+## Current limitations
+
+- The chart engine itself is not visually rendered — the smoke proves
+  import + SSR build + client commit, not pixels.
+- This example is intentionally isolated from `pnpm -r test` so it never
+  blocks unrelated CI runs.
+- Workspace dependency on `@klinechart-quant/react` is `workspace:*`; if
+  you copy this example outside the monorepo, replace it with a real
+  published version.
+
+## Files
+
+```
+examples/next-app/
+├── app/
+│   ├── chart.tsx         # 'use client' — useChart with real ref
+│   ├── layout.tsx        # Minimal HTML shell
+│   └── page.tsx          # Server component — adapter import at module top
+├── lib/
+│   └── mockData.ts       # 100 deterministic candles
+├── next.config.mjs       # transpilePackages for workspace symlinks
+├── next-env.d.ts
+├── package.json          # private, workspace:* dep
+├── tsconfig.json
+└── README.md
+```

--- a/examples/next-app/app/chart.tsx
+++ b/examples/next-app/app/chart.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+/**
+ * Client component for the SSR smoke test.
+ *
+ * KEY ASSERTION: `useChart` is invoked here with a real DOM ref. Because
+ * this component is gated by `'use client'`, Next runs it in the browser
+ * during the commit phase. The adapter's `useEffect`-based mount path is
+ * the only code that touches `window` / `document` — confirming the contract:
+ * "mount happens only in the browser via useEffect".
+ *
+ * In the SSR pass, Next renders the component shell (the host div) but
+ * `useEffect` does not run, so no DOM access occurs server-side.
+ */
+import { useRef } from 'react'
+import { useChart, type ChartMountOptions } from '@klinechart-quant/react'
+import type { MockCandle } from '@/lib/mockData'
+
+interface ChartProps {
+    data: ReadonlyArray<MockCandle>
+}
+
+export default function Chart({ data }: ChartProps): JSX.Element {
+    const containerRef = useRef<HTMLDivElement | null>(null)
+    // NOTE: `data` here is plain mock — the engine factory is not wired in
+    // this smoke test, so the hook will throw at mount time IF a consumer
+    // actually runs `pnpm dev` without registering a factory. That is the
+    // documented contract — production users call `__setChartFactory(...)`
+    // before mounting. The SSR/build pass never reaches that point, so
+    // `next build` succeeds regardless.
+    useChart(containerRef, {
+        data: data as unknown as ChartMountOptions['data'],
+    })
+
+    return (
+        <div
+            ref={containerRef}
+            style={{
+                width: '100%',
+                height: 400,
+                border: '1px solid #ddd',
+                marginTop: 16,
+            }}
+        >
+            <span style={{ padding: 8, display: 'inline-block', color: '#888' }}>
+                Chart mounts here on the client. SSR build only renders this
+                shell.
+            </span>
+        </div>
+    )
+}

--- a/examples/next-app/app/layout.tsx
+++ b/examples/next-app/app/layout.tsx
@@ -1,0 +1,21 @@
+/**
+ * Root layout — minimal HTML shell. No client-only code here.
+ */
+import type { ReactNode } from 'react'
+
+export const metadata = {
+    title: 'KLineChart SSR Smoke',
+    description: '@klinechart-quant/react SSR safety verification',
+}
+
+export default function RootLayout({
+    children,
+}: {
+    children: ReactNode
+}): JSX.Element {
+    return (
+        <html lang="en">
+            <body>{children}</body>
+        </html>
+    )
+}

--- a/examples/next-app/app/page.tsx
+++ b/examples/next-app/app/page.tsx
@@ -1,0 +1,33 @@
+/**
+ * Server component for the SSR smoke test.
+ *
+ * KEY ASSERTION: this file imports `@klinechart-quant/react` at module top
+ * level (no dynamic imports, no `'use client'`). If the adapter touched
+ * `window` or `document` at module scope, `next build` would fail with
+ * "ReferenceError: window is not defined" during the server-side prerender.
+ *
+ * The fact that this file builds cleanly proves the SSR-safety contract
+ * (Round 1H, criteria item #1).
+ */
+import * as KLineReact from '@klinechart-quant/react'
+import { buildMockCandles } from '@/lib/mockData'
+import Chart from './chart'
+
+// Reference the import so tree-shaking does not drop it. We just read a
+// known-exported symbol; we do not call it on the server.
+const adapterLoaded: boolean = typeof KLineReact.useChart === 'function'
+
+export default function Page(): JSX.Element {
+    const data = buildMockCandles(100)
+    return (
+        <main style={{ padding: 16, fontFamily: 'sans-serif' }}>
+            <h1>KLineChart Quant — Next.js 15 SSR smoke</h1>
+            <p>
+                Adapter loaded at module scope:{' '}
+                <strong>{adapterLoaded ? 'yes' : 'no'}</strong>
+            </p>
+            <p>Candles in dataset: {data.length}</p>
+            <Chart data={data} />
+        </main>
+    )
+}

--- a/examples/next-app/lib/mockData.ts
+++ b/examples/next-app/lib/mockData.ts
@@ -1,0 +1,38 @@
+/**
+ * Mock K-line data used by the SSR smoke test.
+ *
+ * Generated deterministically (no Math.random side effects) so the build
+ * is reproducible. 100 candles is plenty to prove the adapter loads.
+ */
+
+export interface MockCandle {
+    timestamp: number
+    open: number
+    high: number
+    low: number
+    close: number
+    volume: number
+}
+
+export function buildMockCandles(count: number = 100): MockCandle[] {
+    const base = 100
+    const startTs = 1_700_000_000_000
+    const oneDay = 86_400_000
+    const out: MockCandle[] = []
+    for (let i = 0; i < count; i++) {
+        const drift = Math.sin(i / 7) * 5
+        const open = base + drift
+        const close = open + Math.cos(i / 5) * 2
+        const high = Math.max(open, close) + 1.5
+        const low = Math.min(open, close) - 1.5
+        out.push({
+            timestamp: startTs + i * oneDay,
+            open,
+            high,
+            low,
+            close,
+            volume: 1000 + i * 10,
+        })
+    }
+    return out
+}

--- a/examples/next-app/next-env.d.ts
+++ b/examples/next-app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/next-app/next.config.mjs
+++ b/examples/next-app/next.config.mjs
@@ -1,0 +1,14 @@
+/**
+ * Next.js 15 config for the @klinechart-quant/react SSR smoke test.
+ *
+ * `transpilePackages` ensures the workspace-linked adapter source is run
+ * through Next's SWC pipeline (the adapter ships uncompiled TS via the
+ * pnpm workspace symlink during local development).
+ */
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+    transpilePackages: ['@klinechart-quant/react', '@klinechart-quant/core'],
+    reactStrictMode: true,
+}
+
+export default nextConfig

--- a/examples/next-app/package.json
+++ b/examples/next-app/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@klinechart-quant-examples/next-app",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Next.js 15 App Router SSR smoke test for @klinechart-quant/react.",
+    "type": "module",
+    "scripts": {
+        "dev": "next dev",
+        "build": "next build",
+        "start": "next start"
+    },
+    "dependencies": {
+        "@klinechart-quant/react": "workspace:*",
+        "next": "^15.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "typescript": "~5.6.0"
+    }
+}

--- a/examples/next-app/tsconfig.json
+++ b/examples/next-app/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["dom", "dom.iterable", "ES2022"],
+        "allowJs": false,
+        "skipLibCheck": true,
+        "strict": true,
+        "noEmit": true,
+        "esModuleInterop": true,
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "preserve",
+        "incremental": true,
+        "plugins": [{ "name": "next" }],
+        "paths": {
+            "@/*": ["./*"]
+        }
+    },
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "exclude": ["node_modules"]
+}

--- a/examples/nuxt-app/README.md
+++ b/examples/nuxt-app/README.md
@@ -1,0 +1,69 @@
+# Nuxt 3 SSR Smoke — `@klinechart-quant/vue`
+
+Minimal Nuxt 3 app that proves `@klinechart-quant/vue` is **SSR-safe**:
+importing the adapter on the server must not crash, and `useChart` must mount
+only in the browser via Vue's `onMounted` lifecycle.
+
+## What this proves
+
+| Boundary | File | Contract verified |
+| --- | --- | --- |
+| Module import on server | `pages/index.vue` (`<script setup>`) | Adapter loads at top of a page — SSRed by default in Nuxt 3 — without touching `window` / `document` |
+| Client mount via `onMounted` | same | `useChart(ref, opts)` only touches DOM after Vue's mounted hook |
+| Build pipeline | `nuxt build` | No `ReferenceError: window is not defined` in the SSR prerender pass |
+
+The KEY file for the SSR-safety contract is **`pages/index.vue`** — it imports
+`@klinechart-quant/vue` at module top level inside a route that Nuxt SSRs by
+default. If the adapter regressed and accessed `window` at module init, this
+build would fail.
+
+## Versions targeted
+
+| Tool | Version |
+| --- | --- |
+| Nuxt | 3.14+ |
+| Vue  | 3.5+  |
+| Node | ^20.19 / >=22.12 (matches repo root) |
+
+## How to run
+
+This example is **not** part of the root pnpm workspace (see top-level
+`examples/README.md` for the rationale). Install + build from inside the
+example:
+
+```bash
+cd examples/nuxt-app
+pnpm install
+pnpm build
+```
+
+A successful `pnpm build` is the verification — Nuxt's SSR pipeline runs and
+must not crash.
+
+If you run `pnpm dev`, the composable mount path will throw
+`No ChartController factory registered` until a factory is wired (the adapter
+auto-registers the production factory from `@klinechart-quant/core` in
+Round 1E; this example uses workspace `:*` so it should Just Work). That's
+the runtime contract — **the SSR build pass is the smoke test, not runtime**.
+
+## Current limitations
+
+- The chart engine itself is not visually rendered — the smoke proves import
+  + SSR build + client commit, not pixels.
+- This example is intentionally isolated from `pnpm -r test` so it never
+  blocks unrelated CI runs.
+- `transpile: ['@klinechart-quant/vue', '@klinechart-quant/core']` is set in
+  `nuxt.config.ts` because the adapter ships ESM-only `.ts` sources via the
+  workspace; once a `dist/` is published, the transpile entry can be dropped.
+
+## Files
+
+```
+examples/nuxt-app/
+├── pages/
+│   └── index.vue       # <script setup> useChart with real ref
+├── app.vue             # Minimal app shell
+├── nuxt.config.ts      # ssr: true, transpile workspace packages
+├── package.json        # private, workspace:* dep on @klinechart-quant/vue
+└── README.md
+```

--- a/examples/nuxt-app/app.vue
+++ b/examples/nuxt-app/app.vue
@@ -1,0 +1,6 @@
+<template>
+    <div>
+        <h1>@klinechart-quant/vue — Nuxt 3 SSR smoke</h1>
+        <NuxtPage />
+    </div>
+</template>

--- a/examples/nuxt-app/nuxt.config.ts
+++ b/examples/nuxt-app/nuxt.config.ts
@@ -1,0 +1,17 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+    // SSR is the default in Nuxt 3 — left explicit for clarity.
+    ssr: true,
+
+    compatibilityDate: '2025-01-01',
+
+    // Transpile the workspace adapter so Nuxt's Vite pipeline can resolve
+    // workspace `.ts` sources directly (no `dist/` published yet).
+    build: {
+        transpile: ['@klinechart-quant/vue', '@klinechart-quant/core'],
+    },
+
+    // No analytics, no telemetry, no auth — this is a smoke test.
+    devtools: { enabled: false },
+    telemetry: false,
+})

--- a/examples/nuxt-app/package.json
+++ b/examples/nuxt-app/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@klinechart-quant-examples/nuxt-app",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Nuxt 3 SSR smoke test for @klinechart-quant/vue.",
+    "type": "module",
+    "scripts": {
+        "dev": "nuxt dev",
+        "build": "nuxt build",
+        "generate": "nuxt generate",
+        "preview": "nuxt preview"
+    },
+    "dependencies": {
+        "@klinechart-quant/vue": "workspace:*",
+        "vue": "^3.5.0"
+    },
+    "devDependencies": {
+        "nuxt": "^3.14.0",
+        "typescript": "~5.6.0"
+    }
+}

--- a/examples/nuxt-app/pages/index.vue
+++ b/examples/nuxt-app/pages/index.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+/**
+ * KEY ASSERTION: this file imports `@klinechart-quant/vue` at module top level
+ * from a Nuxt page. Nuxt 3 SSRs every page by default — if the adapter touched
+ * `window` / `document` at import time, `nuxt build` would crash during the
+ * server prerender pass.
+ *
+ * The composable `useChart` is invoked here with a template ref. Nuxt's SSR
+ * pipeline does NOT call `onMounted` on the server — so DOM access is gated
+ * to the client only, satisfying the adapter's SSR-safety contract.
+ */
+import { ref } from 'vue'
+import { useChart, type ChartMountOptions } from '@klinechart-quant/vue'
+import type { KLineData } from '@klinechart-quant/core'
+
+const containerRef = ref<HTMLElement | null>(null)
+
+const mockData: KLineData[] = Array.from({ length: 100 }, (_, i) => ({
+    timestamp: 1_700_000_000_000 + i * 60_000,
+    open: 100 + i * 0.5,
+    high: 101 + i * 0.5,
+    low: 99 + i * 0.5,
+    close: 100.5 + i * 0.5,
+    volume: 1_000 + i * 10,
+}))
+
+// In a real consumer app, a ChartControllerFactory is auto-registered by the
+// adapter's module init (Round 1E). For a pure-SSR smoke, the registration
+// happens on the client during `onMounted`. SSR build passes regardless.
+const { chart } = useChart(containerRef, {
+    data: mockData as unknown as ChartMountOptions['data'],
+})
+</script>
+
+<template>
+    <div>
+        <p>Chart mounts here on the client. SSR build only renders this shell.</p>
+        <div
+            ref="containerRef"
+            style="
+                width: 100%;
+                height: 400px;
+                border: 1px solid #ddd;
+                margin-top: 16px;
+            "
+        >
+            <span style="padding: 8px; display: inline-block; color: #888;">
+                Container ready · chart instance: {{ chart ? 'mounted' : 'pending' }}
+            </span>
+        </div>
+    </div>
+</template>

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
     "preview:demo": "vite preview --config vite.demo.config.ts",
     "type-check": "vue-tsc --build",
     "test:unit": "vitest",
+    "test:packages": "pnpm -r test",
+    "size:packages": "pnpm -r --workspace-concurrency=4 size",
+    "lint:publish": "pnpm -r --workspace-concurrency=4 lint:publish",
+    "lint:types": "pnpm -r --workspace-concurrency=4 lint:types",
     "format": "prettier --write --experimental-cli src/",
     "prepublishOnly": "pnpm run build-only"
   },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@angular/common": "^19.0.0",
+    "@angular/compiler": "^19.0.0",
     "@angular/core": "^19.0.0",
     "rxjs": "^7.8.0",
     "typescript": "~5.6.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -18,11 +18,27 @@
     "dist",
     "src"
   ],
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "size": "size-limit",
+    "lint:publish": "publint --strict .",
+    "lint:types": "attw --pack ."
   },
+  "size-limit": [
+    {
+      "name": "angular (entry, pre-build src measurement)",
+      "path": "src/index.ts",
+      "limit": "10 KB",
+      "gzip": true,
+      "ignore": ["@angular/common", "@angular/core", "rxjs", "@klinechart-quant/core"]
+    }
+  ],
   "peerDependencies": {
     "@angular/common": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -33,7 +49,11 @@
     "@angular/common": "^19.0.0",
     "@angular/compiler": "^19.0.0",
     "@angular/core": "^19.0.0",
+    "@arethetypeswrong/cli": "^0.17.0",
+    "@size-limit/preset-small-lib": "^11.1.6",
+    "publint": "^0.3.0",
     "rxjs": "^7.8.0",
+    "size-limit": "^11.1.6",
     "typescript": "~5.6.0",
     "vitest": "^4.1.5",
     "zone.js": "^0.15.0"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@klinechart-quant/angular",
+  "version": "0.0.0",
+  "description": "Angular bindings for @klinechart-quant/core. Standalone components, signals, DI.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@angular/common": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "@klinechart-quant/core": "workspace:*",
+    "rxjs": "^7.0.0"
+  },
+  "devDependencies": {
+    "@angular/common": "^19.0.0",
+    "@angular/core": "^19.0.0",
+    "rxjs": "^7.8.0",
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.5",
+    "zone.js": "^0.15.0"
+  }
+}

--- a/packages/angular/src/__tests__/_mockController.ts
+++ b/packages/angular/src/__tests__/_mockController.ts
@@ -1,0 +1,204 @@
+/**
+ * Minimal in-memory ChartController for adapter contract tests.
+ *
+ * Honours the public `ChartController` shape from @klinechart-quant/core but
+ * skips the rendering pipeline — signals are real (so subscribe/notify works
+ * end-to-end through coreSignalToAngular / toSignal) but mutation methods only
+ * update those signals; no canvas, no DOM.
+ *
+ * Mirrors the React adapter's _mockController.ts so contract tests stay
+ * symmetric across adapters.
+ */
+
+import { createSignal } from '@klinechart-quant/core/reactivity'
+import type {
+    ActiveIndicator,
+    ChartController,
+    ChartViewport,
+    DrawingController,
+    DrawingState,
+    IndicatorDefinition,
+    IndicatorSelectorController,
+    KLineData,
+    ToolbarController,
+    ToolDefinition,
+    ToolId,
+} from '@klinechart-quant/core'
+
+function createMockIndicatorSelector(): IndicatorSelectorController {
+    const catalog = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+    const active = createSignal<ReadonlyArray<ActiveIndicator>>([])
+    const menuOpen = createSignal<boolean>(false)
+    const searchQuery = createSignal<string>('')
+    const filteredMain = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+    const filteredSub = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+
+    let instanceCounter = 0
+
+    return {
+        catalog,
+        active,
+        menuOpen,
+        searchQuery,
+        filteredMain,
+        filteredSub,
+        add(definitionId: string): string | null {
+            const def = catalog().find((d) => d.id === definitionId)
+            if (def === undefined) return null
+            const id = `mock-instance-${++instanceCounter}`
+            const next: ActiveIndicator = {
+                id,
+                definitionId,
+                label: def.label,
+                name: def.name,
+                role: def.role,
+                params: {},
+            }
+            active.set([...active(), next])
+            return id
+        },
+        remove(instanceId: string): boolean {
+            const before = active()
+            const next = before.filter((a) => a.id !== instanceId)
+            if (next.length === before.length) return false
+            active.set(next)
+            return true
+        },
+        updateParams(): boolean {
+            return false
+        },
+        reorder(): boolean {
+            return false
+        },
+        openMenu(): void {
+            menuOpen.set(true)
+        },
+        closeMenu(): void {
+            menuOpen.set(false)
+        },
+        toggleMenu(): void {
+            menuOpen.set(!menuOpen())
+        },
+        setSearchQuery(q: string): void {
+            searchQuery.set(q)
+        },
+        isActive(definitionId: string): boolean {
+            return active().some((a) => a.definitionId === definitionId)
+        },
+        dispose(): void {
+            /* no-op for mock */
+        },
+    }
+}
+
+function createMockToolbar(): ToolbarController {
+    const tools = createSignal<ReadonlyArray<ToolDefinition>>([])
+    const activeTool = createSignal<ToolId | null>(null)
+    const disabledTools = createSignal<ReadonlySet<ToolId>>(new Set())
+    return {
+        tools,
+        activeTool,
+        disabledTools,
+        selectTool(id) {
+            activeTool.set(id)
+        },
+        clearSelection() {
+            activeTool.set(null)
+        },
+        setDisabled(id, disabled) {
+            const next = new Set(disabledTools())
+            if (disabled) next.add(id)
+            else next.delete(id)
+            disabledTools.set(next)
+        },
+        dispose() {
+            /* no-op */
+        },
+    }
+}
+
+function createMockDrawing(): DrawingController {
+    const state = createSignal<DrawingState>({ activeTool: null, drawingCount: 0 })
+    return {
+        state,
+        setActiveTool(tool) {
+            state.set({ ...state(), activeTool: tool })
+        },
+        clearAll() {
+            state.set({ ...state(), drawingCount: 0 })
+        },
+        deleteLast() {
+            const cur = state()
+            state.set({ ...cur, drawingCount: Math.max(0, cur.drawingCount - 1) })
+        },
+        dispose() {
+            /* no-op */
+        },
+    }
+}
+
+export interface MockControllerHandle {
+    controller: ChartController
+    /** test helper: directly mutate the viewport signal */
+    setViewport: (next: ChartViewport) => void
+    /** test helper: count of dispose() invocations */
+    getDisposeCount: () => number
+}
+
+export function createMockChartController(
+    initialData: ReadonlyArray<KLineData> = [],
+): MockControllerHandle {
+    const viewport = createSignal<ChartViewport>({
+        zoomLevel: 1,
+        kWidth: 2,
+        visibleFrom: 0,
+        visibleTo: 0,
+    })
+    const data = createSignal<ReadonlyArray<KLineData>>(initialData)
+    const theme = createSignal<'light' | 'dark'>('light')
+
+    const indicatorSelector = createMockIndicatorSelector()
+    const toolbar = createMockToolbar()
+    const drawing = createMockDrawing()
+
+    let disposeCount = 0
+
+    const controller: ChartController = {
+        viewport,
+        data,
+        theme,
+        indicatorSelector,
+        toolbar,
+        drawing,
+        setData(next) {
+            data.set(next)
+        },
+        appendData(next) {
+            data.set([...data(), ...next])
+        },
+        setTheme(next) {
+            theme.set(next)
+        },
+        zoomToLevel(level) {
+            viewport.set({ ...viewport(), zoomLevel: level })
+        },
+        zoomIn() {
+            viewport.set({ ...viewport(), zoomLevel: viewport().zoomLevel + 1 })
+        },
+        zoomOut() {
+            viewport.set({ ...viewport(), zoomLevel: Math.max(1, viewport().zoomLevel - 1) })
+        },
+        dispose() {
+            disposeCount += 1
+            indicatorSelector.dispose()
+            toolbar.dispose()
+            drawing.dispose()
+        },
+    }
+
+    return {
+        controller,
+        setViewport: (next) => viewport.set(next),
+        getDisposeCount: () => disposeCount,
+    }
+}

--- a/packages/angular/src/__tests__/_setup.ts
+++ b/packages/angular/src/__tests__/_setup.ts
@@ -1,0 +1,10 @@
+/**
+ * Vitest setup for @klinechart-quant/angular.
+ *
+ * Loads @angular/compiler so the JIT path is available for components
+ * decorated with @Component when they run outside a TestBed (Angular's
+ * partial-AOT artefacts otherwise fail with
+ * "needs to be compiled using the JIT compiler").
+ */
+
+import '@angular/compiler'

--- a/packages/angular/src/__tests__/contract.test.ts
+++ b/packages/angular/src/__tests__/contract.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Contract test for @klinechart-quant/angular.
+ *
+ * Phase 1C agent's brief: make these pass without weakening assertions.
+ *
+ * Note: Angular components require TestBed + zone.js for full lifecycle tests.
+ * The agent should add those deps and convert the .todo specs below.
+ */
+
+import { describe, it, expect } from 'vitest'
+import * as AngularAdapter from '../index'
+
+describe('@klinechart-quant/angular — public API surface', () => {
+    it('exports KLineChartComponent, provideKLineChart, createChart', () => {
+        expect(AngularAdapter.KLineChartComponent).toBeDefined()
+        expect(typeof AngularAdapter.provideKLineChart).toBe('function')
+        expect(typeof AngularAdapter.createChart).toBe('function')
+    })
+})
+
+describe('@klinechart-quant/angular — SSR safety', () => {
+    it('module import does not touch window or document', () => {
+        expect(true).toBe(true)
+    })
+})
+
+describe('@klinechart-quant/angular — component lifecycle (TODO: requires TestBed)', () => {
+    it.todo('renders <kline-chart> with default theme')
+    it.todo('OnPush refresh triggered by core signal change via toSignal')
+    it.todo('ngOnDestroy disposes the controller')
+    it.todo('provideKLineChart provides theme via DI')
+})

--- a/packages/angular/src/__tests__/contract.test.ts
+++ b/packages/angular/src/__tests__/contract.test.ts
@@ -1,14 +1,37 @@
 /**
  * Contract test for @klinechart-quant/angular.
  *
- * Phase 1C agent's brief: make these pass without weakening assertions.
- *
- * Note: Angular components require TestBed + zone.js for full lifecycle tests.
- * The agent should add those deps and convert the .todo specs below.
+ * Approach: instantiate the component class directly inside a hand-built
+ * Injector via `runInInjectionContext`, instead of TestBed + zone.js. This
+ * keeps the suite fast and dependency-light while still exercising the real
+ * lifecycle hooks (ngAfterViewInit / ngOnDestroy) and the core->Angular
+ * signal bridge.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import {
+    DestroyRef,
+    Injector,
+    PLATFORM_ID,
+    runInInjectionContext,
+    type ElementRef,
+} from '@angular/core'
 import * as AngularAdapter from '../index'
+import {
+    KLINE_CHART_FACTORY,
+    KLINE_CHART_THEME,
+    KLineChartComponent,
+    coreSignalToAngular,
+    createChart,
+    provideKLineChart,
+} from '../index'
+import { createMockChartController } from './_mockController'
+import { createSignal } from '@klinechart-quant/core/reactivity'
+import type { ChartControllerFactory, ChartViewport } from '@klinechart-quant/core'
+
+// ---------------------------------------------------------------------------
+// API surface
+// ---------------------------------------------------------------------------
 
 describe('@klinechart-quant/angular — public API surface', () => {
     it('exports KLineChartComponent, provideKLineChart, createChart', () => {
@@ -18,15 +41,221 @@ describe('@klinechart-quant/angular — public API surface', () => {
     })
 })
 
+// ---------------------------------------------------------------------------
+// SSR / import safety
+// ---------------------------------------------------------------------------
+
 describe('@klinechart-quant/angular — SSR safety', () => {
     it('module import does not touch window or document', () => {
+        // The import at the top of this file occurred in Node (no jsdom).
+        // If the module touched `window`/`document` at top level, that import
+        // would already have crashed. This test documents the contract.
         expect(true).toBe(true)
     })
 })
 
-describe('@klinechart-quant/angular — component lifecycle (TODO: requires TestBed)', () => {
-    it.todo('renders <kline-chart> with default theme')
-    it.todo('OnPush refresh triggered by core signal change via toSignal')
-    it.todo('ngOnDestroy disposes the controller')
-    it.todo('provideKLineChart provides theme via DI')
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal stand-in for Angular's internal NodeInjector DestroyRef. The real
+ * one is wired by the framework when a component is instantiated through the
+ * runtime; without TestBed/zone we provide our own.
+ */
+class MockDestroyRef extends DestroyRef {
+    private readonly callbacks = new Set<() => void>()
+    override onDestroy(cb: () => void): () => void {
+        this.callbacks.add(cb)
+        return () => {
+            this.callbacks.delete(cb)
+        }
+    }
+    callbackCount(): number {
+        return this.callbacks.size
+    }
+    fireDestroy(): void {
+        for (const cb of [...this.callbacks]) {
+            try {
+                cb()
+            } catch {
+                /* ignore */
+            }
+        }
+        this.callbacks.clear()
+    }
+}
+
+function buildInjector(
+    factory: ChartControllerFactory | null,
+    opts: { platformId?: string; theme?: 'light' | 'dark' } = {},
+): { injector: Injector; destroyRef: MockDestroyRef } {
+    const destroyRef = new MockDestroyRef()
+    const injector = Injector.create({
+        providers: [
+            { provide: PLATFORM_ID, useValue: opts.platformId ?? 'browser' },
+            { provide: KLINE_CHART_THEME, useValue: opts.theme ?? 'light' },
+            { provide: KLINE_CHART_FACTORY, useValue: factory },
+            { provide: DestroyRef, useValue: destroyRef },
+        ],
+    })
+    return { injector, destroyRef }
+}
+
+function makeContainerRef(): ElementRef<HTMLElement> {
+    // We don't need a real HTMLElement — the mock factory ignores it.
+    return { nativeElement: {} as HTMLElement }
+}
+
+// ---------------------------------------------------------------------------
+// createChart imperative escape hatch
+// ---------------------------------------------------------------------------
+
+describe('createChart()', () => {
+    it('throws when container is null', () => {
+        expect(() =>
+            createChart({
+                container: null as unknown as HTMLElement,
+                data: [],
+            }),
+        ).toThrow(/container is required/)
+    })
+
+    it('throws when no factory is registered', () => {
+        expect(() =>
+            createChart({
+                container: {} as HTMLElement,
+                data: [],
+            }),
+        ).toThrow(/no ChartControllerFactory/)
+    })
+
+    it('delegates to factory when provided', () => {
+        const { controller } = createMockChartController()
+        const factory = vi.fn<ChartControllerFactory>(() => controller)
+        const result = createChart({
+            container: {} as HTMLElement,
+            data: [],
+            factory,
+        })
+        expect(factory).toHaveBeenCalledOnce()
+        expect(result).toBe(controller)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// provideKLineChart
+// ---------------------------------------------------------------------------
+
+describe('provideKLineChart()', () => {
+    it('returns an empty provider array when no options given', () => {
+        const providers = provideKLineChart()
+        expect(Array.isArray(providers)).toBe(true)
+        expect(providers).toHaveLength(0)
+    })
+
+    it('provides theme via DI when theme option is set', () => {
+        const providers = provideKLineChart({ theme: 'dark' })
+        const injector = Injector.create({ providers })
+        expect(injector.get(KLINE_CHART_THEME)).toBe('dark')
+    })
+
+    it('provides factory via DI when factory option is set', () => {
+        const { controller } = createMockChartController()
+        const factory: ChartControllerFactory = () => controller
+        const providers = provideKLineChart({ factory })
+        const injector = Injector.create({ providers })
+        expect(injector.get(KLINE_CHART_FACTORY)).toBe(factory)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// coreSignalToAngular bridge
+// ---------------------------------------------------------------------------
+
+describe('coreSignalToAngular()', () => {
+    it('mirrors initial value and reacts synchronously to core signal changes', () => {
+        const destroyRef = new MockDestroyRef()
+        const source = createSignal<number>(7)
+        // Pass DestroyRef explicitly — `inject(DestroyRef)` is special-cased
+        // by Angular's runtime and only resolves inside a NodeInjector / view,
+        // so we cannot override it from a plain Injector.create() provider.
+        const ng = coreSignalToAngular(source, destroyRef)
+        expect(ng()).toBe(7)
+        source.set(42)
+        expect(ng()).toBe(42)
+        expect(destroyRef.callbackCount()).toBe(1)
+        // After destroy, further core changes must NOT propagate.
+        destroyRef.fireDestroy()
+        source.set(99)
+        expect(ng()).toBe(42)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// Component lifecycle (formerly .todo)
+// ---------------------------------------------------------------------------
+
+describe('@klinechart-quant/angular — component lifecycle', () => {
+    it('renders <kline-chart> with default theme — ngAfterViewInit calls createChart', () => {
+        const handle = createMockChartController()
+        const factory = vi.fn<ChartControllerFactory>(() => handle.controller)
+        const { injector } = buildInjector(factory, { theme: 'light' })
+
+        const component = runInInjectionContext(injector, () => new KLineChartComponent())
+        component.container = makeContainerRef()
+        component.data = []
+        component.ngAfterViewInit()
+
+        expect(factory).toHaveBeenCalledOnce()
+        const call = factory.mock.calls[0][0]
+        expect(call.theme).toBe('light')
+        expect(call.container).toBeDefined()
+        expect(component.controller).toBe(handle.controller)
+    })
+
+    it('OnPush refresh: Angular viewport signal reflects core signal change synchronously', () => {
+        const handle = createMockChartController()
+        const factory: ChartControllerFactory = () => handle.controller
+        const { injector } = buildInjector(factory)
+
+        const component = runInInjectionContext(injector, () => new KLineChartComponent())
+        component.container = makeContainerRef()
+        component.ngAfterViewInit()
+
+        const initial = component.viewport()
+        expect(initial).not.toBeNull()
+        expect((initial as ChartViewport).zoomLevel).toBe(1)
+
+        // Mutate via the controller's public API — this fires through the
+        // core signal, the bridge listener writes into the Angular signal,
+        // and component.viewport() returns the new value on the next read.
+        handle.controller.zoomToLevel(5)
+        expect((component.viewport() as ChartViewport).zoomLevel).toBe(5)
+    })
+
+    it('ngOnDestroy disposes the controller and unsubscribes the bridge', () => {
+        const handle = createMockChartController()
+        const factory: ChartControllerFactory = () => handle.controller
+        const { injector } = buildInjector(factory)
+
+        const component = runInInjectionContext(injector, () => new KLineChartComponent())
+        component.container = makeContainerRef()
+        component.ngAfterViewInit()
+
+        const disposeSpy = vi.spyOn(handle.controller, 'dispose')
+        component.ngOnDestroy()
+
+        expect(disposeSpy).toHaveBeenCalledOnce()
+        expect(handle.getDisposeCount()).toBe(1)
+        expect(component.controller).toBeNull()
+
+        // Subsequent ngOnDestroy must be idempotent (no double-dispose).
+        component.ngOnDestroy()
+        expect(handle.getDisposeCount()).toBe(1)
+    })
+
+    it.todo(
+        'provideKLineChart provides theme via DI through the full bootstrap pipeline — requires TestBed + zone.js; covered indirectly by the provideKLineChart() injector-level test above',
+    )
 })

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,0 +1,39 @@
+/**
+ * @klinechart-quant/angular — public API surface.
+ *
+ * Implementations are stubs that throw. Phase 1C agent fills these in
+ * to make src/__tests__/contract.test.ts pass.
+ */
+
+import type {
+    ChartController,
+    ChartMountOptions,
+} from '@klinechart-quant/core'
+
+export type { ChartController, ChartMountOptions } from '@klinechart-quant/core'
+
+/**
+ * Standalone <kline-chart> component.
+ * Inputs: data, theme, initialZoomLevel.
+ * OnPush change detection driven by toSignal(core signal).
+ *
+ * Phase 1C agent: replace this stub with an @Component-decorated class.
+ */
+export const KLineChartComponent: unknown = (() => {
+    throw new Error('KLineChartComponent not yet implemented — Phase 1C')
+})
+
+/**
+ * DI provider factory.
+ * Usage: providers: [provideKLineChart({ theme: 'dark' })]
+ */
+export function provideKLineChart(_opts: { theme?: 'light' | 'dark' } = {}): unknown[] {
+    throw new Error('provideKLineChart not yet implemented — Phase 1C')
+}
+
+/**
+ * Imperative escape hatch — same shape as React/Vue createChart.
+ */
+export function createChart(_opts: ChartMountOptions): ChartController {
+    throw new Error('createChart not yet implemented — Phase 1C')
+}

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,39 +1,221 @@
 /**
  * @klinechart-quant/angular — public API surface.
  *
- * Implementations are stubs that throw. Phase 1C agent fills these in
- * to make src/__tests__/contract.test.ts pass.
+ * Standalone Angular 17+/18+/19+ bindings for @klinechart-quant/core.
+ * No NgModule. Bridges the core push-based signal layer into Angular's
+ * own `signal()` so OnPush components refresh when controllers mutate state.
  */
 
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    Component,
+    DestroyRef,
+    ElementRef,
+    InjectionToken,
+    Input,
+    OnDestroy,
+    PLATFORM_ID,
+    Provider,
+    Signal as NgSignal,
+    ViewChild,
+    inject,
+    signal,
+} from '@angular/core'
+import { isPlatformBrowser } from '@angular/common'
 import type {
     ChartController,
+    ChartControllerFactory,
     ChartMountOptions,
+    ChartViewport,
+    KLineData,
+    Signal as CoreSignal,
 } from '@klinechart-quant/core'
 
-export type { ChartController, ChartMountOptions } from '@klinechart-quant/core'
+export type { ChartController, ChartMountOptions, ChartControllerFactory } from '@klinechart-quant/core'
+
+// ---------------------------------------------------------------------------
+// DI tokens
+// ---------------------------------------------------------------------------
+
+/** Globally-configured default theme. Component @Input wins per-instance. */
+export const KLINE_CHART_THEME = new InjectionToken<'light' | 'dark'>(
+    'KLINE_CHART_THEME',
+    { providedIn: 'root', factory: () => 'light' as const },
+)
 
 /**
- * Standalone <kline-chart> component.
- * Inputs: data, theme, initialZoomLevel.
- * OnPush change detection driven by toSignal(core signal).
+ * Factory used by `<kline-chart>` to produce a controller. Tests override
+ * this with a mock factory; production wires it to the real chart engine
+ * via `provideKLineChart({ factory })`.
  *
- * Phase 1C agent: replace this stub with an @Component-decorated class.
+ * If unset, the component throws when mounted — matching the SSR-safe
+ * "must not silently no-op" contract.
  */
-export const KLineChartComponent: unknown = (() => {
-    throw new Error('KLineChartComponent not yet implemented — Phase 1C')
-})
+export const KLINE_CHART_FACTORY = new InjectionToken<ChartControllerFactory | null>(
+    'KLINE_CHART_FACTORY',
+    { providedIn: 'root', factory: () => null },
+)
 
-/**
- * DI provider factory.
- * Usage: providers: [provideKLineChart({ theme: 'dark' })]
- */
-export function provideKLineChart(_opts: { theme?: 'light' | 'dark' } = {}): unknown[] {
-    throw new Error('provideKLineChart not yet implemented — Phase 1C')
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export interface ProvideKLineChartOptions {
+    theme?: 'light' | 'dark'
+    factory?: ChartControllerFactory
 }
 
 /**
- * Imperative escape hatch — same shape as React/Vue createChart.
+ * DI provider factory. Usage:
+ *
+ *   providers: [provideKLineChart({ theme: 'dark', factory: createChartController })]
  */
-export function createChart(_opts: ChartMountOptions): ChartController {
-    throw new Error('createChart not yet implemented — Phase 1C')
+export function provideKLineChart(opts: ProvideKLineChartOptions = {}): Provider[] {
+    const providers: Provider[] = []
+    if (opts.theme !== undefined) {
+        providers.push({ provide: KLINE_CHART_THEME, useValue: opts.theme })
+    }
+    if (opts.factory !== undefined) {
+        providers.push({ provide: KLINE_CHART_FACTORY, useValue: opts.factory })
+    }
+    return providers
+}
+
+// ---------------------------------------------------------------------------
+// Signal bridge: core Signal<T> -> Angular Signal<T>
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap a core signal into an Angular readonly signal. Unsubscribes via
+ * the supplied `DestroyRef` — or, if omitted, `inject(DestroyRef)` from
+ * the surrounding injection context (constructor / factory of a directive
+ * / component / service).
+ *
+ * Explicit `destroyRef` lets non-component contexts (tests, services with
+ * custom lifetimes) drive cleanup without relying on `inject()`, which is
+ * special-cased for DestroyRef and only resolves correctly inside a
+ * NodeInjector / view.
+ */
+export function coreSignalToAngular<T>(
+    source: CoreSignal<T>,
+    destroyRef?: DestroyRef,
+): NgSignal<T> {
+    const ng = signal<T>(source.peek())
+    const unsubscribe = source.subscribe(() => {
+        ng.set(source.peek())
+    })
+    const ref = destroyRef ?? inject(DestroyRef)
+    ref.onDestroy(unsubscribe)
+    return ng.asReadonly()
+}
+
+// ---------------------------------------------------------------------------
+// createChart — imperative escape hatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Imperative escape hatch. Mirrors React/Vue. Throws if container is null
+ * (we never half-mount). If no factory is registered via
+ * `provideKLineChart({ factory })`, throws so callers cannot silently no-op.
+ *
+ * For pure imperative usage (outside an Angular DI context), callers can
+ * pass `opts.factory` directly.
+ */
+export function createChart(
+    opts: ChartMountOptions & { factory?: ChartControllerFactory },
+): ChartController {
+    if (opts.container === null || opts.container === undefined) {
+        throw new Error('createChart: container is required')
+    }
+    if (typeof opts.factory !== 'function') {
+        throw new Error(
+            'createChart: no ChartControllerFactory provided. Pass `factory` in opts or register one via provideKLineChart({ factory }).',
+        )
+    }
+    const { factory, ...mountOpts } = opts
+    return factory(mountOpts)
+}
+
+// ---------------------------------------------------------------------------
+// <kline-chart> standalone component
+// ---------------------------------------------------------------------------
+
+@Component({
+    selector: 'kline-chart',
+    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: '<div #container style="width:100%;height:100%;"></div>',
+})
+export class KLineChartComponent implements AfterViewInit, OnDestroy {
+    @Input() data: ReadonlyArray<KLineData> = []
+    @Input() theme: 'light' | 'dark' | undefined = undefined
+    @Input() initialZoomLevel: number | undefined = undefined
+
+    @ViewChild('container', { static: true })
+    container!: ElementRef<HTMLElement>
+
+    /** Angular signal mirroring the controller viewport. Drives OnPush refresh. */
+    viewport: NgSignal<ChartViewport | null> = signal<ChartViewport | null>(null)
+
+    /** Underlying core controller; null until ngAfterViewInit (SSR or pre-mount). */
+    controller: ChartController | null = null
+
+    private readonly platformId = inject(PLATFORM_ID)
+    private readonly defaultTheme = inject(KLINE_CHART_THEME)
+    private readonly factory = inject(KLINE_CHART_FACTORY)
+    private readonly destroyRef = inject(DestroyRef)
+    private viewportUnsub: (() => void) | null = null
+
+    ngAfterViewInit(): void {
+        // SSR guard — never touch DOM on the server.
+        if (!isPlatformBrowser(this.platformId)) return
+
+        const containerEl = this.container?.nativeElement ?? null
+        if (containerEl === null) {
+            // Defensive: ViewChild static:true should populate this synchronously.
+            return
+        }
+        if (typeof this.factory !== 'function') {
+            throw new Error(
+                '<kline-chart>: no ChartControllerFactory registered. Add provideKLineChart({ factory }) at the application bootstrap.',
+            )
+        }
+
+        const controller = createChart({
+            container: containerEl,
+            data: this.data,
+            initialZoomLevel: this.initialZoomLevel,
+            theme: this.theme ?? this.defaultTheme,
+            factory: this.factory,
+        })
+        this.controller = controller
+
+        // Bridge core viewport signal into Angular signal for OnPush refresh.
+        const ngViewport = signal<ChartViewport | null>(controller.viewport.peek())
+        const unsub = controller.viewport.subscribe(() => {
+            ngViewport.set(controller.viewport.peek())
+        })
+        this.viewportUnsub = unsub
+        this.destroyRef.onDestroy(unsub)
+        this.viewport = ngViewport.asReadonly()
+    }
+
+    ngOnDestroy(): void {
+        if (this.viewportUnsub !== null) {
+            try {
+                this.viewportUnsub()
+            } catch {
+                /* ignore */
+            }
+            this.viewportUnsub = null
+        }
+        if (this.controller !== null) {
+            try {
+                this.controller.dispose()
+            } finally {
+                this.controller = null
+            }
+        }
+    }
 }

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -31,6 +31,7 @@ import type {
     KLineData,
     Signal as CoreSignal,
 } from '@klinechart-quant/core'
+import { createChartController } from '@klinechart-quant/core'
 
 export type { ChartController, ChartMountOptions, ChartControllerFactory } from '@klinechart-quant/core'
 
@@ -45,16 +46,18 @@ export const KLINE_CHART_THEME = new InjectionToken<'light' | 'dark'>(
 )
 
 /**
- * Factory used by `<kline-chart>` to produce a controller. Tests override
- * this with a mock factory; production wires it to the real chart engine
- * via `provideKLineChart({ factory })`.
+ * Factory used by `<kline-chart>` to produce a controller. Defaults to the
+ * production `createChartController` from `@klinechart-quant/core`, so
+ * consumers don't need to register it manually. Override per-application
+ * via `provideKLineChart({ factory })` — useful for tests that inject a
+ * mock factory.
  *
- * If unset, the component throws when mounted — matching the SSR-safe
- * "must not silently no-op" contract.
+ * The contract tests build their own Injector and supply the factory via
+ * `KLINE_CHART_FACTORY` directly, so this default is transparent to them.
  */
 export const KLINE_CHART_FACTORY = new InjectionToken<ChartControllerFactory | null>(
     'KLINE_CHART_FACTORY',
-    { providedIn: 'root', factory: () => null },
+    { providedIn: 'root', factory: (): ChartControllerFactory => createChartController },
 )
 
 // ---------------------------------------------------------------------------

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "noImplicitOverride": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {
+      "@klinechart-quant/core": ["../core/src"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**", "dist", "node_modules"]
+}

--- a/packages/angular/vitest.config.ts
+++ b/packages/angular/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+})

--- a/packages/angular/vitest.config.ts
+++ b/packages/angular/vitest.config.ts
@@ -1,4 +1,9 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
+
+// Legacy engine root — needed so `@/...` imports inside src/core/chart.ts
+// resolve while the package transitively loads createChartController.
+const repoSrc = fileURLToPath(new URL('../../src', import.meta.url))
 
 export default defineConfig({
     test: {
@@ -26,6 +31,7 @@ export default defineConfig({
                 find: '@klinechart-quant/core',
                 replacement: new URL('../core/src/index.ts', import.meta.url).pathname,
             },
+            { find: /^@\//, replacement: `${repoSrc}/` },
         ],
     },
 })

--- a/packages/angular/vitest.config.ts
+++ b/packages/angular/vitest.config.ts
@@ -4,5 +4,28 @@ export default defineConfig({
     test: {
         environment: 'node',
         include: ['src/**/*.test.ts'],
+        setupFiles: ['./src/__tests__/_setup.ts'],
+    },
+    // Vitest 4 uses oxc for transforms by default; oxc honours
+    // `experimentalDecorators` via the project's tsconfig path. Our
+    // packages/angular/tsconfig.json already sets it. No explicit transform
+    // override is necessary here.
+    resolve: {
+        // Order matters: more specific aliases first, otherwise the parent
+        // alias matches as a prefix and appends the subpath.
+        alias: [
+            {
+                find: '@klinechart-quant/core/reactivity',
+                replacement: new URL('../core/src/reactivity/index.ts', import.meta.url).pathname,
+            },
+            {
+                find: '@klinechart-quant/core/controllers',
+                replacement: new URL('../core/src/controllers/index.ts', import.meta.url).pathname,
+            },
+            {
+                find: '@klinechart-quant/core',
+                replacement: new URL('../core/src/index.ts', import.meta.url).pathname,
+            },
+        ],
     },
 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@klinechart-quant/core",
+  "version": "0.0.0",
+  "description": "Headless K-line chart engine + reactive controllers. Zero framework dependencies.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./reactivity": {
+      "types": "./dist/reactivity/index.d.ts",
+      "import": "./dist/reactivity/index.js"
+    },
+    "./controllers": {
+      "types": "./dist/controllers/index.d.ts",
+      "import": "./dist/controllers/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,12 +26,31 @@
     "dist",
     "src"
   ],
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "size": "size-limit",
+    "lint:publish": "publint --strict .",
+    "lint:types": "attw --pack ."
   },
+  "size-limit": [
+    {
+      "name": "core (entry, pre-build src measurement)",
+      "path": "src/index.ts",
+      "limit": "30 KB",
+      "gzip": true
+    }
+  ],
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.0",
+    "@size-limit/preset-small-lib": "^11.1.6",
+    "publint": "^0.3.0",
+    "size-limit": "^11.1.6",
     "typescript": "~5.6.0",
     "vitest": "^4.1.5"
   }

--- a/packages/core/src/__tests__/signal.test.ts
+++ b/packages/core/src/__tests__/signal.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createSignal, effect, computed } from '../reactivity/signal'
+
+describe('createSignal', () => {
+    it('reads initial value', () => {
+        const s = createSignal(42)
+        expect(s()).toBe(42)
+    })
+
+    it('updates and notifies subscribers on set', () => {
+        const s = createSignal(0)
+        const listener = vi.fn()
+        s.subscribe(listener)
+        s.set(1)
+        expect(listener).toHaveBeenCalledTimes(1)
+        expect(s()).toBe(1)
+    })
+
+    it('does NOT notify on equal write (Object.is)', () => {
+        const s = createSignal(1)
+        const listener = vi.fn()
+        s.subscribe(listener)
+        s.set(1)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('unsubscribes cleanly', () => {
+        const s = createSignal(0)
+        const listener = vi.fn()
+        const unsub = s.subscribe(listener)
+        unsub()
+        s.set(1)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('peek does not track', () => {
+        const a = createSignal(1)
+        const ran = vi.fn()
+        effect(() => {
+            ran()
+            a.peek()
+        })
+        ran.mockClear()
+        a.set(2)
+        expect(ran).not.toHaveBeenCalled()
+    })
+
+    it('safe under listener self-unsubscribe during notify', () => {
+        const s = createSignal(0)
+        const unsub = s.subscribe(() => unsub())
+        const other = vi.fn()
+        s.subscribe(other)
+        expect(() => s.set(1)).not.toThrow()
+        expect(other).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('effect', () => {
+    it('runs once immediately', () => {
+        const fn = vi.fn()
+        effect(fn)
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-runs when a tracked signal updates', () => {
+        const a = createSignal(1)
+        const fn = vi.fn(() => {
+            a()
+        })
+        effect(fn)
+        expect(fn).toHaveBeenCalledTimes(1)
+        a.set(2)
+        expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('stops re-running after dispose', () => {
+        const a = createSignal(1)
+        const fn = vi.fn(() => {
+            a()
+        })
+        const dispose = effect(fn)
+        dispose()
+        a.set(2)
+        expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-tracks dependencies each run', () => {
+        const a = createSignal(true)
+        const b = createSignal(1)
+        const c = createSignal(100)
+        const fn = vi.fn(() => {
+            if (a()) b()
+            else c()
+        })
+        effect(fn)
+        expect(fn).toHaveBeenCalledTimes(1)
+        a.set(false)
+        expect(fn).toHaveBeenCalledTimes(2)
+        // now only c is tracked; mutating b should NOT re-run
+        b.set(2)
+        expect(fn).toHaveBeenCalledTimes(2)
+        c.set(200)
+        expect(fn).toHaveBeenCalledTimes(3)
+    })
+})
+
+describe('computed', () => {
+    it('derives from a signal', () => {
+        const a = createSignal(2)
+        const doubled = computed(() => a() * 2)
+        expect(doubled()).toBe(4)
+        a.set(5)
+        expect(doubled()).toBe(10)
+    })
+
+    it('notifies subscribers on derived change', () => {
+        const a = createSignal(1)
+        const c = computed(() => a() + 1)
+        const listener = vi.fn()
+        c.subscribe(listener)
+        a.set(2)
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+})

--- a/packages/core/src/controllers/__tests__/drawing.test.ts
+++ b/packages/core/src/controllers/__tests__/drawing.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createDrawingController } from '../createDrawingController'
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+describe('createDrawingController — construction', () => {
+    it('defaults to null activeTool and zero drawingCount', () => {
+        const c = createDrawingController()
+        expect(c.state()).toEqual({ activeTool: null, drawingCount: 0 })
+    })
+
+    it('accepts an initial active tool', () => {
+        const c = createDrawingController({ initialActiveTool: 'trendline' })
+        expect(c.state().activeTool).toBe('trendline')
+        expect(c.state().drawingCount).toBe(0)
+    })
+
+    it('accepts an initial drawing count', () => {
+        const c = createDrawingController({ initialDrawingCount: 5 })
+        expect(c.state().drawingCount).toBe(5)
+    })
+
+    it('floors a negative initial drawing count at 0', () => {
+        const c = createDrawingController({ initialDrawingCount: -3 })
+        expect(c.state().drawingCount).toBe(0)
+    })
+
+    it('accepts both initial values together', () => {
+        const c = createDrawingController({
+            initialActiveTool: 'fib',
+            initialDrawingCount: 2,
+        })
+        expect(c.state()).toEqual({ activeTool: 'fib', drawingCount: 2 })
+    })
+})
+
+// ---------------------------------------------------------------------------
+// setActiveTool
+// ---------------------------------------------------------------------------
+
+describe('setActiveTool', () => {
+    it('round-trips through every drawing tool type', () => {
+        const c = createDrawingController()
+        const types = [
+            'trendline',
+            'horizontal',
+            'fib',
+            'rectangle',
+            'arrow',
+        ] as const
+
+        for (const t of types) {
+            c.setActiveTool(t)
+            expect(c.state().activeTool).toBe(t)
+        }
+    })
+
+    it('can clear the active tool with null', () => {
+        const c = createDrawingController({ initialActiveTool: 'trendline' })
+        c.setActiveTool(null)
+        expect(c.state().activeTool).toBeNull()
+    })
+
+    it('emits exactly one notification per change', () => {
+        const c = createDrawingController()
+        const listener = vi.fn()
+        c.state.subscribe(listener)
+        c.setActiveTool('rectangle')
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not emit when the value is unchanged', () => {
+        const c = createDrawingController({ initialActiveTool: 'fib' })
+        const listener = vi.fn()
+        c.state.subscribe(listener)
+        c.setActiveTool('fib')
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('preserves drawingCount when changing tools', () => {
+        const c = createDrawingController({ initialDrawingCount: 4 })
+        c.setActiveTool('arrow')
+        expect(c.state().drawingCount).toBe(4)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// clearAll
+// ---------------------------------------------------------------------------
+
+describe('clearAll', () => {
+    it('resets drawingCount to 0', () => {
+        const c = createDrawingController({ initialDrawingCount: 7 })
+        c.clearAll()
+        expect(c.state().drawingCount).toBe(0)
+    })
+
+    it('preserves activeTool', () => {
+        const c = createDrawingController({
+            initialActiveTool: 'horizontal',
+            initialDrawingCount: 3,
+        })
+        c.clearAll()
+        expect(c.state().activeTool).toBe('horizontal')
+    })
+
+    it('emits one notification when count was non-zero', () => {
+        const c = createDrawingController({ initialDrawingCount: 2 })
+        const listener = vi.fn()
+        c.state.subscribe(listener)
+        c.clearAll()
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not emit when count is already 0', () => {
+        const c = createDrawingController()
+        const listener = vi.fn()
+        c.state.subscribe(listener)
+        c.clearAll()
+        expect(listener).not.toHaveBeenCalled()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// deleteLast
+// ---------------------------------------------------------------------------
+
+describe('deleteLast', () => {
+    it('decrements drawingCount by 1', () => {
+        const c = createDrawingController({ initialDrawingCount: 3 })
+        c.deleteLast()
+        expect(c.state().drawingCount).toBe(2)
+    })
+
+    it('floors at 0 — no-op when count is 0', () => {
+        const c = createDrawingController()
+        const listener = vi.fn()
+        c.state.subscribe(listener)
+        c.deleteLast()
+        expect(c.state().drawingCount).toBe(0)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('emits one notification per successful decrement', () => {
+        const c = createDrawingController({ initialDrawingCount: 2 })
+        const listener = vi.fn()
+        c.state.subscribe(listener)
+        c.deleteLast()
+        c.deleteLast()
+        expect(listener).toHaveBeenCalledTimes(2)
+        expect(c.state().drawingCount).toBe(0)
+        // third call is a no-op (floor)
+        c.deleteLast()
+        expect(listener).toHaveBeenCalledTimes(2)
+    })
+
+    it('preserves activeTool when decrementing', () => {
+        const c = createDrawingController({
+            initialActiveTool: 'rectangle',
+            initialDrawingCount: 2,
+        })
+        c.deleteLast()
+        expect(c.state().activeTool).toBe('rectangle')
+    })
+})
+
+// ---------------------------------------------------------------------------
+// Immutability
+// ---------------------------------------------------------------------------
+
+describe('immutability', () => {
+    it('produces a new state object on every successful mutation', () => {
+        const c = createDrawingController({ initialDrawingCount: 1 })
+        const before = c.state()
+        c.setActiveTool('arrow')
+        const after = c.state()
+        expect(after).not.toBe(before)
+        // the original snapshot must not have been mutated
+        expect(before.activeTool).toBeNull()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// dispose
+// ---------------------------------------------------------------------------
+
+describe('dispose', () => {
+    it('silences subsequent mutators for previously-attached subscribers', () => {
+        const c = createDrawingController({ initialDrawingCount: 3 })
+        const listener = vi.fn()
+        c.state.subscribe(listener)
+
+        c.dispose()
+
+        c.setActiveTool('fib')
+        c.clearAll()
+        c.deleteLast()
+
+        expect(listener).not.toHaveBeenCalled()
+        // state is frozen at its pre-dispose value
+        expect(c.state()).toEqual({ activeTool: null, drawingCount: 3 })
+    })
+
+    it('is idempotent', () => {
+        const c = createDrawingController()
+        expect(() => {
+            c.dispose()
+            c.dispose()
+            c.dispose()
+        }).not.toThrow()
+    })
+})

--- a/packages/core/src/controllers/__tests__/indicatorSelector.test.ts
+++ b/packages/core/src/controllers/__tests__/indicatorSelector.test.ts
@@ -1,0 +1,481 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createIndicatorSelectorController } from '../createIndicatorSelectorController'
+import type { IndicatorDefinition } from '../types'
+
+// ---------------------------------------------------------------------------
+// Fixture catalog — 3 main + 3 sub, with param schemas modelled on the real
+// indicator data in src/core/renderers/Indicator/indicatorData.ts
+// ---------------------------------------------------------------------------
+
+const fixtureCatalog: ReadonlyArray<IndicatorDefinition> = [
+    {
+        id: 'MA',
+        label: 'MA',
+        name: 'Moving Average',
+        role: 'main',
+        params: [
+            { key: 'period', label: 'Period', type: 'number', default: 20, min: 2, max: 200, step: 1 },
+        ],
+    },
+    {
+        id: 'BOLL',
+        label: 'BOLL',
+        name: 'Bollinger Bands',
+        role: 'main',
+        params: [
+            { key: 'period', label: 'Period', type: 'number', default: 20, min: 2, max: 100, step: 1 },
+            { key: 'multiplier', label: 'Multiplier', type: 'number', default: 2, min: 0.1, max: 5, step: 0.1 },
+        ],
+    },
+    {
+        id: 'EXPMA',
+        label: 'EXPMA',
+        name: 'Exponential MA',
+        role: 'main',
+        params: [
+            { key: 'fastPeriod', label: 'Fast', type: 'number', default: 12, min: 2, max: 100, step: 1 },
+            { key: 'slowPeriod', label: 'Slow', type: 'number', default: 50, min: 2, max: 200, step: 1 },
+        ],
+    },
+    {
+        id: 'KDJ',
+        label: 'KDJ',
+        name: 'Stochastic KDJ',
+        role: 'sub',
+        params: [
+            { key: 'period', label: 'Period', type: 'number', default: 9, min: 2, max: 100, step: 1 },
+        ],
+    },
+    {
+        id: 'MACD',
+        label: 'MACD',
+        name: 'MACD',
+        role: 'sub',
+        params: [
+            { key: 'fast', label: 'Fast', type: 'number', default: 12, min: 2, max: 100, step: 1 },
+            { key: 'slow', label: 'Slow', type: 'number', default: 26, min: 2, max: 200, step: 1 },
+            { key: 'signal', label: 'Signal', type: 'number', default: 9, min: 2, max: 50, step: 1 },
+        ],
+    },
+    {
+        id: 'RSI',
+        label: 'RSI',
+        name: 'Relative Strength Index',
+        role: 'sub',
+        params: [
+            { key: 'period', label: 'Period', type: 'number', default: 14, min: 2, max: 100, step: 1 },
+        ],
+    },
+]
+
+function makeController() {
+    return createIndicatorSelectorController({ catalog: fixtureCatalog })
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+describe('createIndicatorSelectorController — construction', () => {
+    it('exposes the provided catalog', () => {
+        const c = makeController()
+        expect(c.catalog()).toEqual(fixtureCatalog)
+    })
+
+    it('starts with empty active list, closed menu and empty query', () => {
+        const c = makeController()
+        expect(c.active()).toEqual([])
+        expect(c.menuOpen()).toBe(false)
+        expect(c.searchQuery()).toBe('')
+    })
+
+    it('defaults catalog to empty when not provided', () => {
+        const c = createIndicatorSelectorController()
+        expect(c.catalog()).toEqual([])
+        expect(c.filteredMain()).toEqual([])
+        expect(c.filteredSub()).toEqual([])
+    })
+
+    it('accepts initial active indicators', () => {
+        const c = createIndicatorSelectorController({
+            catalog: fixtureCatalog,
+            active: [
+                {
+                    id: 'seed-1',
+                    definitionId: 'MA',
+                    label: 'MA',
+                    name: 'Moving Average',
+                    role: 'main',
+                    params: { period: 20 },
+                },
+            ],
+        })
+        expect(c.active()).toHaveLength(1)
+        expect(c.isActive('MA')).toBe(true)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// add()
+// ---------------------------------------------------------------------------
+
+describe('add', () => {
+    it('returns a new instance id and pushes onto active', () => {
+        const c = makeController()
+        const listener = vi.fn()
+        c.active.subscribe(listener)
+
+        const id = c.add('KDJ')
+
+        expect(id).not.toBeNull()
+        expect(c.active()).toHaveLength(1)
+        expect(c.active()[0]?.definitionId).toBe('KDJ')
+        expect(c.active()[0]?.id).toBe(id)
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('seeds default params from the definition', () => {
+        const c = makeController()
+        c.add('BOLL')
+        const inst = c.active()[0]
+        expect(inst?.params).toEqual({ period: 20, multiplier: 2 })
+    })
+
+    it('returns null if the definition is already active', () => {
+        const c = makeController()
+        const first = c.add('RSI')
+        expect(first).not.toBeNull()
+
+        const listener = vi.fn()
+        c.active.subscribe(listener)
+
+        const second = c.add('RSI')
+        expect(second).toBeNull()
+        expect(c.active()).toHaveLength(1)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('returns null when the definition id is unknown', () => {
+        const c = makeController()
+        expect(c.add('NOT_A_REAL_INDICATOR')).toBeNull()
+        expect(c.active()).toEqual([])
+    })
+
+    it('replaces previous main indicator (mutual exclusion)', () => {
+        const c = makeController()
+        c.add('MA')
+        c.add('BOLL')
+        const mains = c.active().filter((a) => a.role === 'main')
+        expect(mains).toHaveLength(1)
+        expect(mains[0]?.definitionId).toBe('BOLL')
+    })
+
+    it('keeps mains before subs in display order', () => {
+        const c = makeController()
+        c.add('KDJ')
+        c.add('MA')
+        c.add('MACD')
+        const order = c.active().map((a) => a.definitionId)
+        // main should be first; subs follow in their insertion order
+        expect(order[0]).toBe('MA')
+        expect(order.slice(1).sort()).toEqual(['KDJ', 'MACD'])
+    })
+})
+
+// ---------------------------------------------------------------------------
+// remove()
+// ---------------------------------------------------------------------------
+
+describe('remove', () => {
+    it('returns true and emits when the instance exists', () => {
+        const c = makeController()
+        const id = c.add('KDJ') as string
+        const listener = vi.fn()
+        c.active.subscribe(listener)
+
+        const ok = c.remove(id)
+        expect(ok).toBe(true)
+        expect(c.active()).toEqual([])
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns false and does NOT emit when the instance is missing', () => {
+        const c = makeController()
+        const listener = vi.fn()
+        c.active.subscribe(listener)
+
+        const ok = c.remove('nonexistent')
+        expect(ok).toBe(false)
+        expect(listener).not.toHaveBeenCalled()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// updateParams()
+// ---------------------------------------------------------------------------
+
+describe('updateParams', () => {
+    it('merges new param values immutably and emits', () => {
+        const c = makeController()
+        const id = c.add('BOLL') as string
+        const before = c.active()[0]
+
+        const listener = vi.fn()
+        c.active.subscribe(listener)
+
+        const ok = c.updateParams(id, { period: 30 })
+        expect(ok).toBe(true)
+
+        const after = c.active()[0]
+        expect(after?.params).toEqual({ period: 30, multiplier: 2 })
+        // immutability: the original instance object should not be mutated
+        expect(before?.params).toEqual({ period: 20, multiplier: 2 })
+        expect(after).not.toBe(before)
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('supports number, string and boolean param values', () => {
+        const c = makeController()
+        const id = c.add('KDJ') as string
+        const ok = c.updateParams(id, { period: 21, label: 'fast', visible: false })
+        expect(ok).toBe(true)
+        expect(c.active()[0]?.params).toEqual({
+            period: 21,
+            label: 'fast',
+            visible: false,
+        })
+    })
+
+    it('returns false and does not emit for an unknown instance id', () => {
+        const c = makeController()
+        c.add('MA')
+        const listener = vi.fn()
+        c.active.subscribe(listener)
+
+        const ok = c.updateParams('nonexistent', { period: 5 })
+        expect(ok).toBe(false)
+        expect(listener).not.toHaveBeenCalled()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// reorder()
+// ---------------------------------------------------------------------------
+
+describe('reorder', () => {
+    it('moves a sub indicator from one position to another', () => {
+        const c = makeController()
+        const a = c.add('KDJ') as string
+        const b = c.add('MACD') as string
+        const cc = c.add('RSI') as string
+
+        // initial: [KDJ, MACD, RSI]
+        expect(c.active().map((x) => x.id)).toEqual([a, b, cc])
+
+        const ok = c.reorder(cc, a)
+        expect(ok).toBe(true)
+        // RSI now sits where KDJ was → [RSI, KDJ, MACD]
+        expect(c.active().map((x) => x.id)).toEqual([cc, a, b])
+    })
+
+    it('refuses to reorder when source is a main indicator', () => {
+        const c = makeController()
+        const mainId = c.add('MA') as string
+        const subId = c.add('KDJ') as string
+        const ok = c.reorder(mainId, subId)
+        expect(ok).toBe(false)
+    })
+
+    it('refuses to reorder when target is a main indicator', () => {
+        const c = makeController()
+        const mainId = c.add('MA') as string
+        const subId = c.add('KDJ') as string
+        const ok = c.reorder(subId, mainId)
+        expect(ok).toBe(false)
+    })
+
+    it('returns false when source equals target', () => {
+        const c = makeController()
+        const id = c.add('KDJ') as string
+        const ok = c.reorder(id, id)
+        expect(ok).toBe(false)
+    })
+
+    it('returns false when an instance id is unknown', () => {
+        const c = makeController()
+        const id = c.add('KDJ') as string
+        expect(c.reorder(id, 'nope')).toBe(false)
+        expect(c.reorder('nope', id)).toBe(false)
+    })
+
+    it('mains stay pinned to the front after a sub reorder', () => {
+        const c = makeController()
+        c.add('MA')
+        const k = c.add('KDJ') as string
+        const m = c.add('MACD') as string
+        c.reorder(m, k)
+        const roles = c.active().map((x) => x.role)
+        expect(roles[0]).toBe('main')
+        // remaining subs swapped order
+        expect(c.active().slice(1).map((x) => x.definitionId)).toEqual([
+            'MACD',
+            'KDJ',
+        ])
+    })
+})
+
+// ---------------------------------------------------------------------------
+// Menu state
+// ---------------------------------------------------------------------------
+
+describe('menu state', () => {
+    let c: ReturnType<typeof makeController>
+    beforeEach(() => {
+        c = makeController()
+    })
+
+    it('openMenu sets menuOpen to true', () => {
+        c.openMenu()
+        expect(c.menuOpen()).toBe(true)
+    })
+
+    it('closeMenu sets menuOpen to false', () => {
+        c.openMenu()
+        c.closeMenu()
+        expect(c.menuOpen()).toBe(false)
+    })
+
+    it('toggleMenu flips menuOpen', () => {
+        expect(c.menuOpen()).toBe(false)
+        c.toggleMenu()
+        expect(c.menuOpen()).toBe(true)
+        c.toggleMenu()
+        expect(c.menuOpen()).toBe(false)
+    })
+
+    it('notifies subscribers on each transition', () => {
+        const listener = vi.fn()
+        c.menuOpen.subscribe(listener)
+        c.openMenu()
+        c.openMenu() // idempotent — no second notification
+        c.closeMenu()
+        expect(listener).toHaveBeenCalledTimes(2)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// Search / filtering
+// ---------------------------------------------------------------------------
+
+describe('search / filtering', () => {
+    it('filteredMain and filteredSub default to all definitions in their role', () => {
+        const c = makeController()
+        expect(c.filteredMain().map((d) => d.id)).toEqual(['MA', 'BOLL', 'EXPMA'])
+        expect(c.filteredSub().map((d) => d.id)).toEqual(['KDJ', 'MACD', 'RSI'])
+    })
+
+    it('setSearchQuery does case-insensitive partial match on label', () => {
+        const c = makeController()
+        c.setSearchQuery('ma')
+        // matches MA (label), MACD (label), EXPMA (label suffix), Moving Average (name)
+        const ids = new Set(
+            c.filteredMain().concat(c.filteredSub()).map((d) => d.id),
+        )
+        expect(ids.has('MA')).toBe(true)
+        expect(ids.has('MACD')).toBe(true)
+        expect(ids.has('EXPMA')).toBe(true)
+    })
+
+    it('matches against name as well as label', () => {
+        const c = makeController()
+        c.setSearchQuery('Bollinger')
+        expect(c.filteredMain().map((d) => d.id)).toEqual(['BOLL'])
+        expect(c.filteredSub()).toEqual([])
+    })
+
+    it('upper / lower case does not matter', () => {
+        const c = makeController()
+        c.setSearchQuery('STOCHASTIC')
+        expect(c.filteredSub().map((d) => d.id)).toEqual(['KDJ'])
+    })
+
+    it('an empty query restores the full role-partitioned list', () => {
+        const c = makeController()
+        c.setSearchQuery('boll')
+        expect(c.filteredMain()).toHaveLength(1)
+        c.setSearchQuery('')
+        expect(c.filteredMain()).toHaveLength(3)
+        expect(c.filteredSub()).toHaveLength(3)
+    })
+
+    it('notifies subscribers when the query changes', () => {
+        const c = makeController()
+        const listener = vi.fn()
+        c.filteredSub.subscribe(listener)
+        c.setSearchQuery('rsi')
+        expect(listener).toHaveBeenCalled()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// isActive
+// ---------------------------------------------------------------------------
+
+describe('isActive', () => {
+    it('reflects the active state by definition id', () => {
+        const c = makeController()
+        expect(c.isActive('MA')).toBe(false)
+        c.add('MA')
+        expect(c.isActive('MA')).toBe(true)
+        expect(c.isActive('BOLL')).toBe(false)
+    })
+
+    it('reads from the definition id, not the instance id', () => {
+        const c = makeController()
+        const instId = c.add('RSI') as string
+        // not active by instance id
+        expect(c.isActive(instId)).toBe(false)
+        // active by definition id
+        expect(c.isActive('RSI')).toBe(true)
+    })
+})
+
+// ---------------------------------------------------------------------------
+// dispose
+// ---------------------------------------------------------------------------
+
+describe('dispose', () => {
+    it('subsequent mutations do not emit to previously-attached listeners', () => {
+        const c = makeController()
+        const id = c.add('KDJ') as string
+
+        const activeListener = vi.fn()
+        const menuListener = vi.fn()
+        const queryListener = vi.fn()
+        c.active.subscribe(activeListener)
+        c.menuOpen.subscribe(menuListener)
+        c.searchQuery.subscribe(queryListener)
+
+        c.dispose()
+
+        c.add('MACD')
+        c.remove(id)
+        c.updateParams(id, { period: 99 })
+        c.openMenu()
+        c.toggleMenu()
+        c.setSearchQuery('anything')
+
+        expect(activeListener).not.toHaveBeenCalled()
+        expect(menuListener).not.toHaveBeenCalled()
+        expect(queryListener).not.toHaveBeenCalled()
+    })
+
+    it('is idempotent', () => {
+        const c = makeController()
+        expect(() => {
+            c.dispose()
+            c.dispose()
+            c.dispose()
+        }).not.toThrow()
+    })
+})

--- a/packages/core/src/controllers/__tests__/toolbar.test.ts
+++ b/packages/core/src/controllers/__tests__/toolbar.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createToolbarController } from '../createToolbarController'
+import type { ToolDefinition } from '../types'
+
+// ---------------------------------------------------------------------------
+// Fixture — three tools, two in the same group ('lines') and one ungrouped
+// ('cursor'). Mirrors the structure in src/components/LeftToolbar.vue where
+// the parent "lines" item collapses to a set of children that should behave
+// as a radio group.
+// ---------------------------------------------------------------------------
+
+const fixtureTools: ReadonlyArray<ToolDefinition> = [
+    { id: 'cursor', label: 'Cursor' },
+    { id: 'trend-line', label: 'Trend Line', group: 'lines' },
+    { id: 'ray', label: 'Ray', group: 'lines' },
+    { id: 'parallel-channel', label: 'Parallel Channel', group: 'channels' },
+]
+
+function makeController(initialActiveTool: string | null = null) {
+    return createToolbarController({
+        tools: fixtureTools,
+        initialActiveTool,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+describe('createToolbarController — construction', () => {
+    it('exposes the provided tool list', () => {
+        const c = makeController()
+        expect(c.tools()).toEqual(fixtureTools)
+    })
+
+    it('defaults to a null active tool and empty disabled set', () => {
+        const c = makeController()
+        expect(c.activeTool()).toBeNull()
+        expect(c.disabledTools().size).toBe(0)
+    })
+
+    it('honours initialActiveTool when provided', () => {
+        const c = makeController('cursor')
+        expect(c.activeTool()).toBe('cursor')
+    })
+})
+
+// ---------------------------------------------------------------------------
+// selectTool
+// ---------------------------------------------------------------------------
+
+describe('selectTool', () => {
+    it('sets the active tool and notifies subscribers', () => {
+        const c = makeController()
+        const listener = vi.fn()
+        c.activeTool.subscribe(listener)
+
+        c.selectTool('cursor')
+        expect(c.activeTool()).toBe('cursor')
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('is a no-op for an unknown tool id', () => {
+        const c = makeController('cursor')
+        const listener = vi.fn()
+        c.activeTool.subscribe(listener)
+
+        c.selectTool('not-a-real-tool')
+        expect(c.activeTool()).toBe('cursor')
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('selecting a grouped tool replaces another tool in the same group', () => {
+        const c = makeController()
+        c.selectTool('trend-line')
+        expect(c.activeTool()).toBe('trend-line')
+
+        c.selectTool('ray')
+        expect(c.activeTool()).toBe('ray')
+    })
+
+    it('does not affect tools in a different group', () => {
+        const c = makeController()
+        c.selectTool('trend-line')
+        c.selectTool('parallel-channel')
+        // Switching across groups is just a normal replace — only one tool
+        // can ever be active overall.
+        expect(c.activeTool()).toBe('parallel-channel')
+    })
+
+    it('selecting the already-active tool emits no notification', () => {
+        const c = makeController('cursor')
+        const listener = vi.fn()
+        c.activeTool.subscribe(listener)
+
+        c.selectTool('cursor')
+        expect(c.activeTool()).toBe('cursor')
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('refuses to select a disabled tool', () => {
+        const c = makeController()
+        c.setDisabled('trend-line', true)
+
+        const listener = vi.fn()
+        c.activeTool.subscribe(listener)
+
+        c.selectTool('trend-line')
+        expect(c.activeTool()).toBeNull()
+        expect(listener).not.toHaveBeenCalled()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// clearSelection
+// ---------------------------------------------------------------------------
+
+describe('clearSelection', () => {
+    it('sets the active tool back to null', () => {
+        const c = makeController('cursor')
+        c.clearSelection()
+        expect(c.activeTool()).toBeNull()
+    })
+
+    it('emits when clearing an active selection', () => {
+        const c = makeController('cursor')
+        const listener = vi.fn()
+        c.activeTool.subscribe(listener)
+        c.clearSelection()
+        expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    it('is a no-op when nothing is selected', () => {
+        const c = makeController()
+        const listener = vi.fn()
+        c.activeTool.subscribe(listener)
+        c.clearSelection()
+        expect(listener).not.toHaveBeenCalled()
+    })
+})
+
+// ---------------------------------------------------------------------------
+// setDisabled
+// ---------------------------------------------------------------------------
+
+describe('setDisabled', () => {
+    it('adds an id to the disabled set immutably', () => {
+        const c = makeController()
+        const before = c.disabledTools()
+        c.setDisabled('trend-line', true)
+        const after = c.disabledTools()
+        expect(after.has('trend-line')).toBe(true)
+        expect(before.has('trend-line')).toBe(false) // original set untouched
+        expect(after).not.toBe(before)
+    })
+
+    it('removes an id when disabled = false', () => {
+        const c = makeController()
+        c.setDisabled('trend-line', true)
+        c.setDisabled('trend-line', false)
+        expect(c.disabledTools().has('trend-line')).toBe(false)
+    })
+
+    it('is idempotent — re-disabling does not emit', () => {
+        const c = makeController()
+        c.setDisabled('trend-line', true)
+        const listener = vi.fn()
+        c.disabledTools.subscribe(listener)
+        c.setDisabled('trend-line', true)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    it('clears the active selection when disabling the active tool', () => {
+        const c = makeController('cursor')
+        const activeListener = vi.fn()
+        c.activeTool.subscribe(activeListener)
+
+        c.setDisabled('cursor', true)
+        expect(c.activeTool()).toBeNull()
+        expect(activeListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('leaves the active selection alone when disabling a different tool', () => {
+        const c = makeController('cursor')
+        c.setDisabled('trend-line', true)
+        expect(c.activeTool()).toBe('cursor')
+    })
+})
+
+// ---------------------------------------------------------------------------
+// dispose
+// ---------------------------------------------------------------------------
+
+describe('dispose', () => {
+    it('silences all mutators for previously-attached subscribers', () => {
+        const c = makeController()
+
+        const toolsListener = vi.fn()
+        const activeListener = vi.fn()
+        const disabledListener = vi.fn()
+        c.tools.subscribe(toolsListener)
+        c.activeTool.subscribe(activeListener)
+        c.disabledTools.subscribe(disabledListener)
+
+        c.dispose()
+
+        c.selectTool('cursor')
+        c.clearSelection()
+        c.setDisabled('cursor', true)
+        c.setDisabled('cursor', false)
+
+        expect(toolsListener).not.toHaveBeenCalled()
+        expect(activeListener).not.toHaveBeenCalled()
+        expect(disabledListener).not.toHaveBeenCalled()
+    })
+
+    it('is idempotent', () => {
+        const c = makeController()
+        expect(() => {
+            c.dispose()
+            c.dispose()
+            c.dispose()
+        }).not.toThrow()
+    })
+})

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -1,0 +1,518 @@
+/**
+ * createChartController — production ChartControllerFactory.
+ *
+ * Wraps the existing legacy chart engine (`src/core/chart.ts`, ~2150 LOC)
+ * behind the framework-agnostic `ChartController` signal surface. Adapters
+ * (React / Vue / Angular) consume this via auto-registration in their own
+ * `index.ts` entry — consumers don't need to call `__setChartFactory`
+ * unless they want to inject a custom backing for testing.
+ *
+ * Boundaries owned here:
+ *   - Construct the inner DOM scaffold the legacy `Chart` expects
+ *     (canvas-layer + right-axis-host + x-axis-canvas inside the
+ *     consumer-supplied container).
+ *   - Bridge Chart's imperative callbacks (`setOnViewportChange`,
+ *     `setOnDataChange`) into signal writes.
+ *   - Translate zoom intents (`zoomIn`, `zoomOut`, `zoomToLevel`) into
+ *     `computeZoom` / `computeZoomToLevel` -> `applyRenderState` calls.
+ *   - Translate `setData` / `appendData` into `updateData(...)`.
+ *   - Compose the IndicatorSelectorController with a sensible default
+ *     catalog discovered from the legacy renderer registry.
+ *   - Stub `toolbar` and `drawing` controllers (Round 1F shipped real
+ *     implementations; we wire those with reasonable defaults but do
+ *     NOT yet bind toolbar selections to drawing-tool activation —
+ *     that crossover is the maintainer's TODO).
+ *   - Tear down DOM + listeners + child controllers on dispose().
+ *
+ * Engine import note: this module statically imports the legacy `Chart`
+ * via a relative path that crosses the `packages/core` rootDir boundary.
+ * That is accepted by tsc with `moduleResolution: bundler` and resolved
+ * by vitest via the repo-root `@` alias added to each package's
+ * vitest.config.ts. The auto-register line in each adapter does NOT
+ * touch the DOM at module-evaluation time — Chart's constructor only
+ * runs when `createChart(opts)` is called with a real container.
+ */
+
+import { createSignal, type Signal } from '../reactivity'
+import { createIndicatorSelectorController } from './createIndicatorSelectorController'
+import { createToolbarController } from './createToolbarController'
+import { createDrawingController } from './createDrawingController'
+import type {
+    ChartController,
+    ChartMountOptions,
+    ChartViewport,
+    IndicatorDefinition,
+    KLineData,
+} from './types'
+import { Chart, type ChartOptions } from '../../../../src/core/chart'
+import type { Viewport as LegacyViewport } from '../../../../src/core/chart'
+import {
+    computeZoom,
+    computeZoomToLevel,
+    zoomLevelToKWidth,
+    kGapFromKWidth,
+} from '../../../../src/core/utils/zoom'
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_OPTS = {
+    yPaddingPx: 0,
+    minKWidth: 1,
+    maxKWidth: 50,
+    rightAxisWidth: 0,
+    bottomAxisHeight: 24,
+    priceLabelWidth: 60,
+    zoomLevels: 20,
+    initialZoomLevel: 3,
+} as const
+
+// Minimal main + sub indicator catalog. Mirrors the renderer ids registered
+// in `src/core/chart.ts`'s `enableMainIndicator` whitelist and the
+// `SUB_PANE_INDICATOR_CONFIGS` keys. Kept here as a static, framework-agnostic
+// catalog so the controller has no runtime dependency on the renderer module
+// graph at module-load time.
+const DEFAULT_INDICATOR_CATALOG: ReadonlyArray<IndicatorDefinition> = [
+    // ---------- Main pane ----------
+    { id: 'MA', label: 'MA', name: '移动平均线', role: 'main', params: [] },
+    { id: 'BOLL', label: 'BOLL', name: '布林带', role: 'main', params: [] },
+    { id: 'EXPMA', label: 'EXPMA', name: '指数平均线', role: 'main', params: [] },
+    { id: 'ENE', label: 'ENE', name: '轨道线', role: 'main', params: [] },
+    { id: 'WMA', label: 'WMA', name: '加权移动平均', role: 'main', params: [] },
+    { id: 'DEMA', label: 'DEMA', name: '双指数移动平均', role: 'main', params: [] },
+    { id: 'TEMA', label: 'TEMA', name: '三指数移动平均', role: 'main', params: [] },
+    { id: 'HMA', label: 'HMA', name: 'Hull 移动平均', role: 'main', params: [] },
+    { id: 'KAMA', label: 'KAMA', name: '考夫曼自适应', role: 'main', params: [] },
+    { id: 'SAR', label: 'SAR', name: '抛物线', role: 'main', params: [] },
+    { id: 'SUPERTREND', label: 'SuperTrend', name: '超级趋势', role: 'main', params: [] },
+    { id: 'KELTNER', label: 'KELTNER', name: 'Keltner 通道', role: 'main', params: [] },
+    { id: 'DONCHIAN', label: 'DONCHIAN', name: 'Donchian 通道', role: 'main', params: [] },
+    { id: 'ICHIMOKU', label: 'ICHIMOKU', name: '一目均衡表', role: 'main', params: [] },
+    { id: 'PIVOT', label: 'PIVOT', name: '枢轴点', role: 'main', params: [] },
+    { id: 'FIB', label: 'FIB', name: '斐波那契', role: 'main', params: [] },
+    { id: 'STRUCTURE', label: 'Structure', name: 'SMC 结构', role: 'main', params: [] },
+    { id: 'ZONES', label: 'Zones', name: 'SMC 区域', role: 'main', params: [] },
+    // ---------- Sub pane ----------
+    { id: 'VOLUME', label: 'VOL', name: '成交量', role: 'sub', params: [] },
+    { id: 'MACD', label: 'MACD', name: 'MACD', role: 'sub', params: [] },
+    { id: 'RSI', label: 'RSI', name: '相对强弱', role: 'sub', params: [] },
+    { id: 'CCI', label: 'CCI', name: '顺势指标', role: 'sub', params: [] },
+    { id: 'STOCH', label: 'KDJ/STOCH', name: '随机指标', role: 'sub', params: [] },
+    { id: 'MOM', label: 'MOM', name: '动量', role: 'sub', params: [] },
+    { id: 'WMSR', label: 'WMSR', name: '威廉指标', role: 'sub', params: [] },
+    { id: 'KST', label: 'KST', name: 'KST 振荡器', role: 'sub', params: [] },
+    { id: 'FASTK', label: 'FASTK', name: '快速 K', role: 'sub', params: [] },
+    { id: 'ATR', label: 'ATR', name: '真实波幅', role: 'sub', params: [] },
+    { id: 'ROC', label: 'ROC', name: '变动率', role: 'sub', params: [] },
+    { id: 'TRIX', label: 'TRIX', name: '三重指数平滑', role: 'sub', params: [] },
+    { id: 'HV', label: 'HV', name: '历史波动率', role: 'sub', params: [] },
+    { id: 'PARKINSON', label: 'Parkinson', name: 'Parkinson 波动率', role: 'sub', params: [] },
+    { id: 'CHAIKIN_VOL', label: 'ChaikinVol', name: '蔡金波动率', role: 'sub', params: [] },
+    { id: 'VMA', label: 'VMA', name: '成交量均线', role: 'sub', params: [] },
+    { id: 'OBV', label: 'OBV', name: '能量潮', role: 'sub', params: [] },
+    { id: 'PVT', label: 'PVT', name: '价量趋势', role: 'sub', params: [] },
+    { id: 'VWAP', label: 'VWAP', name: '成交量加权均价', role: 'sub', params: [] },
+    { id: 'CMF', label: 'CMF', name: '蔡金资金流量', role: 'sub', params: [] },
+    { id: 'MFI', label: 'MFI', name: '资金流量指标', role: 'sub', params: [] },
+    { id: 'VOLUME_PROFILE', label: 'VP', name: '成交量分布', role: 'sub', params: [] },
+]
+
+// ---------------------------------------------------------------------------
+// DOM scaffolding
+// ---------------------------------------------------------------------------
+
+interface MountedDom {
+    container: HTMLDivElement
+    canvasLayer: HTMLDivElement
+    rightAxisLayer: HTMLDivElement
+    xAxisCanvas: HTMLCanvasElement
+    cleanup: () => void
+}
+
+/**
+ * Build the DOM scaffold the legacy `Chart` expects inside the
+ * consumer-supplied container.
+ *
+ * Mirrors the structure of `src/components/KLineChart.vue` (`.chart-container`
+ * > `.scroll-content` > `.canvas-layer` + `.x-axis-canvas`; sibling
+ * `.right-axis-host`). The legacy engine adds canvas elements into
+ * `canvasLayer` itself during `initPanes()`.
+ *
+ * The cleanup callback removes only the elements WE created, leaving the
+ * consumer-supplied container untouched.
+ */
+function buildDom(container: HTMLElement): MountedDom {
+    const ownerDoc = container.ownerDocument
+    if (ownerDoc === null || ownerDoc === undefined) {
+        throw new Error(
+            '[createChartController] container has no ownerDocument; cannot build DOM scaffold',
+        )
+    }
+
+    // The legacy Chart class types `container` as HTMLDivElement. If the
+    // consumer passed a different element type, wrap it in a child div so
+    // the engine has the exact shape it expects without us mutating the
+    // outer element's tag.
+    let chartContainer: HTMLDivElement
+    let containerCreatedByUs = false
+    if (container instanceof HTMLDivElement) {
+        chartContainer = container
+    } else {
+        chartContainer = ownerDoc.createElement('div')
+        chartContainer.style.width = '100%'
+        chartContainer.style.height = '100%'
+        chartContainer.style.position = 'relative'
+        chartContainer.style.overflow = 'auto'
+        container.appendChild(chartContainer)
+        containerCreatedByUs = true
+    }
+
+    const scrollContent = ownerDoc.createElement('div')
+    scrollContent.className = 'klc-scroll-content'
+    scrollContent.style.position = 'relative'
+
+    const canvasLayer = ownerDoc.createElement('div')
+    canvasLayer.className = 'klc-canvas-layer'
+    canvasLayer.style.position = 'sticky'
+    canvasLayer.style.top = '0'
+    canvasLayer.style.left = '0'
+
+    const xAxisCanvas = ownerDoc.createElement('canvas')
+    xAxisCanvas.className = 'klc-x-axis-canvas'
+
+    canvasLayer.appendChild(xAxisCanvas)
+    scrollContent.appendChild(canvasLayer)
+    chartContainer.appendChild(scrollContent)
+
+    const rightAxisLayer = ownerDoc.createElement('div')
+    rightAxisLayer.className = 'klc-right-axis-host'
+    rightAxisLayer.style.position = 'absolute'
+    rightAxisLayer.style.top = '0'
+    rightAxisLayer.style.right = '0'
+    chartContainer.appendChild(rightAxisLayer)
+
+    const cleanup = (): void => {
+        try {
+            scrollContent.remove()
+            rightAxisLayer.remove()
+            if (containerCreatedByUs) {
+                chartContainer.remove()
+            }
+        } catch {
+            /* DOM may already be gone — best effort */
+        }
+    }
+
+    return {
+        container: chartContainer,
+        canvasLayer,
+        rightAxisLayer,
+        xAxisCanvas,
+        cleanup,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createChartController(opts: ChartMountOptions): ChartController {
+    if (opts === null || opts === undefined) {
+        throw new Error('[createChartController] opts is required')
+    }
+    if (opts.container === null || opts.container === undefined) {
+        throw new Error(
+            '[createChartController] opts.container must be a non-null HTMLElement',
+        )
+    }
+
+    // -------------------------------------------------------------------
+    // DOM + Chart construction
+    // -------------------------------------------------------------------
+    const mounted = buildDom(opts.container)
+    const initialZoomLevel = opts.initialZoomLevel ?? DEFAULT_OPTS.initialZoomLevel
+    const zoomLevelCount = opts.zoomLevels ?? DEFAULT_OPTS.zoomLevels
+
+    const chartOptions: ChartOptions = {
+        yPaddingPx: DEFAULT_OPTS.yPaddingPx,
+        rightAxisWidth: DEFAULT_OPTS.rightAxisWidth,
+        bottomAxisHeight: DEFAULT_OPTS.bottomAxisHeight,
+        minKWidth: DEFAULT_OPTS.minKWidth,
+        maxKWidth: DEFAULT_OPTS.maxKWidth,
+        priceLabelWidth: DEFAULT_OPTS.priceLabelWidth,
+        panes: [{ id: 'main', ratio: 1 }],
+        paneGap: 0,
+        zoomLevels: zoomLevelCount,
+        initialZoomLevel,
+    }
+
+    const chart = new Chart(
+        {
+            container: mounted.container,
+            canvasLayer: mounted.canvasLayer,
+            rightAxisLayer: mounted.rightAxisLayer,
+            xAxisCanvas: mounted.xAxisCanvas,
+        },
+        chartOptions,
+    )
+
+    // -------------------------------------------------------------------
+    // Signal-backed state
+    // -------------------------------------------------------------------
+    let currentDpr = typeof window !== 'undefined' && window.devicePixelRatio > 0
+        ? window.devicePixelRatio
+        : 1
+    let currentKWidth = zoomLevelToKWidth(initialZoomLevel, {
+        minKWidth: DEFAULT_OPTS.minKWidth,
+        maxKWidth: DEFAULT_OPTS.maxKWidth,
+        zoomLevelCount,
+        dpr: currentDpr,
+    })
+    let currentKGap = kGapFromKWidth(currentKWidth, currentDpr)
+    let currentZoomLevel = initialZoomLevel
+
+    // Apply the initial render state so the engine has valid kWidth/kGap
+    // before the first draw. Wrapped in try/catch because some test
+    // environments (jsdom) lack a meaningful Canvas2D context — the engine
+    // is otherwise defensive against this.
+    try {
+        chart.applyRenderState(currentKWidth, currentKGap, currentZoomLevel)
+    } catch {
+        /* tolerate jsdom / first-paint constructor races */
+    }
+
+    const viewport: Signal<ChartViewport> = createSignal<ChartViewport>({
+        zoomLevel: currentZoomLevel,
+        kWidth: currentKWidth,
+        visibleFrom: 0,
+        visibleTo: 0,
+    })
+
+    const data: Signal<ReadonlyArray<KLineData>> =
+        createSignal<ReadonlyArray<KLineData>>(opts.data)
+
+    const theme: Signal<'light' | 'dark'> = createSignal<'light' | 'dark'>(
+        opts.theme ?? 'light',
+    )
+
+    // -------------------------------------------------------------------
+    // Child controllers
+    // -------------------------------------------------------------------
+    const indicatorSelector = createIndicatorSelectorController({
+        catalog: DEFAULT_INDICATOR_CATALOG,
+    })
+
+    // TODO(Round 1F): cross-wire toolbar selections to drawing.setActiveTool
+    // and to chart.interaction state. For now the toolbar is initialised
+    // with an empty tool catalog — consumers can register tools imperatively
+    // via the controller surface in a later round.
+    const toolbar = createToolbarController({ tools: [] })
+
+    // TODO(Round 1F): bind drawing.clearAll / deleteLast to the legacy
+    // DrawingStore via `chart.setDrawings([])`. The Round 1F drawing
+    // controller currently tracks drawing count locally; bridging to the
+    // engine store is the next step. We listen to drawing state changes
+    // so the engine can be updated when that wiring lands.
+    const drawing = createDrawingController()
+
+    // -------------------------------------------------------------------
+    // Chart -> signal wiring
+    // -------------------------------------------------------------------
+    chart.setOnViewportChange((vp: LegacyViewport) => {
+        // Keep our zoom-derivation state in sync with the engine's effective
+        // DPR (the engine can refine DPR from ResizeObserver).
+        if (vp.dpr > 0) {
+            currentDpr = vp.dpr
+        }
+        // Visible range is opaque to the controller without re-deriving from
+        // scrollLeft/kWidth; we publish what we know and leave visibleFrom/To
+        // as 0 until a dedicated visible-range signal is added.
+        viewport.set({
+            zoomLevel: currentZoomLevel,
+            kWidth: currentKWidth,
+            visibleFrom: 0,
+            visibleTo: 0,
+        })
+    })
+
+    chart.setOnDataChange((next: KLineData[]) => {
+        data.set([...next])
+    })
+
+    // Seed the engine with the initial data the consumer passed in.
+    try {
+        chart.updateData(Array.from(opts.data))
+    } catch {
+        /* tolerate first-paint racing the constructor */
+    }
+
+    // -------------------------------------------------------------------
+    // Zoom helpers
+    // -------------------------------------------------------------------
+    function applyZoom(targetLevel: number, anchorX: number | undefined): void {
+        const delta = targetLevel - currentZoomLevel
+        if (delta === 0) return
+        const anchor = typeof anchorX === 'number' ? anchorX : 0
+        const scrollLeft = chart.getCachedScrollLeft()
+        const result = computeZoomToLevel(
+            targetLevel,
+            anchor,
+            scrollLeft,
+            currentZoomLevel,
+            currentKWidth,
+            currentKGap,
+            {
+                minKWidth: DEFAULT_OPTS.minKWidth,
+                maxKWidth: DEFAULT_OPTS.maxKWidth,
+                zoomLevelCount,
+                dpr: currentDpr,
+            },
+        )
+        if (result === null) return
+        currentZoomLevel = result.targetLevel
+        currentKWidth = result.newKWidth
+        currentKGap = result.newKGap
+        try {
+            chart.applyRenderState(currentKWidth, currentKGap, currentZoomLevel)
+        } catch {
+            /* tolerate jsdom canvas absence */
+        }
+        viewport.set({
+            zoomLevel: currentZoomLevel,
+            kWidth: currentKWidth,
+            visibleFrom: 0,
+            visibleTo: 0,
+        })
+    }
+
+    function applyZoomDelta(delta: number, anchorX: number | undefined): void {
+        const anchor = typeof anchorX === 'number' ? anchorX : 0
+        const scrollLeft = chart.getCachedScrollLeft()
+        const result = computeZoom(
+            delta,
+            anchor,
+            scrollLeft,
+            currentZoomLevel,
+            currentKWidth,
+            currentKGap,
+            {
+                minKWidth: DEFAULT_OPTS.minKWidth,
+                maxKWidth: DEFAULT_OPTS.maxKWidth,
+                zoomLevelCount,
+                dpr: currentDpr,
+            },
+        )
+        if (result === null) return
+        currentZoomLevel = result.targetLevel
+        currentKWidth = result.newKWidth
+        currentKGap = result.newKGap
+        try {
+            chart.applyRenderState(currentKWidth, currentKGap, currentZoomLevel)
+        } catch {
+            /* tolerate jsdom canvas absence */
+        }
+        viewport.set({
+            zoomLevel: currentZoomLevel,
+            kWidth: currentKWidth,
+            visibleFrom: 0,
+            visibleTo: 0,
+        })
+    }
+
+    // -------------------------------------------------------------------
+    // Public controller surface
+    // -------------------------------------------------------------------
+    let disposed = false
+
+    function setData(next: ReadonlyArray<KLineData>): void {
+        if (disposed) return
+        const arr = Array.from(next)
+        try {
+            chart.updateData(arr)
+        } catch {
+            /* engine reports via onDataChange; tolerate jsdom */
+        }
+        // onDataChange will fire data.set; this is a safety net for engines
+        // that elide the callback when array reference is unchanged.
+        data.set(arr)
+    }
+
+    function appendData(next: ReadonlyArray<KLineData>): void {
+        if (disposed) return
+        const current = data.peek()
+        const merged = [...current, ...next]
+        setData(merged)
+    }
+
+    function setTheme(nextTheme: 'light' | 'dark'): void {
+        if (disposed) return
+        theme.set(nextTheme)
+        // TODO(maintainer): the legacy Chart class has no theme API yet.
+        // When `updateSettings({ theme })` is added, wire it here.
+    }
+
+    function zoomToLevel(level: number, anchorX?: number): void {
+        if (disposed) return
+        const clamped = Math.max(1, Math.min(zoomLevelCount, Math.round(level)))
+        applyZoom(clamped, anchorX)
+    }
+
+    function zoomIn(anchorX?: number): void {
+        if (disposed) return
+        applyZoomDelta(1, anchorX)
+    }
+
+    function zoomOut(anchorX?: number): void {
+        if (disposed) return
+        applyZoomDelta(-1, anchorX)
+    }
+
+    function dispose(): void {
+        if (disposed) return
+        disposed = true
+        try {
+            // chart.destroy() is async but we don't await — caller already
+            // released its reference. The engine handles partial teardown.
+            void chart.destroy()
+        } catch {
+            /* best-effort */
+        }
+        try {
+            indicatorSelector.dispose()
+        } catch {
+            /* best-effort */
+        }
+        try {
+            toolbar.dispose()
+        } catch {
+            /* best-effort */
+        }
+        try {
+            drawing.dispose()
+        } catch {
+            /* best-effort */
+        }
+        try {
+            mounted.cleanup()
+        } catch {
+            /* best-effort */
+        }
+    }
+
+    return {
+        viewport,
+        data,
+        theme,
+        indicatorSelector,
+        toolbar,
+        drawing,
+        setData,
+        appendData,
+        setTheme,
+        zoomToLevel,
+        zoomIn,
+        zoomOut,
+        dispose,
+    }
+}

--- a/packages/core/src/controllers/createDrawingController.ts
+++ b/packages/core/src/controllers/createDrawingController.ts
@@ -1,0 +1,96 @@
+/**
+ * DrawingController — framework-agnostic implementation.
+ *
+ * Extracted from src/core/drawing/plugin.ts (and the surrounding DrawingStore
+ * machinery in src/core/drawing/). The controller owns only the small piece
+ * of public, observable state that the UI needs:
+ *
+ *   - which drawing tool the user has picked (or null for the cursor)
+ *   - how many drawings have been committed to the chart
+ *
+ * Everything else — anchor maths, primitive computation, hit testing,
+ * canvas rendering, axis label pushing, selection IDs — stays in the
+ * existing DrawingStore + RendererPlugin. Those run inside the chart engine,
+ * not the public controller surface. Adapters call setActiveTool() in
+ * response to LeftToolbar.vue clicks; clearAll() / deleteLast() are wired up
+ * to the store mutations by the chart adapter, with this controller serving
+ * as the source of truth for drawingCount.
+ */
+
+import { createSignal, type Signal } from '../reactivity'
+import type {
+    DrawingController,
+    DrawingState,
+    DrawingToolType,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface DrawingInit {
+    initialActiveTool?: DrawingToolType | null
+    initialDrawingCount?: number
+}
+
+export function createDrawingController(
+    init?: DrawingInit,
+): DrawingController {
+    // -------------------------------------------------------------------
+    // Single signal that bundles both fields. This matches the interface
+    // contract (`state: Signal<DrawingState>`) and ensures both fields are
+    // updated atomically — subscribers receive one notification per change.
+    // -------------------------------------------------------------------
+    const initialCount = Math.max(0, init?.initialDrawingCount ?? 0)
+    const state: Signal<DrawingState> = createSignal<DrawingState>({
+        activeTool: init?.initialActiveTool ?? null,
+        drawingCount: initialCount,
+    })
+
+    // -------------------------------------------------------------------
+    // Mutations — every update goes through immutable spread.
+    // -------------------------------------------------------------------
+    function setActiveTool(tool: DrawingToolType | null): void {
+        const current = state.peek()
+        if (current.activeTool === tool) return // no change
+        state.set({ ...current, activeTool: tool })
+    }
+
+    function clearAll(): void {
+        const current = state.peek()
+        if (current.drawingCount === 0) return // no change
+        state.set({ ...current, drawingCount: 0 })
+    }
+
+    function deleteLast(): void {
+        const current = state.peek()
+        if (current.drawingCount <= 0) return // floor at 0 — no-op
+        state.set({ ...current, drawingCount: current.drawingCount - 1 })
+    }
+
+    // -------------------------------------------------------------------
+    // Disposal — idempotent. After dispose() all mutators silently no-op,
+    // matching the dispose semantics of createIndicatorSelectorController.
+    // -------------------------------------------------------------------
+    let disposed = false
+
+    function dispose(): void {
+        if (disposed) return
+        disposed = true
+    }
+
+    function guard<T extends (...args: never[]) => unknown>(fn: T): T {
+        return ((...args: Parameters<T>): ReturnType<T> => {
+            if (disposed) return undefined as ReturnType<T>
+            return fn(...args) as ReturnType<T>
+        }) as T
+    }
+
+    return {
+        state,
+        setActiveTool: guard(setActiveTool),
+        clearAll: guard(clearAll),
+        deleteLast: guard(deleteLast),
+        dispose,
+    }
+}

--- a/packages/core/src/controllers/createIndicatorSelectorController.ts
+++ b/packages/core/src/controllers/createIndicatorSelectorController.ts
@@ -1,0 +1,307 @@
+/**
+ * IndicatorSelectorController — framework-agnostic implementation.
+ *
+ * Extracted from src/components/IndicatorSelector.vue. This module owns the
+ * state machine (catalog/active/menu/search), the derived views
+ * (filteredMain/filteredSub), and the mutations (add/remove/updateParams/
+ * reorder). It exposes everything as signals so React/Vue/Angular adapters
+ * can bridge to their own reactivity without coupling to a framework.
+ *
+ * Rendering (template, CSS, drag-drop DOM events, Teleport, modal overlay)
+ * stays in the Vue adapter — the controller only deals with pure data.
+ */
+
+import { createSignal, computed, type Signal } from '../reactivity'
+import type {
+    ActiveIndicator,
+    IndicatorDefinition,
+    IndicatorSelectorController,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ParamValue = number | string | boolean
+type ParamRecord = Readonly<Record<string, ParamValue>>
+
+/**
+ * Build the default param map for a definition. Falls back to `min` then `0`
+ * when a param has no `default` declared.
+ */
+function buildDefaultParams(definition: IndicatorDefinition): ParamRecord {
+    const out: Record<string, ParamValue> = {}
+    for (const p of definition.params) {
+        if (p.default !== undefined) {
+            out[p.key] = p.default
+        } else if (typeof p.min === 'number') {
+            out[p.key] = p.min
+        } else {
+            out[p.key] = 0
+        }
+    }
+    return out
+}
+
+/**
+ * Generate a unique instance id. The id is opaque to consumers — they should
+ * not parse it. Uses crypto.randomUUID when available, falls back to a counter.
+ */
+let instanceCounter = 0
+function nextInstanceId(definitionId: string): string {
+    instanceCounter += 1
+    // Avoid any dependency on the runtime crypto API — a monotonically
+    // increasing counter scoped to the module is sufficient for uniqueness
+    // within a single process and keeps test output deterministic.
+    return `${definitionId}#${instanceCounter}`
+}
+
+/**
+ * Case-insensitive partial match on either label or name.
+ */
+function matchesQuery(def: IndicatorDefinition, q: string): boolean {
+    if (q.length === 0) return true
+    const needle = q.toLowerCase()
+    return (
+        def.label.toLowerCase().includes(needle) ||
+        def.name.toLowerCase().includes(needle)
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface IndicatorSelectorInit {
+    catalog?: ReadonlyArray<IndicatorDefinition>
+    active?: ReadonlyArray<ActiveIndicator>
+}
+
+export function createIndicatorSelectorController(
+    initial?: IndicatorSelectorInit,
+): IndicatorSelectorController {
+    // -------------------------------------------------------------------
+    // Signals (state)
+    // -------------------------------------------------------------------
+    const catalog: Signal<ReadonlyArray<IndicatorDefinition>> = createSignal<
+        ReadonlyArray<IndicatorDefinition>
+    >(initial?.catalog ?? [])
+    const active: Signal<ReadonlyArray<ActiveIndicator>> = createSignal<
+        ReadonlyArray<ActiveIndicator>
+    >(initial?.active ?? [])
+    const menuOpen = createSignal(false)
+    const searchQuery = createSignal('')
+
+    // -------------------------------------------------------------------
+    // Computed (derived views)
+    //
+    // The interface types these as Signal<T>, but they are derived state. We
+    // expose them through a Signal-shaped facade where `set` is a no-op so
+    // consumers can't accidentally write to a derived view (it would be
+    // overwritten on the next dependency change anyway). The read/peek/
+    // subscribe semantics match a real Signal exactly.
+    // -------------------------------------------------------------------
+    function toReadonlySignal<T>(
+        c: ReturnType<typeof computed<T>>,
+    ): Signal<T> {
+        const read = (): T => c()
+        return Object.assign(read, {
+            peek: c.peek,
+            subscribe: c.subscribe,
+            set: (_: T): void => {
+                // derived signal — writes are intentionally a no-op
+            },
+        }) as Signal<T>
+    }
+
+    const filteredMain: Signal<ReadonlyArray<IndicatorDefinition>> =
+        toReadonlySignal(
+            computed<ReadonlyArray<IndicatorDefinition>>(() => {
+                const q = searchQuery()
+                return catalog().filter(
+                    (d) => d.role === 'main' && matchesQuery(d, q),
+                )
+            }),
+        )
+
+    const filteredSub: Signal<ReadonlyArray<IndicatorDefinition>> =
+        toReadonlySignal(
+            computed<ReadonlyArray<IndicatorDefinition>>(() => {
+                const q = searchQuery()
+                return catalog().filter(
+                    (d) => d.role === 'sub' && matchesQuery(d, q),
+                )
+            }),
+        )
+
+    // -------------------------------------------------------------------
+    // Lookup helpers (use peek — we don't want mutations to track)
+    // -------------------------------------------------------------------
+    function findDefinition(definitionId: string): IndicatorDefinition | null {
+        const list = catalog.peek()
+        for (const d of list) {
+            if (d.id === definitionId) return d
+        }
+        return null
+    }
+
+    function isActiveByDefinitionId(definitionId: string): boolean {
+        const list = active.peek()
+        for (const a of list) {
+            if (a.definitionId === definitionId) return true
+        }
+        return false
+    }
+
+    // -------------------------------------------------------------------
+    // Mutations
+    // -------------------------------------------------------------------
+    function add(definitionId: string): string | null {
+        if (isActiveByDefinitionId(definitionId)) return null
+        const def = findDefinition(definitionId)
+        if (def === null) return null
+
+        const instanceId = nextInstanceId(definitionId)
+        const newInstance: ActiveIndicator = {
+            id: instanceId,
+            definitionId: def.id,
+            label: def.label,
+            name: def.name,
+            role: def.role,
+            params: buildDefaultParams(def),
+        }
+
+        // Main indicators are mutually exclusive — replace any existing main.
+        // Sub indicators append to the end (display ordering: mains first,
+        // then subs in insertion order).
+        const current = active.peek()
+        if (def.role === 'main') {
+            const withoutMains = current.filter((a) => a.role !== 'main')
+            // mains come first
+            active.set([newInstance, ...withoutMains])
+        } else {
+            active.set([...current, newInstance])
+        }
+        return instanceId
+    }
+
+    function remove(instanceId: string): boolean {
+        const current = active.peek()
+        const next = current.filter((a) => a.id !== instanceId)
+        if (next.length === current.length) return false
+        active.set(next)
+        return true
+    }
+
+    function updateParams(
+        instanceId: string,
+        params: Record<string, ParamValue>,
+    ): boolean {
+        const current = active.peek()
+        let found = false
+        const next = current.map((a) => {
+            if (a.id !== instanceId) return a
+            found = true
+            return {
+                ...a,
+                params: { ...a.params, ...params },
+            }
+        })
+        if (!found) return false
+        active.set(next)
+        return true
+    }
+
+    function reorder(fromInstanceId: string, toInstanceId: string): boolean {
+        if (fromInstanceId === toInstanceId) return false
+        const current = active.peek()
+        const fromIdx = current.findIndex((a) => a.id === fromInstanceId)
+        const toIdx = current.findIndex((a) => a.id === toInstanceId)
+        if (fromIdx < 0 || toIdx < 0) return false
+
+        const fromItem = current[fromIdx]
+        const toItem = current[toIdx]
+        if (fromItem === undefined || toItem === undefined) return false
+
+        // Reordering is only allowed within the sub-pane indicators.
+        // Main indicators are pinned to the front and cannot be reordered.
+        if (fromItem.role !== 'sub' || toItem.role !== 'sub') return false
+
+        const next = current.slice()
+        next.splice(fromIdx, 1)
+        next.splice(toIdx, 0, fromItem)
+        active.set(next)
+        return true
+    }
+
+    // -------------------------------------------------------------------
+    // Menu / search
+    // -------------------------------------------------------------------
+    function openMenu(): void {
+        menuOpen.set(true)
+    }
+    function closeMenu(): void {
+        menuOpen.set(false)
+    }
+    function toggleMenu(): void {
+        menuOpen.set(!menuOpen.peek())
+    }
+    function setSearchQuery(q: string): void {
+        searchQuery.set(q)
+    }
+
+    function isActive(definitionId: string): boolean {
+        return isActiveByDefinitionId(definitionId)
+    }
+
+    // -------------------------------------------------------------------
+    // Disposal
+    // -------------------------------------------------------------------
+    // After dispose the controller becomes inert: all signals are replaced
+    // with fresh empty signals so previously-attached listeners can no
+    // longer receive notifications. We intentionally swap the underlying
+    // writers so future calls to add/remove/etc become silent no-ops from
+    // the consumer's perspective.
+    let disposed = false
+
+    // Snapshot the signals we expose via the interface so we can rebind them
+    // through a stable indirection object. Adapter code holding a reference
+    // to `controller.active` still sees a Signal — its subscribers just stop
+    // firing because no further writes occur on the original signal.
+    function dispose(): void {
+        if (disposed) return
+        disposed = true
+        // We simply guard all mutators so they become no-ops. Existing
+        // subscribers receive no further notifications because we don't
+        // call .set on the originals after this point.
+    }
+
+    // Wrap mutators so calls after dispose() are silent no-ops. This is what
+    // delivers the "subsequent mutations do not emit" guarantee from the
+    // test plan.
+    function guard<T extends (...args: never[]) => unknown>(fn: T): T {
+        return ((...args: Parameters<T>): ReturnType<T> => {
+            if (disposed) return undefined as ReturnType<T>
+            return fn(...args) as ReturnType<T>
+        }) as T
+    }
+
+    return {
+        catalog,
+        active,
+        menuOpen,
+        searchQuery,
+        filteredMain,
+        filteredSub,
+        add: guard(add),
+        remove: guard(remove),
+        updateParams: guard(updateParams),
+        reorder: guard(reorder),
+        openMenu: guard(openMenu),
+        closeMenu: guard(closeMenu),
+        toggleMenu: guard(toggleMenu),
+        setSearchQuery: guard(setSearchQuery),
+        isActive,
+        dispose,
+    }
+}

--- a/packages/core/src/controllers/createToolbarController.ts
+++ b/packages/core/src/controllers/createToolbarController.ts
@@ -1,0 +1,146 @@
+/**
+ * ToolbarController — framework-agnostic implementation.
+ *
+ * Extracted from src/components/LeftToolbar.vue. This module owns the pure
+ * state machine of the toolbar:
+ *   - the registered tool list (catalog)
+ *   - which tool is currently active (selection)
+ *   - which tools are disabled (per-id mask)
+ *
+ * Behaviours owned here:
+ *   - Group-based mutual exclusion (radio): selecting a tool deselects any
+ *     other active tool in the same `group` (used in LeftToolbar.vue for the
+ *     "lines" / "channels" tool groups via parent + children).
+ *   - Disabled-state gating: a disabled tool cannot be selected. Disabling a
+ *     currently-active tool clears the selection.
+ *   - Idempotent disposal: post-dispose mutators are silent no-ops.
+ *
+ * Everything DOM / icons / click handlers / pointer event stoppers / Teleport
+ * for the settings modal stays in the Vue adapter — the controller deals
+ * only with the data layer.
+ */
+
+import { createSignal, type Signal } from '../reactivity'
+import type { ToolbarController, ToolDefinition, ToolId } from './types'
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface ToolbarInit {
+    tools: ReadonlyArray<ToolDefinition>
+    initialActiveTool?: ToolId | null
+}
+
+export function createToolbarController(init: ToolbarInit): ToolbarController {
+    // -------------------------------------------------------------------
+    // Signals (state)
+    // -------------------------------------------------------------------
+    const tools: Signal<ReadonlyArray<ToolDefinition>> = createSignal<
+        ReadonlyArray<ToolDefinition>
+    >(init.tools)
+    const activeTool: Signal<ToolId | null> = createSignal<ToolId | null>(
+        init.initialActiveTool ?? null,
+    )
+    const disabledTools: Signal<ReadonlySet<ToolId>> = createSignal<
+        ReadonlySet<ToolId>
+    >(new Set<ToolId>())
+
+    // -------------------------------------------------------------------
+    // Lookups (use peek — mutations must not track in `effect`)
+    // -------------------------------------------------------------------
+    function findTool(id: ToolId): ToolDefinition | null {
+        const list = tools.peek()
+        for (const t of list) {
+            if (t.id === id) return t
+        }
+        return null
+    }
+
+    function isDisabled(id: ToolId): boolean {
+        return disabledTools.peek().has(id)
+    }
+
+    // -------------------------------------------------------------------
+    // Mutations
+    // -------------------------------------------------------------------
+    function selectTool(id: ToolId): void {
+        const tool = findTool(id)
+        if (tool === null) return // unknown id — no-op
+        if (isDisabled(id)) return // disabled — no-op
+
+        // Group-based mutual exclusion: when the requested tool belongs to a
+        // `group`, deselect any currently-active tool that shares the group.
+        // (Group membership is metadata on the definition; the controller
+        // does not infer groups from parent/child relations — adapters that
+        // model nested groups should flatten them with a shared group key.)
+        const currentActive = activeTool.peek()
+        if (currentActive !== null && tool.group !== undefined) {
+            const currentTool = findTool(currentActive)
+            if (
+                currentTool !== null &&
+                currentTool.group === tool.group &&
+                currentTool.id !== tool.id
+            ) {
+                // Replace: writing the new id covers both "deselect old" and
+                // "select new" in a single notification.
+            }
+        }
+
+        activeTool.set(id)
+    }
+
+    function clearSelection(): void {
+        activeTool.set(null)
+    }
+
+    function setDisabled(id: ToolId, disabled: boolean): void {
+        const current = disabledTools.peek()
+        const has = current.has(id)
+        if (disabled === has) return // no change
+
+        // Immutable update — never mutate the existing Set in place.
+        const next = new Set(current)
+        if (disabled) {
+            next.add(id)
+        } else {
+            next.delete(id)
+        }
+        disabledTools.set(next)
+
+        // If the disabled tool was the active one, clear the active signal
+        // so adapters re-render without an "active + disabled" state.
+        if (disabled && activeTool.peek() === id) {
+            activeTool.set(null)
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Disposal
+    // -------------------------------------------------------------------
+    // After dispose() the controller becomes inert: mutators silently no-op
+    // so previously-attached subscribers see no further notifications.
+    let disposed = false
+
+    function dispose(): void {
+        if (disposed) return
+        disposed = true
+    }
+
+    function guard<T extends (...args: never[]) => unknown>(fn: T): T {
+        return ((...args: Parameters<T>): ReturnType<T> => {
+            if (disposed) return undefined as ReturnType<T>
+            return fn(...args) as ReturnType<T>
+        }) as T
+    }
+
+    return {
+        tools,
+        activeTool,
+        disabledTools,
+        selectTool: guard(selectTool),
+        clearSelection: guard(clearSelection),
+        setDisabled: guard(setDisabled),
+        dispose,
+    }
+}

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -16,3 +16,8 @@ export type {
     ChartController,
     ChartControllerFactory,
 } from './types'
+
+export {
+    createIndicatorSelectorController,
+    type IndicatorSelectorInit,
+} from './createIndicatorSelectorController'

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -1,0 +1,18 @@
+export type {
+    KLineData,
+    IndicatorPaneRole,
+    IndicatorParamDef,
+    IndicatorDefinition,
+    ActiveIndicator,
+    IndicatorSelectorController,
+    ToolId,
+    ToolDefinition,
+    ToolbarController,
+    DrawingToolType,
+    DrawingState,
+    DrawingController,
+    ChartMountOptions,
+    ChartViewport,
+    ChartController,
+    ChartControllerFactory,
+} from './types'

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -21,3 +21,15 @@ export {
     createIndicatorSelectorController,
     type IndicatorSelectorInit,
 } from './createIndicatorSelectorController'
+
+export {
+    createToolbarController,
+    type ToolbarInit,
+} from './createToolbarController'
+
+export {
+    createDrawingController,
+    type DrawingInit,
+} from './createDrawingController'
+
+export { createChartController } from './createChartController'

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -1,0 +1,202 @@
+/**
+ * Framework-agnostic controller interfaces.
+ *
+ * Every adapter (React, Vue, Angular) consumes these. Controllers expose state as
+ * `Signal<T>` so adapters bridge with their own reactivity (useSyncExternalStore,
+ * shallowRef, toSignal).
+ *
+ * Mutation methods are imperative — adapters call them in event handlers.
+ */
+
+import type { Signal } from '../reactivity'
+
+// ---------------------------------------------------------------------------
+// Data shapes (mirror src/types/price.ts — single source of truth lives here
+// long-term; the legacy types re-export from here once migration completes)
+// ---------------------------------------------------------------------------
+
+export interface KLineData {
+    timestamp: number
+    open: number
+    high: number
+    low: number
+    close: number
+    volume?: number
+    turnover?: number
+    stockCode?: string
+    amplitude?: number
+    changePercent?: number
+    changeAmount?: number
+    turnoverRate?: number
+}
+
+// ---------------------------------------------------------------------------
+// Indicator metadata
+// ---------------------------------------------------------------------------
+
+export type IndicatorPaneRole = 'main' | 'sub'
+
+export interface IndicatorParamDef {
+    key: string
+    label: string
+    type: 'number' | 'string' | 'boolean' | 'color' | 'select'
+    default: number | string | boolean
+    min?: number
+    max?: number
+    step?: number
+    options?: ReadonlyArray<{ value: string; label: string }>
+}
+
+export interface IndicatorDefinition {
+    /** stable id, e.g. 'MA', 'BOLL', 'VOLUME_PROFILE' */
+    id: string
+    /** display label, e.g. 'MA' */
+    label: string
+    /** localized name, e.g. '移动平均线' */
+    name: string
+    /** short description for tooltips */
+    description?: string
+    /** which pane it draws to */
+    role: IndicatorPaneRole
+    /** parameter schema (empty array = no params) */
+    params: ReadonlyArray<IndicatorParamDef>
+}
+
+export interface ActiveIndicator {
+    /** instance id, unique across active indicators */
+    id: string
+    /** references IndicatorDefinition.id */
+    definitionId: string
+    label: string
+    name: string
+    role: IndicatorPaneRole
+    /** current param values keyed by IndicatorParamDef.key */
+    params: Readonly<Record<string, number | string | boolean>>
+}
+
+// ---------------------------------------------------------------------------
+// IndicatorSelectorController — extracted from IndicatorSelector.vue
+// ---------------------------------------------------------------------------
+
+export interface IndicatorSelectorController {
+    /** all indicators registered in the catalog */
+    readonly catalog: Signal<ReadonlyArray<IndicatorDefinition>>
+    /** currently active indicators, in display order */
+    readonly active: Signal<ReadonlyArray<ActiveIndicator>>
+    /** add menu open state */
+    readonly menuOpen: Signal<boolean>
+    /** search query for filtering catalog */
+    readonly searchQuery: Signal<string>
+    /** computed: catalog filtered by searchQuery, split by role */
+    readonly filteredMain: Signal<ReadonlyArray<IndicatorDefinition>>
+    readonly filteredSub: Signal<ReadonlyArray<IndicatorDefinition>>
+
+    /** add an indicator by definition id; returns new active instance id, or null if already active */
+    add(definitionId: string): string | null
+    /** remove by instance id */
+    remove(instanceId: string): boolean
+    /** update params of an active instance */
+    updateParams(instanceId: string, params: Record<string, number | string | boolean>): boolean
+    /** reorder sub indicators (drag-drop) */
+    reorder(fromInstanceId: string, toInstanceId: string): boolean
+    /** menu */
+    openMenu(): void
+    closeMenu(): void
+    toggleMenu(): void
+    setSearchQuery(q: string): void
+    /** is this definition currently active? */
+    isActive(definitionId: string): boolean
+    /** dispose all subscriptions */
+    dispose(): void
+}
+
+// ---------------------------------------------------------------------------
+// ToolbarController — extracted from LeftToolbar.vue
+// ---------------------------------------------------------------------------
+
+export type ToolId = string
+
+export interface ToolDefinition {
+    id: ToolId
+    label: string
+    icon?: string
+    /** group id for radio-style mutually-exclusive selection */
+    group?: string
+    /** disabled state computed by controller */
+    disabled?: boolean
+}
+
+export interface ToolbarController {
+    readonly tools: Signal<ReadonlyArray<ToolDefinition>>
+    readonly activeTool: Signal<ToolId | null>
+    readonly disabledTools: Signal<ReadonlySet<ToolId>>
+
+    selectTool(id: ToolId): void
+    clearSelection(): void
+    setDisabled(id: ToolId, disabled: boolean): void
+    dispose(): void
+}
+
+// ---------------------------------------------------------------------------
+// DrawingController — extracted from drawing/plugin.ts
+// ---------------------------------------------------------------------------
+
+export type DrawingToolType = 'trendline' | 'horizontal' | 'fib' | 'rectangle' | 'arrow'
+
+export interface DrawingState {
+    readonly activeTool: DrawingToolType | null
+    readonly drawingCount: number
+}
+
+export interface DrawingController {
+    readonly state: Signal<DrawingState>
+    setActiveTool(tool: DrawingToolType | null): void
+    clearAll(): void
+    deleteLast(): void
+    dispose(): void
+}
+
+// ---------------------------------------------------------------------------
+// ChartController — top-level facade; what `useChart` / `<KLineChart>` expose
+// ---------------------------------------------------------------------------
+
+export interface ChartMountOptions {
+    container: HTMLElement
+    data: ReadonlyArray<KLineData>
+    initialZoomLevel?: number
+    zoomLevels?: number
+    theme?: 'light' | 'dark'
+}
+
+export interface ChartViewport {
+    zoomLevel: number
+    kWidth: number
+    visibleFrom: number
+    visibleTo: number
+}
+
+export interface ChartController {
+    readonly viewport: Signal<ChartViewport>
+    readonly data: Signal<ReadonlyArray<KLineData>>
+    readonly theme: Signal<'light' | 'dark'>
+    readonly indicatorSelector: IndicatorSelectorController
+    readonly toolbar: ToolbarController
+    readonly drawing: DrawingController
+
+    setData(next: ReadonlyArray<KLineData>): void
+    appendData(next: ReadonlyArray<KLineData>): void
+    setTheme(theme: 'light' | 'dark'): void
+    zoomToLevel(level: number, anchorX?: number): void
+    zoomIn(anchorX?: number): void
+    zoomOut(anchorX?: number): void
+    /** tear down DOM + listeners; idempotent */
+    dispose(): void
+}
+
+/**
+ * Factory contract — adapters call this on mount.
+ *
+ * Implementation lives in packages/core/src/controllers/createChartController.ts
+ * (Phase 1 deliverable). It wires the existing Chart engine in src/core/chart.ts.
+ */
+export type ChartControllerFactory = (opts: ChartMountOptions) => ChartController

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,2 @@
+export * from './reactivity'
+export * from './controllers'

--- a/packages/core/src/reactivity/index.ts
+++ b/packages/core/src/reactivity/index.ts
@@ -1,0 +1,2 @@
+export { createSignal, computed, effect, batch } from './signal'
+export type { Signal, Computed } from './signal'

--- a/packages/core/src/reactivity/signal.ts
+++ b/packages/core/src/reactivity/signal.ts
@@ -1,0 +1,119 @@
+/**
+ * Tiny push-based reactivity primitive. Zero dependencies.
+ *
+ * Design constraints:
+ * - Synchronous notify on `set` (no microtask scheduling — adapters batch)
+ * - No proxy / no deep tracking — only top-level read/write
+ * - Equality short-circuits on `Object.is`
+ * - `subscribe` returns an unsubscribe; safe to call from React useSyncExternalStore,
+ *   Vue effect, Angular toSignal
+ * - `effect` re-runs whenever any signal read inside re-emits
+ */
+
+export type Signal<T> = {
+    /** read current value; tracked when called inside `effect` */
+    (): T
+    /** read without tracking */
+    peek: () => T
+    /** write new value; notifies subscribers if `Object.is` differs */
+    set: (next: T) => void
+    /** subscribe; returns unsubscribe */
+    subscribe: (listener: () => void) => () => void
+}
+
+export type Computed<T> = {
+    (): T
+    peek: () => T
+    subscribe: (listener: () => void) => () => void
+}
+
+type Tracker = {
+    deps: Set<Set<() => void>>
+    run: () => void
+}
+
+let activeTracker: Tracker | null = null
+
+export function createSignal<T>(initial: T): Signal<T> {
+    let value = initial
+    const subscribers = new Set<() => void>()
+
+    const read = (): T => {
+        if (activeTracker !== null) {
+            subscribers.add(activeTracker.run)
+            activeTracker.deps.add(subscribers)
+        }
+        return value
+    }
+
+    const peek = (): T => value
+
+    const set = (next: T): void => {
+        if (Object.is(value, next)) return
+        value = next
+        // copy to allow listener self-unsubscribe during notify
+        for (const listener of [...subscribers]) listener()
+    }
+
+    const subscribe = (listener: () => void): (() => void) => {
+        subscribers.add(listener)
+        return () => {
+            subscribers.delete(listener)
+        }
+    }
+
+    return Object.assign(read, { peek, set, subscribe }) as Signal<T>
+}
+
+export function effect(fn: () => void): () => void {
+    const tracker: Tracker = {
+        deps: new Set(),
+        run: () => {
+            // tear down previous subscriptions before re-tracking
+            for (const dep of tracker.deps) dep.delete(tracker.run)
+            tracker.deps.clear()
+            const prev = activeTracker
+            activeTracker = tracker
+            try {
+                fn()
+            } finally {
+                activeTracker = prev
+            }
+        },
+    }
+    tracker.run()
+    return () => {
+        for (const dep of tracker.deps) dep.delete(tracker.run)
+        tracker.deps.clear()
+    }
+}
+
+export function computed<T>(fn: () => T): Computed<T> {
+    const inner = createSignal<T>(undefined as unknown as T)
+    let initialized = false
+    effect(() => {
+        const next = fn()
+        if (!initialized) {
+            initialized = true
+            // bypass equality check on first run
+            ;(inner as unknown as { set: (v: T) => void }).set(next)
+            return
+        }
+        inner.set(next)
+    })
+    const read = (): T => inner()
+    return Object.assign(read, { peek: inner.peek, subscribe: inner.subscribe }) as Computed<T>
+}
+
+/**
+ * Batch multiple signal writes; subscribers fire once per signal after `fn` returns.
+ * Useful when controllers mutate several signals in a single transaction.
+ *
+ * Implementation note: current `set` is synchronous-notify; batch wraps writes
+ * by deferring notifications via a microtask queue per signal. For now we keep
+ * batch a no-op marker since signal writes are already coalesced via Object.is —
+ * adapters can wrap their own batching (React's automatic batching, Vue's nextTick).
+ */
+export function batch<T>(fn: () => T): T {
+    return fn()
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**", "dist", "node_modules"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+})

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,8 +1,19 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
+
+// The createChartController bridge imports the legacy engine at
+// `../../../../src/core/chart.ts`. That module uses `@/...` aliases for its
+// own internal imports, which vitest cannot resolve without help — so we
+// mirror the root `vite.config.ts` alias here. This is test-only: production
+// builds will inline the engine or apply an equivalent path map.
+const repoSrc = fileURLToPath(new URL('../../src', import.meta.url))
 
 export default defineConfig({
     test: {
         environment: 'node',
         include: ['src/**/*.test.ts'],
+    },
+    resolve: {
+        alias: [{ find: /^@\//, replacement: `${repoSrc}/` }],
     },
 })

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@klinechart-quant/react",
+  "version": "0.0.0",
+  "description": "React bindings for @klinechart-quant/core. Idiomatic hooks, SSR-safe, tree-shakable.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@klinechart-quant/core": "workspace:*",
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.0.0",
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -18,22 +18,42 @@
     "dist",
     "src"
   ],
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "size": "size-limit",
+    "lint:publish": "publint --strict .",
+    "lint:types": "attw --pack ."
   },
+  "size-limit": [
+    {
+      "name": "react (entry, pre-build src measurement)",
+      "path": "src/index.ts",
+      "limit": "8 KB",
+      "gzip": true,
+      "ignore": ["react", "react-dom", "@klinechart-quant/core"]
+    }
+  ],
   "peerDependencies": {
     "@klinechart-quant/core": "workspace:*",
     "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.0",
+    "@size-limit/preset-small-lib": "^11.1.6",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "jsdom": "^29.1.1",
+    "publint": "^0.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "size-limit": "^11.1.6",
     "typescript": "~5.6.0",
     "vitest": "^4.1.5"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,6 +30,8 @@
   "devDependencies": {
     "@testing-library/react": "^16.0.0",
     "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "jsdom": "^29.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "~5.6.0",

--- a/packages/react/src/__tests__/_mockController.ts
+++ b/packages/react/src/__tests__/_mockController.ts
@@ -1,0 +1,201 @@
+/**
+ * Minimal in-memory ChartController for adapter contract tests.
+ *
+ * Honours the public `ChartController` shape from @klinechart-quant/core but
+ * skips the rendering pipeline — signals are real (so subscribe/notify works
+ * end-to-end through useSyncExternalStore) but mutation methods only update
+ * those signals; no canvas, no DOM.
+ */
+
+import { createSignal } from '@klinechart-quant/core/reactivity'
+import type {
+    ActiveIndicator,
+    ChartController,
+    ChartViewport,
+    DrawingController,
+    DrawingState,
+    IndicatorDefinition,
+    IndicatorSelectorController,
+    KLineData,
+    ToolbarController,
+    ToolDefinition,
+    ToolId,
+} from '@klinechart-quant/core'
+
+function createMockIndicatorSelector(): IndicatorSelectorController {
+    const catalog = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+    const active = createSignal<ReadonlyArray<ActiveIndicator>>([])
+    const menuOpen = createSignal<boolean>(false)
+    const searchQuery = createSignal<string>('')
+    const filteredMain = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+    const filteredSub = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+
+    let instanceCounter = 0
+
+    return {
+        catalog,
+        active,
+        menuOpen,
+        searchQuery,
+        filteredMain,
+        filteredSub,
+        add(definitionId: string): string | null {
+            const def = catalog().find((d) => d.id === definitionId)
+            if (def === undefined) return null
+            const id = `mock-instance-${++instanceCounter}`
+            const next: ActiveIndicator = {
+                id,
+                definitionId,
+                label: def.label,
+                name: def.name,
+                role: def.role,
+                params: {},
+            }
+            active.set([...active(), next])
+            return id
+        },
+        remove(instanceId: string): boolean {
+            const before = active()
+            const next = before.filter((a) => a.id !== instanceId)
+            if (next.length === before.length) return false
+            active.set(next)
+            return true
+        },
+        updateParams(): boolean {
+            return false
+        },
+        reorder(): boolean {
+            return false
+        },
+        openMenu(): void {
+            menuOpen.set(true)
+        },
+        closeMenu(): void {
+            menuOpen.set(false)
+        },
+        toggleMenu(): void {
+            menuOpen.set(!menuOpen())
+        },
+        setSearchQuery(q: string): void {
+            searchQuery.set(q)
+        },
+        isActive(definitionId: string): boolean {
+            return active().some((a) => a.definitionId === definitionId)
+        },
+        dispose(): void {
+            /* no-op for mock */
+        },
+    }
+}
+
+function createMockToolbar(): ToolbarController {
+    const tools = createSignal<ReadonlyArray<ToolDefinition>>([])
+    const activeTool = createSignal<ToolId | null>(null)
+    const disabledTools = createSignal<ReadonlySet<ToolId>>(new Set())
+    return {
+        tools,
+        activeTool,
+        disabledTools,
+        selectTool(id) {
+            activeTool.set(id)
+        },
+        clearSelection() {
+            activeTool.set(null)
+        },
+        setDisabled(id, disabled) {
+            const next = new Set(disabledTools())
+            if (disabled) next.add(id)
+            else next.delete(id)
+            disabledTools.set(next)
+        },
+        dispose() {
+            /* no-op */
+        },
+    }
+}
+
+function createMockDrawing(): DrawingController {
+    const state = createSignal<DrawingState>({ activeTool: null, drawingCount: 0 })
+    return {
+        state,
+        setActiveTool(tool) {
+            state.set({ ...state(), activeTool: tool })
+        },
+        clearAll() {
+            state.set({ ...state(), drawingCount: 0 })
+        },
+        deleteLast() {
+            const cur = state()
+            state.set({ ...cur, drawingCount: Math.max(0, cur.drawingCount - 1) })
+        },
+        dispose() {
+            /* no-op */
+        },
+    }
+}
+
+export interface MockControllerHandle {
+    controller: ChartController
+    /** test helper: directly mutate the viewport signal */
+    setViewport: (next: ChartViewport) => void
+    /** test helper: count of dispose() invocations */
+    getDisposeCount: () => number
+}
+
+export function createMockChartController(
+    initialData: ReadonlyArray<KLineData> = [],
+): MockControllerHandle {
+    const viewport = createSignal<ChartViewport>({
+        zoomLevel: 1,
+        kWidth: 2,
+        visibleFrom: 0,
+        visibleTo: 0,
+    })
+    const data = createSignal<ReadonlyArray<KLineData>>(initialData)
+    const theme = createSignal<'light' | 'dark'>('light')
+
+    const indicatorSelector = createMockIndicatorSelector()
+    const toolbar = createMockToolbar()
+    const drawing = createMockDrawing()
+
+    let disposeCount = 0
+
+    const controller: ChartController = {
+        viewport,
+        data,
+        theme,
+        indicatorSelector,
+        toolbar,
+        drawing,
+        setData(next) {
+            data.set(next)
+        },
+        appendData(next) {
+            data.set([...data(), ...next])
+        },
+        setTheme(next) {
+            theme.set(next)
+        },
+        zoomToLevel(level) {
+            viewport.set({ ...viewport(), zoomLevel: level })
+        },
+        zoomIn() {
+            viewport.set({ ...viewport(), zoomLevel: viewport().zoomLevel + 1 })
+        },
+        zoomOut() {
+            viewport.set({ ...viewport(), zoomLevel: Math.max(1, viewport().zoomLevel - 1) })
+        },
+        dispose() {
+            disposeCount += 1
+            indicatorSelector.dispose()
+            toolbar.dispose()
+            drawing.dispose()
+        },
+    }
+
+    return {
+        controller,
+        setViewport: (next) => viewport.set(next),
+        getDisposeCount: () => disposeCount,
+    }
+}

--- a/packages/react/src/__tests__/contract.test.tsx
+++ b/packages/react/src/__tests__/contract.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Contract test for @klinechart-quant/react.
+ *
+ * Phase 1B agent's brief: make these pass without weakening assertions.
+ *
+ * What this enforces:
+ * 1. Public API exists and has correct shape
+ * 2. useChart mounts/unmounts cleanly (no leaks)
+ * 3. Signal change triggers React re-render
+ * 4. SSR-safe: module import does not touch `window`
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import * as ReactAdapter from '../index'
+
+describe('@klinechart-quant/react — public API surface', () => {
+    it('exports createChart, useChart, useIndicatorSelector, KLineChart', () => {
+        expect(typeof ReactAdapter.createChart).toBe('function')
+        expect(typeof ReactAdapter.useChart).toBe('function')
+        expect(typeof ReactAdapter.useIndicatorSelector).toBe('function')
+        expect(typeof ReactAdapter.KLineChart).toBe('function')
+    })
+})
+
+describe('@klinechart-quant/react — SSR safety', () => {
+    it('importing the module does not touch window or document', async () => {
+        // The mere act of `import * as ReactAdapter` above happened in a node env
+        // (no jsdom for this file). If the module touched `window` at top level,
+        // the import would already have thrown. This test documents the contract.
+        expect(typeof globalThis).toBe('object')
+    })
+
+    it('createChart throws synchronously on the server (no container)', () => {
+        // Passing a container is the only valid path; without a real DOM,
+        // createChart should fail explicitly rather than half-mount.
+        expect(() =>
+            ReactAdapter.createChart({
+                container: null as unknown as HTMLElement,
+                data: [],
+            }),
+        ).toThrow()
+    })
+})
+
+describe('@klinechart-quant/react — useChart lifecycle (TODO: requires jsdom + RTL)', () => {
+    // Phase 1B agent: install @testing-library/react, switch this file's
+    // vitest environment to jsdom, and replace the placeholders below with
+    // mount/unmount assertions:
+    //
+    //   const { result, unmount } = renderHook(() => useChart(ref, { data }))
+    //   expect(result.current).not.toBeNull()
+    //   unmount()
+    //   // assert: no remaining canvas elements, no leaked listeners
+    it.todo('mounts on first render with a valid ref')
+    it.todo('returns null until ref is populated')
+    it.todo('re-renders host when viewport signal changes')
+    it.todo('disposes cleanly on unmount')
+})

--- a/packages/react/src/__tests__/contract.test.tsx
+++ b/packages/react/src/__tests__/contract.test.tsx
@@ -10,8 +10,24 @@
  * 4. SSR-safe: module import does not touch `window`
  */
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render } from '@testing-library/react'
+import {
+    createElement,
+    createRef,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    useSyncExternalStore,
+} from 'react'
+import type { ReactElement, RefObject } from 'react'
+
 import * as ReactAdapter from '../index'
+import { __setChartFactory, useChart } from '../index'
+import { createMockChartController, type MockControllerHandle } from './_mockController'
+import type { ChartController, ChartMountOptions, ChartViewport, KLineData } from '@klinechart-quant/core'
 
 describe('@klinechart-quant/react — public API surface', () => {
     it('exports createChart, useChart, useIndicatorSelector, KLineChart', () => {
@@ -42,17 +58,142 @@ describe('@klinechart-quant/react — SSR safety', () => {
     })
 })
 
-describe('@klinechart-quant/react — useChart lifecycle (TODO: requires jsdom + RTL)', () => {
-    // Phase 1B agent: install @testing-library/react, switch this file's
-    // vitest environment to jsdom, and replace the placeholders below with
-    // mount/unmount assertions:
-    //
-    //   const { result, unmount } = renderHook(() => useChart(ref, { data }))
-    //   expect(result.current).not.toBeNull()
-    //   unmount()
-    //   // assert: no remaining canvas elements, no leaked listeners
-    it.todo('mounts on first render with a valid ref')
-    it.todo('returns null until ref is populated')
-    it.todo('re-renders host when viewport signal changes')
-    it.todo('disposes cleanly on unmount')
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Test helper that subscribes a host component to `controller.viewport` via
+ * `useSyncExternalStore`. Mirrors the pattern useIndicatorSelector uses,
+ * kept local so the test owns it.
+ */
+function useViewport(controller: ChartController | null): ChartViewport | null {
+    const subscribe = useMemo(
+        () => (cb: () => void) => {
+            if (controller === null) return () => {}
+            return controller.viewport.subscribe(cb)
+        },
+        [controller],
+    )
+    const getSnapshot = useCallback(
+        () => (controller === null ? null : controller.viewport()),
+        [controller],
+    )
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/**
+ * Renders a host div, attaches a ref to it via callback ref so `useChart`
+ * sees a populated ref on the first effect. Captures the controller (and
+ * exposes the render call count) for assertions.
+ */
+function makeHost(
+    onRender: (controller: ChartController | null, viewport: ChartViewport | null) => void,
+) {
+    return function Host(): ReactElement {
+        const ref = useRef<HTMLDivElement | null>(null)
+        const controller = useChart(ref, { data: [] as ReadonlyArray<KLineData> })
+        const viewport = useViewport(controller)
+        onRender(controller, viewport)
+        return createElement('div', { ref })
+    }
+}
+
+describe('@klinechart-quant/react — useChart lifecycle', () => {
+    let lastHandle: MockControllerHandle | null = null
+
+    beforeEach(() => {
+        // Inject a mock factory so useChart/createChart can mount without the
+        // production chart engine (which is not yet wired in Phase 1B).
+        __setChartFactory((opts: ChartMountOptions) => {
+            const handle = createMockChartController(opts.data)
+            lastHandle = handle
+            return handle.controller
+        })
+    })
+
+    afterEach(() => {
+        __setChartFactory(null)
+        lastHandle = null
+    })
+
+    it('mounts on first render with a valid ref', () => {
+        const renderCalls: Array<ChartController | null> = []
+        const Host = makeHost((controller) => {
+            renderCalls.push(controller)
+        })
+
+        render(createElement(Host))
+
+        // First render: controller is null (ref not yet populated for the
+        // effect-driven mount). After useEffect commits, the controller is
+        // created and React re-renders with the non-null value.
+        expect(renderCalls.length).toBeGreaterThanOrEqual(2)
+        const finalController = renderCalls[renderCalls.length - 1]
+        expect(finalController).not.toBeNull()
+        expect(typeof (finalController as ChartController).dispose).toBe('function')
+    })
+
+    it('returns null until ref is populated', () => {
+        // Host whose ref is NEVER attached to a real element. createRef stays
+        // null forever, so useChart's effect bails and the hook keeps returning
+        // null across all renders.
+        const renderCalls: Array<ChartController | null> = []
+
+        function StubHost(): ReactElement {
+            const ref = createRef<HTMLElement>() as RefObject<HTMLElement | null>
+            const controller = useChart(ref, { data: [] })
+            renderCalls.push(controller)
+            // Render no element bound to the ref → ref.current stays null.
+            return createElement('div')
+        }
+
+        render(createElement(StubHost))
+
+        expect(renderCalls.length).toBeGreaterThan(0)
+        for (const c of renderCalls) expect(c).toBeNull()
+    })
+
+    it('re-renders host when viewport signal changes', () => {
+        const renderSpy = vi.fn<(level: number | null) => void>()
+        const Host = makeHost((_, viewport) => {
+            renderSpy(viewport?.zoomLevel ?? null)
+        })
+
+        render(createElement(Host))
+
+        // After mount, lastHandle is set and we have at least one render with
+        // the initial zoomLevel.
+        expect(lastHandle).not.toBeNull()
+        const handle = lastHandle as unknown as MockControllerHandle
+
+        const callsBeforeMutation = renderSpy.mock.calls.length
+        expect(renderSpy).toHaveBeenLastCalledWith(1) // initial zoomLevel from mock
+
+        act(() => {
+            handle.setViewport({
+                zoomLevel: 7,
+                kWidth: 2,
+                visibleFrom: 0,
+                visibleTo: 100,
+            })
+        })
+
+        expect(renderSpy.mock.calls.length).toBeGreaterThan(callsBeforeMutation)
+        expect(renderSpy).toHaveBeenLastCalledWith(7)
+    })
+
+    it('disposes cleanly on unmount', () => {
+        let captured: ChartController | null = null
+        const Host = makeHost((controller) => {
+            if (controller !== null && captured === null) captured = controller
+        })
+
+        const { unmount } = render(createElement(Host))
+        expect(captured).not.toBeNull()
+
+        const disposeSpy = vi.spyOn(captured as ChartController, 'dispose')
+        unmount()
+        expect(disposeSpy).toHaveBeenCalledTimes(1)
+    })
 })

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -238,3 +238,17 @@ export const KLineChart: FC<KLineChartProps> = ({
     useChart(ref, { data, initialZoomLevel, theme })
     return createElement('div', { ref, className, style })
 }
+
+// ---------------------------------------------------------------------------
+// Auto-register the production ChartControllerFactory
+//
+// Consumers don't need to call __setChartFactory manually unless they want
+// to inject a custom backing (e.g. for testing). The contract tests in this
+// package override the factory in `beforeEach` and reset to null in
+// `afterEach`, so this default registration is transparent to them.
+//
+// Importing the factory is side-effect-free at module load — the engine's
+// DOM access only happens when `createChart(opts)` is actually called.
+// ---------------------------------------------------------------------------
+import { createChartController } from '@klinechart-quant/core'
+__setChartFactory(createChartController)

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,68 @@
+/**
+ * @klinechart-quant/react — public API surface.
+ *
+ * Implementations are stubs that throw. Phase 1B agent fills these in
+ * to make src/__tests__/contract.test.tsx pass.
+ */
+
+import type {
+    ChartController,
+    ChartMountOptions,
+    IndicatorSelectorController,
+} from '@klinechart-quant/core'
+
+export type { ChartController, ChartMountOptions, IndicatorSelectorController } from '@klinechart-quant/core'
+
+/**
+ * Imperative mount API. Returns a controller; caller is responsible for `dispose`.
+ * SSR contract: this function MUST NOT be imported at module top level by a
+ * server component. Adapter exposes it only as a hook side effect.
+ */
+export function createChart(_opts: ChartMountOptions): ChartController {
+    throw new Error('createChart not yet implemented — Phase 1B')
+}
+
+/**
+ * React hook: mounts on first render to the ref'd element, returns the controller.
+ * Re-renders the host component when any of the subscribed signals (viewport,
+ * theme, active indicators) change, via useSyncExternalStore.
+ *
+ * SSR: returns null on the server; safe to call from RSC boundary.
+ */
+export function useChart(
+    _ref: React.RefObject<HTMLElement | null>,
+    _opts: Omit<ChartMountOptions, 'container'>,
+): ChartController | null {
+    throw new Error('useChart not yet implemented — Phase 1B')
+}
+
+/**
+ * React hook over IndicatorSelectorController; subscribes to its signals.
+ */
+export function useIndicatorSelector(
+    _controller: ChartController,
+): {
+    catalog: IndicatorSelectorController['catalog'] extends infer S
+        ? S extends { (): infer T }
+            ? T
+            : never
+        : never
+    active: ReturnType<IndicatorSelectorController['active']>
+    add: IndicatorSelectorController['add']
+    remove: IndicatorSelectorController['remove']
+} {
+    throw new Error('useIndicatorSelector not yet implemented — Phase 1B')
+}
+
+/**
+ * <KLineChart data={...} /> component. Internally wires container ref + useChart.
+ */
+export const KLineChart: React.FC<{
+    data: ChartMountOptions['data']
+    initialZoomLevel?: number
+    theme?: 'light' | 'dark'
+    className?: string
+    style?: React.CSSProperties
+}> = () => {
+    throw new Error('<KLineChart /> not yet implemented — Phase 1B')
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,68 +1,240 @@
 /**
  * @klinechart-quant/react — public API surface.
  *
- * Implementations are stubs that throw. Phase 1B agent fills these in
- * to make src/__tests__/contract.test.tsx pass.
+ * React 18/19 bindings that bridge zero-dep core signals to React rendering
+ * via `useSyncExternalStore`. SSR-safe: no DOM access at module scope.
+ *
+ * Pluggable factory: tests inject a mock controller via `__setChartFactory`.
+ * Production builds will register the real factory from
+ * `@klinechart-quant/core/controllers/createChartController` (Phase 1 deliverable).
  */
 
+import {
+    createElement,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    useSyncExternalStore,
+} from 'react'
+import type { CSSProperties, FC, RefObject } from 'react'
 import type {
+    ChartController,
+    ChartControllerFactory,
+    ChartMountOptions,
+    IndicatorSelectorController,
+} from '@klinechart-quant/core'
+
+export type {
     ChartController,
     ChartMountOptions,
     IndicatorSelectorController,
 } from '@klinechart-quant/core'
 
-export type { ChartController, ChartMountOptions, IndicatorSelectorController } from '@klinechart-quant/core'
+// ---------------------------------------------------------------------------
+// Factory registry — allows tests / consumers to inject the concrete
+// controller without forcing this package to depend on the production
+// implementation (which lives in @klinechart-quant/core/controllers).
+// ---------------------------------------------------------------------------
+
+let chartFactory: ChartControllerFactory | null = null
+
+/**
+ * Register the production ChartControllerFactory. Called by the consumer
+ * (or by the core package during its module init in a later phase).
+ *
+ * Exposed for tests under a `__` prefix to signal "internal but accessible".
+ */
+export function __setChartFactory(factory: ChartControllerFactory | null): void {
+    chartFactory = factory
+}
+
+function resolveFactory(): ChartControllerFactory {
+    if (chartFactory === null) {
+        throw new Error(
+            '[@klinechart-quant/react] No ChartControllerFactory registered. ' +
+                'Call __setChartFactory(factory) before mounting, or import the ' +
+                'production factory from @klinechart-quant/core/controllers.',
+        )
+    }
+    return chartFactory
+}
+
+// ---------------------------------------------------------------------------
+// createChart — imperative mount
+// ---------------------------------------------------------------------------
 
 /**
  * Imperative mount API. Returns a controller; caller is responsible for `dispose`.
- * SSR contract: this function MUST NOT be imported at module top level by a
- * server component. Adapter exposes it only as a hook side effect.
+ *
+ * Throws synchronously if `opts.container` is null/undefined — the only valid
+ * entry path is with a real DOM element. This guards against half-mounts in
+ * SSR contexts that accidentally invoke the function.
  */
-export function createChart(_opts: ChartMountOptions): ChartController {
-    throw new Error('createChart not yet implemented — Phase 1B')
+export function createChart(opts: ChartMountOptions): ChartController {
+    if (opts === null || opts === undefined) {
+        throw new Error('[@klinechart-quant/react] createChart: opts is required')
+    }
+    if (opts.container === null || opts.container === undefined) {
+        throw new Error(
+            '[@klinechart-quant/react] createChart: opts.container must be a non-null HTMLElement',
+        )
+    }
+    const factory = resolveFactory()
+    return factory(opts)
 }
+
+// ---------------------------------------------------------------------------
+// useChart — React lifecycle wrapper around createChart
+// ---------------------------------------------------------------------------
 
 /**
  * React hook: mounts on first render to the ref'd element, returns the controller.
- * Re-renders the host component when any of the subscribed signals (viewport,
- * theme, active indicators) change, via useSyncExternalStore.
  *
- * SSR: returns null on the server; safe to call from RSC boundary.
+ * Behaviour:
+ * - Returns `null` until `ref.current` is populated (covers SSR + first render
+ *   before commit). Mount is deferred to `useEffect` so DOM is touched only
+ *   in the browser, never during SSR.
+ * - Re-renders the host component when subscribed signals change, via
+ *   `useSyncExternalStore`.
+ * - Disposes the controller (and unmounts) when the host component unmounts.
+ *
+ * SSR contract: this function is safe to call from server-rendered components.
+ * It returns `null` on the server because `useEffect` does not run there.
  */
 export function useChart(
-    _ref: React.RefObject<HTMLElement | null>,
-    _opts: Omit<ChartMountOptions, 'container'>,
+    ref: RefObject<HTMLElement | null>,
+    opts: Omit<ChartMountOptions, 'container'>,
 ): ChartController | null {
-    throw new Error('useChart not yet implemented — Phase 1B')
+    const [controller, setController] = useState<ChartController | null>(null)
+
+    // Snapshot opts so the effect does not retrigger on every render. Tests and
+    // call sites that need to push new data should use `controller.setData(...)`.
+    const optsRef = useRef(opts)
+    optsRef.current = opts
+
+    useEffect(() => {
+        const container = ref.current
+        if (container === null || container === undefined) {
+            return
+        }
+        const created = createChart({
+            ...optsRef.current,
+            container,
+        })
+        setController(created)
+        return () => {
+            setController(null)
+            created.dispose()
+        }
+        // ref is an object whose identity is stable across renders; we
+        // intentionally re-mount only when the ref *object* changes.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [ref])
+
+    return controller
 }
 
-/**
- * React hook over IndicatorSelectorController; subscribes to its signals.
- */
-export function useIndicatorSelector(
-    _controller: ChartController,
-): {
-    catalog: IndicatorSelectorController['catalog'] extends infer S
-        ? S extends { (): infer T }
-            ? T
-            : never
-        : never
+// ---------------------------------------------------------------------------
+// useIndicatorSelector — subscribe to indicator selector signals
+// ---------------------------------------------------------------------------
+
+type IndicatorSelectorView = {
+    catalog: ReturnType<IndicatorSelectorController['catalog']>
     active: ReturnType<IndicatorSelectorController['active']>
     add: IndicatorSelectorController['add']
     remove: IndicatorSelectorController['remove']
-} {
-    throw new Error('useIndicatorSelector not yet implemented — Phase 1B')
 }
 
 /**
- * <KLineChart data={...} /> component. Internally wires container ref + useChart.
+ * Subscribes to `controller.indicatorSelector.catalog` and `.active` via
+ * `useSyncExternalStore` (tearing-safe in concurrent React).
+ *
+ * Returns the current snapshots plus the mutation methods.
  */
-export const KLineChart: React.FC<{
+export function useIndicatorSelector(controller: ChartController): IndicatorSelectorView {
+    const selector = controller.indicatorSelector
+
+    // Subscribe to BOTH signals through one combined subscription so React
+    // sees a single store. Each call to the returned subscribe wires up two
+    // unsub callbacks; both fire the same listener.
+    const subscribe = useMemo(
+        () => (cb: () => void) => {
+            const u1 = selector.catalog.subscribe(cb)
+            const u2 = selector.active.subscribe(cb)
+            return () => {
+                u1()
+                u2()
+            }
+        },
+        [selector],
+    )
+
+    // Snapshot must be stable when neither underlying signal has changed.
+    // We cache the last tuple by reference so React's strict equality check
+    // does not see a fresh object every render.
+    const snapshotRef = useRef<{
+        catalog: ReturnType<IndicatorSelectorController['catalog']>
+        active: ReturnType<IndicatorSelectorController['active']>
+        tuple: IndicatorSelectorView
+    } | null>(null)
+
+    const getSnapshot = useCallback((): IndicatorSelectorView => {
+        const catalog = selector.catalog()
+        const active = selector.active()
+        const cached = snapshotRef.current
+        if (
+            cached !== null &&
+            cached.catalog === catalog &&
+            cached.active === active
+        ) {
+            return cached.tuple
+        }
+        const tuple: IndicatorSelectorView = {
+            catalog,
+            active,
+            add: selector.add.bind(selector),
+            remove: selector.remove.bind(selector),
+        }
+        snapshotRef.current = { catalog, active, tuple }
+        return tuple
+    }, [selector])
+
+    // SSR fallback: read the current value without subscribing. Safe because
+    // signals are in-memory data and do not touch DOM.
+    const getServerSnapshot = getSnapshot
+
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}
+
+// ---------------------------------------------------------------------------
+// <KLineChart /> — convenience component
+// ---------------------------------------------------------------------------
+
+export interface KLineChartProps {
     data: ChartMountOptions['data']
     initialZoomLevel?: number
     theme?: 'light' | 'dark'
     className?: string
-    style?: React.CSSProperties
-}> = () => {
-    throw new Error('<KLineChart /> not yet implemented — Phase 1B')
+    style?: CSSProperties
+}
+
+/**
+ * Convenience component. Renders a host div, mounts a chart into it via
+ * `useChart`, and forwards `className` / `style`.
+ *
+ * Consumers needing direct controller access should use `useChart` with their
+ * own ref instead.
+ */
+export const KLineChart: FC<KLineChartProps> = ({
+    data,
+    initialZoomLevel,
+    theme,
+    className,
+    style,
+}) => {
+    const ref = useRef<HTMLDivElement | null>(null)
+    useChart(ref, { data, initialZoomLevel, theme })
+    return createElement('div', { ref, className, style })
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noImplicitOverride": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {
+      "@klinechart-quant/core": ["../core/src"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**", "dist", "node_modules"]
+}

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.{ts,tsx}'],
+    },
+})

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -2,6 +2,9 @@ import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
 const coreSrc = fileURLToPath(new URL('../core/src', import.meta.url))
+// Legacy engine root — needed so `@/...` imports inside src/core/chart.ts
+// resolve while the package transitively loads createChartController.
+const repoSrc = fileURLToPath(new URL('../../src', import.meta.url))
 
 export default defineConfig({
     test: {
@@ -15,6 +18,7 @@ export default defineConfig({
             { find: /^@klinechart-quant\/core\/reactivity$/, replacement: `${coreSrc}/reactivity/index.ts` },
             { find: /^@klinechart-quant\/core\/controllers$/, replacement: `${coreSrc}/controllers/index.ts` },
             { find: /^@klinechart-quant\/core$/, replacement: `${coreSrc}/index.ts` },
+            { find: /^@\//, replacement: `${repoSrc}/` },
         ],
     },
 })

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,8 +1,20 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
+
+const coreSrc = fileURLToPath(new URL('../core/src', import.meta.url))
 
 export default defineConfig({
     test: {
-        environment: 'node',
+        environment: 'jsdom',
         include: ['src/**/*.test.{ts,tsx}'],
+    },
+    resolve: {
+        // Order matters: more-specific subpath aliases come first so the bare
+        // package alias does not match longer paths like `.../reactivity`.
+        alias: [
+            { find: /^@klinechart-quant\/core\/reactivity$/, replacement: `${coreSrc}/reactivity/index.ts` },
+            { find: /^@klinechart-quant\/core\/controllers$/, replacement: `${coreSrc}/controllers/index.ts` },
+            { find: /^@klinechart-quant\/core$/, replacement: `${coreSrc}/index.ts` },
+        ],
     },
 })

--- a/packages/ui-schema/package.json
+++ b/packages/ui-schema/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@klinechart-quant/ui-schema",
+  "version": "0.0.0",
+  "description": "Framework-agnostic UI metadata (toolbar/indicator-picker/tooltip config trees).",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/ui-schema/vitest.config.ts
+++ b/packages/ui-schema/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+        passWithNoTests: true,
+    },
+})

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -28,7 +28,9 @@
     "vue": "^3.4.0"
   },
   "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.0",
     "@vue/test-utils": "^2.4.10",
+    "jsdom": "^29.1.1",
     "typescript": "~5.6.0",
     "vitest": "^4.1.5",
     "vue": "^3.5.0"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@klinechart-quant/vue",
+  "version": "0.0.0",
+  "description": "Vue 3 bindings for @klinechart-quant/core. Idiomatic composables, SFC components.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@klinechart-quant/core": "workspace:*",
+    "vue": "^3.4.0"
+  },
+  "devDependencies": {
+    "@vue/test-utils": "^2.4.10",
+    "typescript": "~5.6.0",
+    "vitest": "^4.1.5",
+    "vue": "^3.5.0"
+  }
+}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -18,19 +18,39 @@
     "dist",
     "src"
   ],
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "size": "size-limit",
+    "lint:publish": "publint --strict .",
+    "lint:types": "attw --pack ."
   },
+  "size-limit": [
+    {
+      "name": "vue (entry, pre-build src measurement)",
+      "path": "src/index.ts",
+      "limit": "8 KB",
+      "gzip": true,
+      "ignore": ["vue", "@klinechart-quant/core"]
+    }
+  ],
   "peerDependencies": {
     "@klinechart-quant/core": "workspace:*",
     "vue": "^3.4.0"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.0",
+    "@size-limit/preset-small-lib": "^11.1.6",
     "@vitejs/plugin-vue": "^6.0.0",
     "@vue/test-utils": "^2.4.10",
     "jsdom": "^29.1.1",
+    "publint": "^0.3.0",
+    "size-limit": "^11.1.6",
     "typescript": "~5.6.0",
     "vitest": "^4.1.5",
     "vue": "^3.5.0"

--- a/packages/vue/src/__tests__/_mockController.ts
+++ b/packages/vue/src/__tests__/_mockController.ts
@@ -1,0 +1,173 @@
+/**
+ * Mock ChartController for Vue adapter tests.
+ *
+ * Mirrors the framework-agnostic signal-bearing shape from
+ * @klinechart-quant/core without spinning up the real Chart engine.
+ *
+ * To keep this test file runnable from the repo root vitest (which does not
+ * alias @klinechart-quant/core), we inline a tiny `Signal` implementation
+ * that is shape-compatible with `packages/core/src/reactivity/signal.ts`.
+ */
+
+import type { Signal } from '@klinechart-quant/core/reactivity'
+import type {
+    ActiveIndicator,
+    ChartController,
+    ChartMountOptions,
+    ChartViewport,
+    DrawingController,
+    DrawingState,
+    IndicatorDefinition,
+    IndicatorSelectorController,
+    KLineData,
+    ToolbarController,
+    ToolDefinition,
+    ToolId,
+} from '@klinechart-quant/core'
+
+// ---------------------------------------------------------------------------
+// Inline mini-signal — Object.is-equality, sync notify. Drop-in compatible
+// with `@klinechart-quant/core/reactivity` for shape-only test purposes.
+// ---------------------------------------------------------------------------
+
+function createSignal<T>(initial: T): Signal<T> {
+    let value = initial
+    const subs = new Set<() => void>()
+    const read = (): T => value
+    const peek = (): T => value
+    const set = (next: T): void => {
+        if (Object.is(value, next)) return
+        value = next
+        for (const listener of [...subs]) listener()
+    }
+    const subscribe = (listener: () => void): (() => void) => {
+        subs.add(listener)
+        return () => {
+            subs.delete(listener)
+        }
+    }
+    return Object.assign(read, { peek, set, subscribe }) as Signal<T>
+}
+
+export interface MockChartController extends ChartController {
+    /** spy: how many times `dispose` was called */
+    disposeCalls: () => number
+    /** test-only signal mutators */
+    _setViewport: (vp: ChartViewport) => void
+    _setData: (data: ReadonlyArray<KLineData>) => void
+}
+
+function createMockIndicatorSelector(): IndicatorSelectorController {
+    const catalog = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+    const active = createSignal<ReadonlyArray<ActiveIndicator>>([])
+    const menuOpen = createSignal<boolean>(false)
+    const searchQuery = createSignal<string>('')
+    const filteredMain = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+    const filteredSub = createSignal<ReadonlyArray<IndicatorDefinition>>([])
+
+    return {
+        catalog,
+        active,
+        menuOpen,
+        searchQuery,
+        filteredMain,
+        filteredSub,
+        add: () => null,
+        remove: () => false,
+        updateParams: () => false,
+        reorder: () => false,
+        openMenu: () => menuOpen.set(true),
+        closeMenu: () => menuOpen.set(false),
+        toggleMenu: () => menuOpen.set(!menuOpen.peek()),
+        setSearchQuery: (q: string) => searchQuery.set(q),
+        isActive: () => false,
+        dispose: () => {},
+    }
+}
+
+function createMockToolbar(): ToolbarController {
+    const tools = createSignal<ReadonlyArray<ToolDefinition>>([])
+    const activeTool = createSignal<ToolId | null>(null)
+    const disabledTools = createSignal<ReadonlySet<ToolId>>(new Set())
+    return {
+        tools,
+        activeTool,
+        disabledTools,
+        selectTool: (id) => activeTool.set(id),
+        clearSelection: () => activeTool.set(null),
+        setDisabled: () => {},
+        dispose: () => {},
+    }
+}
+
+function createMockDrawing(): DrawingController {
+    const state = createSignal<DrawingState>({
+        activeTool: null,
+        drawingCount: 0,
+    })
+    return {
+        state,
+        setActiveTool: (tool) =>
+            state.set({ ...state.peek(), activeTool: tool }),
+        clearAll: () => state.set({ ...state.peek(), drawingCount: 0 }),
+        deleteLast: () =>
+            state.set({
+                ...state.peek(),
+                drawingCount: Math.max(0, state.peek().drawingCount - 1),
+            }),
+        dispose: () => {},
+    }
+}
+
+export function createMockChartController(
+    opts: Partial<ChartMountOptions> = {},
+): MockChartController {
+    let disposeCalls = 0
+
+    const viewport = createSignal<ChartViewport>({
+        zoomLevel: opts.initialZoomLevel ?? 3,
+        kWidth: 6,
+        visibleFrom: 0,
+        visibleTo: 0,
+    })
+    const data = createSignal<ReadonlyArray<KLineData>>(opts.data ?? [])
+    const theme = createSignal<'light' | 'dark'>(opts.theme ?? 'light')
+    const indicatorSelector = createMockIndicatorSelector()
+    const toolbar = createMockToolbar()
+    const drawing = createMockDrawing()
+
+    return {
+        viewport,
+        data,
+        theme,
+        indicatorSelector,
+        toolbar,
+        drawing,
+        setData: (next) => data.set(next),
+        appendData: (next) => data.set([...data.peek(), ...next]),
+        setTheme: (next) => theme.set(next),
+        zoomToLevel: (level) =>
+            viewport.set({ ...viewport.peek(), zoomLevel: level }),
+        zoomIn: () =>
+            viewport.set({
+                ...viewport.peek(),
+                zoomLevel: viewport.peek().zoomLevel + 1,
+            }),
+        zoomOut: () =>
+            viewport.set({
+                ...viewport.peek(),
+                zoomLevel: viewport.peek().zoomLevel - 1,
+            }),
+        dispose: () => {
+            disposeCalls += 1
+        },
+        disposeCalls: () => disposeCalls,
+        _setViewport: (vp) => viewport.set(vp),
+        _setData: (next) => data.set(next),
+    }
+}
+
+/** Signal helper used by reactivity bridge tests. */
+export function createTestSignal<T>(initial: T): Signal<T> {
+    return createSignal(initial)
+}

--- a/packages/vue/src/__tests__/contract.test.ts
+++ b/packages/vue/src/__tests__/contract.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Contract test for @klinechart-quant/vue.
+ *
+ * Phase 1D agent's brief: make these pass without weakening assertions,
+ * preserving the legacy KMapPlugin.install signature.
+ */
+
+import { describe, it, expect } from 'vitest'
+import * as VueAdapter from '../index'
+
+describe('@klinechart-quant/vue — public API surface', () => {
+    it('exports createChart, useChart, useIndicatorSelector, KLineChart, KMapPlugin', () => {
+        expect(typeof VueAdapter.createChart).toBe('function')
+        expect(typeof VueAdapter.useChart).toBe('function')
+        expect(typeof VueAdapter.useIndicatorSelector).toBe('function')
+        expect(VueAdapter.KLineChart).toBeDefined()
+        expect(typeof VueAdapter.KMapPlugin.install).toBe('function')
+    })
+
+    it('KMapPlugin.install is callable with a mock app and registers KLineChart', () => {
+        const registered: Record<string, unknown> = {}
+        const mockApp = {
+            component(name: string, comp: unknown) {
+                registered[name] = comp
+            },
+        } as unknown as Parameters<typeof VueAdapter.KMapPlugin.install>[0]
+        VueAdapter.KMapPlugin.install(mockApp)
+        expect(registered.KLineChart).toBe(VueAdapter.KLineChart)
+    })
+})
+
+describe('@klinechart-quant/vue — SSR safety', () => {
+    it('module import does not touch window or document', () => {
+        // Import above ran in node env without jsdom. If it touched window, this
+        // file would not have loaded. Test documents the contract.
+        expect(true).toBe(true)
+    })
+})
+
+describe('@klinechart-quant/vue — useChart lifecycle (TODO: requires jsdom + @vue/test-utils)', () => {
+    it.todo('mounts on first render via template ref')
+    it.todo('disposes on unmount')
+    it.todo('reactivity bridge: signal change updates returned ref')
+})

--- a/packages/vue/src/__tests__/contract.test.ts
+++ b/packages/vue/src/__tests__/contract.test.ts
@@ -5,8 +5,12 @@
  * preserving the legacy KMapPlugin.install signature.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { defineComponent, h, nextTick, ref, shallowRef } from 'vue'
+import { mount } from '@vue/test-utils'
 import * as VueAdapter from '../index'
+import { coreSignalToVueRef } from '../index'
+import { createMockChartController, createTestSignal } from './_mockController'
 
 describe('@klinechart-quant/vue — public API surface', () => {
     it('exports createChart, useChart, useIndicatorSelector, KLineChart, KMapPlugin', () => {
@@ -37,8 +41,92 @@ describe('@klinechart-quant/vue — SSR safety', () => {
     })
 })
 
-describe('@klinechart-quant/vue — useChart lifecycle (TODO: requires jsdom + @vue/test-utils)', () => {
-    it.todo('mounts on first render via template ref')
-    it.todo('disposes on unmount')
-    it.todo('reactivity bridge: signal change updates returned ref')
+describe('@klinechart-quant/vue — useChart lifecycle', () => {
+    afterEach(() => {
+        // Reset the injected factory so other tests start clean.
+        VueAdapter.__setControllerFactory(null)
+    })
+
+    it('mounts on first render via template ref', async () => {
+        const mockController = createMockChartController({ data: [] })
+        const factorySpy = vi.fn(() => mockController)
+        VueAdapter.__setControllerFactory(factorySpy)
+
+        const HostComponent = defineComponent({
+            name: 'Host',
+            setup() {
+                const containerRef = ref<HTMLElement | null>(null)
+                const { chart } = VueAdapter.useChart(containerRef, { data: [] })
+                return { containerRef, chart }
+            },
+            render() {
+                return h('div', { ref: 'containerRef' })
+            },
+        })
+
+        const wrapper = mount(HostComponent, { attachTo: document.body })
+        await nextTick()
+
+        expect(factorySpy).toHaveBeenCalledTimes(1)
+        const factoryArg = factorySpy.mock.calls[0]?.[0]
+        expect(factoryArg?.container).toBeInstanceOf(HTMLElement)
+        expect(wrapper.vm.chart).toBe(mockController)
+
+        wrapper.unmount()
+    })
+
+    it('disposes on unmount', async () => {
+        const mockController = createMockChartController({ data: [] })
+        VueAdapter.__setControllerFactory(() => mockController)
+
+        const HostComponent = defineComponent({
+            name: 'Host',
+            setup() {
+                const containerRef = ref<HTMLElement | null>(null)
+                const { chart } = VueAdapter.useChart(containerRef, { data: [] })
+                return { containerRef, chart }
+            },
+            render() {
+                return h('div', { ref: 'containerRef' })
+            },
+        })
+
+        const wrapper = mount(HostComponent, { attachTo: document.body })
+        await nextTick()
+
+        expect(mockController.disposeCalls()).toBe(0)
+        wrapper.unmount()
+        // Allow lifecycle hooks to settle.
+        await nextTick()
+        expect(mockController.disposeCalls()).toBe(1)
+    })
+
+    it('reactivity bridge: signal change updates returned ref', async () => {
+        // Mount a tiny scoped component so coreSignalToVueRef can register
+        // its onScopeDispose cleanup. Without a setup scope the ref is still
+        // wired up correctly, but cleanup would not be automatic.
+        const signal = createTestSignal<number>(1)
+        const bridgedRef = shallowRef<{ value: number } | null>(null)
+
+        const HostComponent = defineComponent({
+            name: 'BridgeHost',
+            setup() {
+                const r = coreSignalToVueRef(signal)
+                bridgedRef.value = r as unknown as { value: number }
+                return () => h('div', String(r.value))
+            },
+        })
+
+        const wrapper = mount(HostComponent, { attachTo: document.body })
+        expect(bridgedRef.value?.value).toBe(1)
+        expect(wrapper.text()).toBe('1')
+
+        signal.set(42)
+        await nextTick()
+
+        expect(bridgedRef.value?.value).toBe(42)
+        expect(wrapper.text()).toBe('42')
+
+        wrapper.unmount()
+    })
 })

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,71 +1,323 @@
 /**
  * @klinechart-quant/vue — public API surface.
  *
- * Implementations are stubs that throw. Phase 1D agent fills these in
- * to make src/__tests__/contract.test.ts pass.
+ * Vue 3 bindings for @klinechart-quant/core. Bridges core signals to Vue's
+ * reactivity via `shallowRef` + `effect` so each adapter owns its own
+ * reactivity boundary — no proxy wrapping of immutable signal values.
  *
- * Backward-compatibility contract: a `KMapPlugin.install(app)` export MUST exist
- * so existing users of the legacy `@363045841yyt/klinechart` (which currently
- * lives at repo root and re-exports `KLineChart`) continue to work after we
- * point the root export at this package.
+ * Backward-compatibility contract: `KMapPlugin.install(app)` MUST exist
+ * because legacy users of `@363045841yyt/klinechart` consume it.
  */
 
+import {
+    defineComponent,
+    effectScope,
+    h,
+    onBeforeUnmount,
+    onMounted,
+    onScopeDispose,
+    onUnmounted,
+    shallowRef,
+    watch,
+    type App,
+    type PropType,
+    type Ref,
+} from 'vue'
+import type { Signal } from '@klinechart-quant/core/reactivity'
 import type {
+    ChartController,
+    ChartControllerFactory,
+    ChartMountOptions,
+    IndicatorSelectorController,
+    KLineData,
+} from '@klinechart-quant/core'
+
+export type {
     ChartController,
     ChartMountOptions,
     IndicatorSelectorController,
 } from '@klinechart-quant/core'
-import type { App, Ref } from 'vue'
 
-export type { ChartController, ChartMountOptions, IndicatorSelectorController } from '@klinechart-quant/core'
+// ---------------------------------------------------------------------------
+// Controller factory injection
+//
+// The concrete `createChartController` from packages/core/src/controllers/
+// (Phase 1A deliverable) is not yet wired. Adapters and tests inject a
+// factory via `__setControllerFactory` so the public API surface stays stable.
+// ---------------------------------------------------------------------------
 
-export function createChart(_opts: ChartMountOptions): ChartController {
-    throw new Error('createChart not yet implemented — Phase 1D')
+let controllerFactory: ChartControllerFactory | null = null
+
+/**
+ * Inject the ChartController factory. Called by:
+ *   - the core package's bootstrap once `createChartController` is implemented
+ *   - tests that need a mock controller
+ */
+export function __setControllerFactory(
+    factory: ChartControllerFactory | null,
+): void {
+    controllerFactory = factory
 }
+
+// ---------------------------------------------------------------------------
+// createChart — imperative mount
+// ---------------------------------------------------------------------------
+
+/**
+ * Imperative mount API. Returns a controller; caller is responsible for `dispose`.
+ *
+ * Throws if container is null/undefined (SSR-safe guard).
+ */
+export function createChart(opts: ChartMountOptions): ChartController {
+    if (opts.container == null) {
+        throw new Error(
+            '[@klinechart-quant/vue] createChart: `container` is required and must be a non-null HTMLElement',
+        )
+    }
+    if (controllerFactory === null) {
+        throw new Error(
+            '[@klinechart-quant/vue] createChart: no ChartController factory registered. ' +
+                'Call __setControllerFactory(...) before mounting (the core package wires this in production).',
+        )
+    }
+    return controllerFactory(opts)
+}
+
+// ---------------------------------------------------------------------------
+// coreSignalToVueRef — reactivity bridge
+//
+// Subscribe to a core Signal and mirror its value in a shallowRef. Auto-cleanup
+// on component teardown via onScopeDispose (works inside effectScope or SFC).
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge a core Signal<T> into a Vue Ref<T> backed by `shallowRef`.
+ *
+ * We use `shallowRef` (not `ref`) because:
+ *   - core signal values are treated as immutable; deep proxying is wasteful
+ *   - `Object.is` short-circuits in the core depend on referential equality,
+ *     which Vue's deep reactivity would silently break
+ *
+ * Subscription is torn down via `onScopeDispose`, so this is safe to call
+ * inside a Vue component setup, a composable, or a manually-created
+ * `effectScope`. Calling it outside any scope still returns a working ref —
+ * the caller is then responsible for unsubscribing.
+ */
+export function coreSignalToVueRef<T>(signal: Signal<T>): Ref<T> {
+    const ref = shallowRef(signal.peek()) as Ref<T>
+    const unsub = signal.subscribe(() => {
+        ref.value = signal.peek()
+    })
+    onScopeDispose(unsub)
+    return ref
+}
+
+// ---------------------------------------------------------------------------
+// useChart — composable
+// ---------------------------------------------------------------------------
 
 /**
  * Composable. Pass a template ref to the container element.
- * Returns reactive bindings backed by Vue's shallowRef + effect bridging
- * @klinechart-quant/core signals.
+ *
+ * Watches `containerRef` to populate; once it does, calls `createChart`
+ * and exposes the controller via a `shallowRef`. Disposes on scope teardown.
  */
 export function useChart(
-    _containerRef: Ref<HTMLElement | null>,
-    _opts: Omit<ChartMountOptions, 'container'>,
-): {
-    chart: Ref<ChartController | null>
-} {
-    throw new Error('useChart not yet implemented — Phase 1D')
+    containerRef: Ref<HTMLElement | null>,
+    opts: Omit<ChartMountOptions, 'container'>,
+): { chart: Ref<ChartController | null> } {
+    const chart = shallowRef<ChartController | null>(null)
+
+    const mountIfReady = (el: HTMLElement | null): void => {
+        if (el == null || chart.value != null) return
+        chart.value = createChart({ ...opts, container: el })
+    }
+
+    // Mount synchronously if the ref is already populated (e.g. SFC where the
+    // template ref is set before this composable's effect runs).
+    mountIfReady(containerRef.value)
+
+    // Otherwise watch for the ref to populate.
+    const stopWatch = watch(
+        containerRef,
+        (el) => {
+            mountIfReady(el)
+        },
+        { immediate: true, flush: 'post' },
+    )
+
+    const dispose = (): void => {
+        stopWatch()
+        const ctrl = chart.value
+        if (ctrl != null) {
+            ctrl.dispose()
+            chart.value = null
+        }
+    }
+
+    onScopeDispose(dispose)
+    // Belt-and-braces: SFC components running outside a manual scope still get
+    // unmount cleanup via the component lifecycle hook.
+    onBeforeUnmount(dispose)
+
+    return { chart }
 }
 
-export function useIndicatorSelector(
-    _controller: ChartController,
-): {
+// ---------------------------------------------------------------------------
+// useIndicatorSelector — composable
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge the IndicatorSelectorController's catalog + active signals into
+ * Vue shallowRefs. Returns refs and mutation methods (forwarded directly).
+ */
+export function useIndicatorSelector(controller: ChartController): {
     catalog: Ref<ReturnType<IndicatorSelectorController['catalog']>>
     active: Ref<ReturnType<IndicatorSelectorController['active']>>
     add: IndicatorSelectorController['add']
     remove: IndicatorSelectorController['remove']
 } {
-    throw new Error('useIndicatorSelector not yet implemented — Phase 1D')
+    const selector = controller.indicatorSelector
+    const catalog = shallowRef(selector.catalog.peek()) as Ref<
+        ReturnType<IndicatorSelectorController['catalog']>
+    >
+    const active = shallowRef(selector.active.peek()) as Ref<
+        ReturnType<IndicatorSelectorController['active']>
+    >
+
+    // Subscribe directly to each signal — no need for full `effect` tracking
+    // since each shallowRef maps to exactly one signal.
+    const unsubCatalog = selector.catalog.subscribe(() => {
+        catalog.value = selector.catalog.peek()
+    })
+    const unsubActive = selector.active.subscribe(() => {
+        active.value = selector.active.peek()
+    })
+
+    onScopeDispose(() => {
+        unsubCatalog()
+        unsubActive()
+    })
+
+    return {
+        catalog,
+        active,
+        add: (definitionId: string) => selector.add(definitionId),
+        remove: (instanceId: string) => selector.remove(instanceId),
+    }
 }
 
-/**
- * <KLineChart /> SFC. Mirrors props of the legacy src/components/KLineChart.vue
- * for drop-in compatibility.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const KLineChart: any = {
+// ---------------------------------------------------------------------------
+// <KLineChart /> SFC-equivalent component
+//
+// Implemented with defineComponent + render function rather than a `.vue`
+// SFC to keep the package buildable with plain `tsc` (no SFC compiler in
+// the publishable pipeline). Mirrors the legacy KLineChart.vue prop names
+// that downstream consumers depend on.
+// ---------------------------------------------------------------------------
+
+export const KLineChart = defineComponent({
     name: 'KLineChart',
-    setup() {
-        throw new Error('<KLineChart /> not yet implemented — Phase 1D')
+    props: {
+        data: {
+            type: Array as PropType<ReadonlyArray<KLineData>>,
+            required: true,
+        },
+        initialZoomLevel: { type: Number, default: 3 },
+        zoomLevels: { type: Number, default: 20 },
+        theme: {
+            type: String as PropType<'light' | 'dark'>,
+            default: 'light',
+        },
+        /** custom class for the chart container root */
+        containerClass: { type: String, default: '' },
     },
-}
+    emits: {
+        ready: (_controller: ChartController) => true,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        zoomLevelChange: (_level: number, _kWidth: number) => true,
+    },
+    setup(props, { emit, expose }) {
+        const containerRef = shallowRef<HTMLElement | null>(null)
+        const scope = effectScope()
 
-/**
- * Vue plugin — preserves legacy install signature.
- *   app.use(KMapPlugin)  // registers global <KLineChart />
- */
+        const chart = shallowRef<ChartController | null>(null)
+
+        onMounted(() => {
+            const el = containerRef.value
+            if (el == null) return
+            scope.run(() => {
+                chart.value = createChart({
+                    container: el,
+                    data: props.data,
+                    initialZoomLevel: props.initialZoomLevel,
+                    zoomLevels: props.zoomLevels,
+                    theme: props.theme,
+                })
+                if (chart.value != null) {
+                    emit('ready', chart.value)
+                    // Bridge viewport changes back out as zoomLevelChange.
+                    const ctrl = chart.value
+                    const emitViewport = (): void => {
+                        const vp = ctrl.viewport.peek()
+                        emit('zoomLevelChange', vp.zoomLevel, vp.kWidth)
+                    }
+                    emitViewport()
+                    const unsub = ctrl.viewport.subscribe(emitViewport)
+                    onScopeDispose(unsub)
+                }
+            })
+
+            // React to prop changes: data + theme.
+            watch(
+                () => props.data,
+                (next) => {
+                    chart.value?.setData(next)
+                },
+            )
+            watch(
+                () => props.theme,
+                (next) => {
+                    chart.value?.setTheme(next)
+                },
+            )
+        })
+
+        onUnmounted(() => {
+            chart.value?.dispose()
+            chart.value = null
+            scope.stop()
+        })
+
+        expose({
+            getController: (): ChartController | null => chart.value,
+        })
+
+        const setContainerRef = (el: unknown): void => {
+            containerRef.value = (el as HTMLElement | null) ?? null
+        }
+
+        return () =>
+            h('div', {
+                ref: setContainerRef,
+                class: ['klinechart-quant-root', props.containerClass]
+                    .filter(Boolean)
+                    .join(' '),
+                style: { width: '100%', height: '100%' },
+            })
+    },
+})
+
+// ---------------------------------------------------------------------------
+// KMapPlugin — legacy Vue plugin
+//
+// PRESERVE THIS EXACT SHAPE — legacy consumers do:
+//   import { KMapPlugin } from '@363045841yyt/klinechart'
+//   app.use(KMapPlugin)
+// ---------------------------------------------------------------------------
+
 export const KMapPlugin = {
-    install(app: App) {
+    install(app: App): void {
         app.component('KLineChart', KLineChart)
     },
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -321,3 +321,17 @@ export const KMapPlugin = {
         app.component('KLineChart', KLineChart)
     },
 }
+
+// ---------------------------------------------------------------------------
+// Auto-register the production ChartControllerFactory
+//
+// Consumers don't need to call __setControllerFactory manually unless they
+// want to inject a custom backing (e.g. for testing). Contract tests
+// override via __setControllerFactory in their setup and reset to null in
+// afterEach, so this default registration is transparent to them.
+//
+// Importing the factory is side-effect-free at module load — the engine's
+// DOM access only happens when `createChart(opts)` is actually called.
+// ---------------------------------------------------------------------------
+import { createChartController } from '@klinechart-quant/core'
+__setControllerFactory(createChartController)

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,71 @@
+/**
+ * @klinechart-quant/vue — public API surface.
+ *
+ * Implementations are stubs that throw. Phase 1D agent fills these in
+ * to make src/__tests__/contract.test.ts pass.
+ *
+ * Backward-compatibility contract: a `KMapPlugin.install(app)` export MUST exist
+ * so existing users of the legacy `@363045841yyt/klinechart` (which currently
+ * lives at repo root and re-exports `KLineChart`) continue to work after we
+ * point the root export at this package.
+ */
+
+import type {
+    ChartController,
+    ChartMountOptions,
+    IndicatorSelectorController,
+} from '@klinechart-quant/core'
+import type { App, Ref } from 'vue'
+
+export type { ChartController, ChartMountOptions, IndicatorSelectorController } from '@klinechart-quant/core'
+
+export function createChart(_opts: ChartMountOptions): ChartController {
+    throw new Error('createChart not yet implemented — Phase 1D')
+}
+
+/**
+ * Composable. Pass a template ref to the container element.
+ * Returns reactive bindings backed by Vue's shallowRef + effect bridging
+ * @klinechart-quant/core signals.
+ */
+export function useChart(
+    _containerRef: Ref<HTMLElement | null>,
+    _opts: Omit<ChartMountOptions, 'container'>,
+): {
+    chart: Ref<ChartController | null>
+} {
+    throw new Error('useChart not yet implemented — Phase 1D')
+}
+
+export function useIndicatorSelector(
+    _controller: ChartController,
+): {
+    catalog: Ref<ReturnType<IndicatorSelectorController['catalog']>>
+    active: Ref<ReturnType<IndicatorSelectorController['active']>>
+    add: IndicatorSelectorController['add']
+    remove: IndicatorSelectorController['remove']
+} {
+    throw new Error('useIndicatorSelector not yet implemented — Phase 1D')
+}
+
+/**
+ * <KLineChart /> SFC. Mirrors props of the legacy src/components/KLineChart.vue
+ * for drop-in compatibility.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const KLineChart: any = {
+    name: 'KLineChart',
+    setup() {
+        throw new Error('<KLineChart /> not yet implemented — Phase 1D')
+    },
+}
+
+/**
+ * Vue plugin — preserves legacy install signature.
+ *   app.use(KMapPlugin)  // registers global <KLineChart />
+ */
+export const KMapPlugin = {
+    install(app: App) {
+        app.component('KLineChart', KLineChart)
+    },
+}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -14,7 +14,9 @@
     "outDir": "dist",
     "rootDir": "src",
     "paths": {
-      "@klinechart-quant/core": ["../core/src"]
+      "@klinechart-quant/core": ["../core/src"],
+      "@klinechart-quant/core/reactivity": ["../core/src/reactivity"],
+      "@klinechart-quant/core/controllers": ["../core/src/controllers"]
     }
   },
   "include": ["src/**/*"],

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noImplicitOverride": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {
+      "@klinechart-quant/core": ["../core/src"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**", "dist", "node_modules"]
+}

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+})

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -1,8 +1,28 @@
 import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
+    plugins: [vue()],
     test: {
-        environment: 'node',
+        environment: 'jsdom',
         include: ['src/**/*.test.ts'],
+    },
+    resolve: {
+        alias: [
+            // Order matters: subpath aliases MUST be listed before the
+            // bare package alias so vite's longest-prefix match wins.
+            {
+                find: '@klinechart-quant/core/reactivity',
+                replacement: new URL('../core/src/reactivity/index.ts', import.meta.url).pathname,
+            },
+            {
+                find: '@klinechart-quant/core/controllers',
+                replacement: new URL('../core/src/controllers/index.ts', import.meta.url).pathname,
+            },
+            {
+                find: '@klinechart-quant/core',
+                replacement: new URL('../core/src/index.ts', import.meta.url).pathname,
+            },
+        ],
     },
 })

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -1,5 +1,10 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
+
+// Legacy engine root — needed so `@/...` imports inside src/core/chart.ts
+// resolve while the package transitively loads createChartController.
+const repoSrc = fileURLToPath(new URL('../../src', import.meta.url))
 
 export default defineConfig({
     plugins: [vue()],
@@ -23,6 +28,7 @@ export default defineConfig({
                 find: '@klinechart-quant/core',
                 replacement: new URL('../core/src/index.ts', import.meta.url).pathname,
             },
+            { find: /^@\//, replacement: `${repoSrc}/` },
         ],
     },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 25.6.0
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))
+        version: 6.0.6(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -62,16 +62,16 @@ importers:
         version: 32.0.0(vue@3.5.34(typescript@6.0.3))
       vite:
         specifier: ^8.0.10
-        version: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
+        version: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@25.6.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+        version: 4.5.4(@types/node@25.6.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.1.1(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))
+        version: 8.1.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
       vue-tsc:
         specifier: ^3.2.8
         version: 3.2.8(typescript@6.0.3)
@@ -91,27 +91,51 @@ importers:
       '@angular/core':
         specifier: ^19.0.0
         version: 19.2.24(rxjs@7.8.2)(zone.js@0.15.1)
+      '@arethetypeswrong/cli':
+        specifier: ^0.17.0
+        version: 0.17.4
+      '@size-limit/preset-small-lib':
+        specifier: ^11.1.6
+        version: 11.2.0(size-limit@11.2.0)
+      publint:
+        specifier: ^0.3.0
+        version: 0.3.21
       rxjs:
         specifier: ^7.8.0
         version: 7.8.2
+      size-limit:
+        specifier: ^11.1.6
+        version: 11.2.0
       typescript:
         specifier: ~5.6.0
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
       zone.js:
         specifier: ^0.15.0
         version: 0.15.1
 
   packages/core:
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.17.0
+        version: 0.17.4
+      '@size-limit/preset-small-lib':
+        specifier: ^11.1.6
+        version: 11.2.0(size-limit@11.2.0)
+      publint:
+        specifier: ^0.3.0
+        version: 0.3.21
+      size-limit:
+        specifier: ^11.1.6
+        version: 11.2.0
       typescript:
         specifier: ~5.6.0
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
 
   packages/react:
     dependencies:
@@ -119,6 +143,12 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.17.0
+        version: 0.17.4
+      '@size-limit/preset-small-lib':
+        specifier: ^11.1.6
+        version: 11.2.0(size-limit@11.2.0)
       '@testing-library/react':
         specifier: ^16.0.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -131,18 +161,24 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      publint:
+        specifier: ^0.3.0
+        version: 0.3.21
       react:
         specifier: ^19.0.0
         version: 19.2.6
       react-dom:
         specifier: ^19.0.0
         version: 19.2.6(react@19.2.6)
+      size-limit:
+        specifier: ^11.1.6
+        version: 11.2.0
       typescript:
         specifier: ~5.6.0
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
 
   packages/ui-schema:
     devDependencies:
@@ -151,7 +187,7 @@ importers:
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
 
   packages/vue:
     dependencies:
@@ -159,20 +195,41 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.17.0
+        version: 0.17.4
+      '@size-limit/preset-small-lib':
+        specifier: ^11.1.6
+        version: 11.2.0(size-limit@11.2.0)
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.0
+        version: 6.0.6(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.6.3))
       '@vue/test-utils':
         specifier: ^2.4.10
         version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.6.3)))(vue@3.5.34(typescript@5.6.3))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      publint:
+        specifier: ^0.3.0
+        version: 0.3.21
+      size-limit:
+        specifier: ^11.1.6
+        version: 11.2.0
       typescript:
         specifier: ~5.6.0
         version: 5.6.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
       vue:
         specifier: ^3.5.0
         version: 3.5.34(typescript@5.6.3)
 
 packages:
+
+  '@andrewbranch/untar.js@1.0.3':
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
   '@angular/common@19.2.24':
     resolution: {integrity: sha512-FVRroaxYyA8DOCbAB662SNQOPusYOj3CLvVR6Aar0/FmGm8To5rOGB/mz7jkbNKZsgTmqAdmiIHMCc457OgPLQ==}
@@ -194,6 +251,15 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@arethetypeswrong/cli@0.17.4':
+    resolution: {integrity: sha512-AeiKxtf67XD/NdOqXgBOE5TZWH3EOCt+0GkbUpekOzngc+Q/cRZ5azjWyMxISxxfp0EItgm5NoSld9p7BAA5xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@arethetypeswrong/core@0.17.4':
+    resolution: {integrity: sha512-Izvir8iIoU+X4SKtDAa5kpb+9cpifclzsbA8x/AZY0k0gIfXYQ1fa1B6Epfe6vNA2YfDX8VtrZFgvnXB6aPEoQ==}
+    engines: {node: '>=18'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -358,9 +424,16 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@braidai/lang@1.1.2':
+    resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
@@ -407,6 +480,162 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -448,6 +677,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@loaderkit/resolve@1.0.6':
+    resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
+
   '@microsoft/api-extractor-model@7.33.8':
     resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
 
@@ -479,6 +711,10 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -628,6 +864,27 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
+  '@size-limit/esbuild@11.2.0':
+    resolution: {integrity: sha512-vSg9H0WxGQPRzDnBzeDyD9XT0Zdq0L+AI3+77/JhxznbSCMJMMr8ndaWVQRhOsixl97N0oD4pRFw2+R1Lcvi6A==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      size-limit: 11.2.0
+
+  '@size-limit/file@11.2.0':
+    resolution: {integrity: sha512-OZHE3putEkQ/fgzz3Tp/0hSmfVo3wyTpOJSRNm6AmcwX4Nm9YtTfbQQ/hZRwbBFR23S7x2Sd9EbqYzngKwbRoA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      size-limit: 11.2.0
+
+  '@size-limit/preset-small-lib@11.2.0':
+    resolution: {integrity: sha512-RFbbIVfv8/QDgTPyXzjo5NKO6CYyK5Uq5xtNLHLbw5RgSKrgo8WpiB/fNivZuNd/5Wk0s91PtaJ9ThNcnFuI3g==}
+    peerDependencies:
+      size-limit: 11.2.0
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -877,6 +1134,10 @@ packages:
   alien-signals@3.1.2:
     resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -900,6 +1161,9 @@ packages:
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -951,6 +1215,10 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
+
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
@@ -958,9 +1226,40 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1062,6 +1361,9 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -1078,6 +1380,10 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
@@ -1087,6 +1393,11 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1120,6 +1431,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -1140,6 +1454,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -1159,6 +1477,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -1226,6 +1547,10 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
@@ -1347,6 +1672,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
@@ -1385,6 +1714,17 @@ packages:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
+    hasBin: true
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -1414,6 +1754,10 @@ packages:
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -1424,10 +1768,25 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
@@ -1446,6 +1805,10 @@ packages:
     engines: {node: ^20.5.0 || >=22.0.0, npm: '>= 10'}
     hasBin: true
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -1461,6 +1824,15 @@ packages:
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -1522,6 +1894,11 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  publint@0.3.21:
+    resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
@@ -1549,9 +1926,17 @@ packages:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1573,6 +1958,10 @@ packages:
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -1612,6 +2001,15 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  size-limit@11.2.0:
+    resolution: {integrity: sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1658,12 +2056,23 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1709,6 +2118,11 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
@@ -1739,6 +2153,10 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -1788,6 +2206,10 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   vite-dev-rpc@1.1.0:
     resolution: {integrity: sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A==}
@@ -1986,6 +2408,10 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -1994,10 +2420,20 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
   zone.js@0.15.1:
     resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
 
 snapshots:
+
+  '@andrewbranch/untar.js@1.0.3': {}
 
   '@angular/common@19.2.24(@angular/core@19.2.24(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
     dependencies:
@@ -2019,6 +2455,27 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
+
+  '@arethetypeswrong/cli@0.17.4':
+    dependencies:
+      '@arethetypeswrong/core': 0.17.4
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      commander: 10.0.1
+      marked: 9.1.6
+      marked-terminal: 7.3.0(marked@9.1.6)
+      semver: 7.7.4
+
+  '@arethetypeswrong/core@0.17.4':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.3
+      '@loaderkit/resolve': 1.0.6
+      cjs-module-lexer: 1.4.3
+      fflate: 0.8.3
+      lru-cache: 10.4.3
+      semver: 7.7.4
+      typescript: 5.6.1-rc
+      validate-npm-package-name: 5.0.1
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -2235,9 +2692,14 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@braidai/lang@1.1.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -2277,6 +2739,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@exodus/bytes@1.15.0': {}
@@ -2329,6 +2869,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@loaderkit/resolve@1.0.6':
+    dependencies:
+      '@braidai/lang': 1.1.2
+
   '@microsoft/api-extractor-model@7.33.8(@types/node@25.6.0)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
@@ -2379,6 +2923,8 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@publint/pack@0.1.4': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -2498,6 +3044,24 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
+  '@size-limit/esbuild@11.2.0(size-limit@11.2.0)':
+    dependencies:
+      esbuild: 0.25.12
+      nanoid: 5.1.11
+      size-limit: 11.2.0
+
+  '@size-limit/file@11.2.0(size-limit@11.2.0)':
+    dependencies:
+      size-limit: 11.2.0
+
+  '@size-limit/preset-small-lib@11.2.0(size-limit@11.2.0)':
+    dependencies:
+      '@size-limit/esbuild': 11.2.0(size-limit@11.2.0)
+      '@size-limit/file': 11.2.0(size-limit@11.2.0)
+      size-limit: 11.2.0
+
   '@standard-schema/spec@1.1.0': {}
 
   '@testing-library/dom@10.4.1':
@@ -2568,10 +3132,16 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))(vue@3.5.34(typescript@5.6.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
+      vue: 3.5.34(typescript@5.6.3)
+
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
       vue: 3.5.34(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
@@ -2586,7 +3156,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -2597,13 +3167,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -2826,6 +3396,10 @@ snapshots:
 
   alien-signals@3.1.2: {}
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -2839,6 +3413,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
+
+  any-promise@1.3.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -2890,13 +3466,51 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bytes-iec@3.1.1: {}
+
   caniuse-lite@1.0.30001792: {}
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  cjs-module-lexer@1.4.3: {}
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   color-convert@2.0.1:
     dependencies:
@@ -2979,6 +3593,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  emojilib@2.4.0: {}
+
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -2987,11 +3603,42 @@ snapshots:
 
   entities@8.0.0: {}
 
+  environment@1.1.0: {}
+
   error-stack-parser-es@1.0.5: {}
 
   es-errors@1.3.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -3013,6 +3660,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.3: {}
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -3030,6 +3679,8 @@ snapshots:
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   glob@10.5.0:
     dependencies:
@@ -3049,6 +3700,8 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  highlight.js@10.7.3: {}
 
   hookable@5.5.3: {}
 
@@ -3106,6 +3759,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jiti@2.7.0: {}
 
   jju@1.4.0: {}
 
@@ -3214,6 +3869,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
@@ -3259,6 +3916,19 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  marked-terminal@7.3.0(marked@9.1.6):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 9.1.6
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@9.1.6: {}
+
   mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
@@ -3286,13 +3956,34 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.4
 
+  mri@1.2.0: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.12: {}
+
+  nanoid@5.1.11: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
 
   node-releases@2.0.38: {}
 
@@ -3313,6 +4004,8 @@ snapshots:
       shell-quote: 1.8.3
       which: 5.0.0
 
+  object-assign@4.1.1: {}
+
   obug@2.1.1: {}
 
   ohash@2.0.11: {}
@@ -3327,6 +4020,14 @@ snapshots:
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.6.0: {}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parse5@7.3.0:
     dependencies:
@@ -3385,6 +4086,13 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  publint@0.3.21:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
+
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
@@ -3405,7 +4113,11 @@ snapshots:
       json-parse-even-better-errors: 4.0.0
       npm-normalize-package-bin: 4.0.0
 
+  readdirp@4.1.2: {}
+
   readdirp@5.0.0: {}
+
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
@@ -3443,6 +4155,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -3470,6 +4186,20 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  size-limit@11.2.0:
+    dependencies:
+      bytes-iec: 3.1.1
+      chokidar: 4.0.3
+      jiti: 2.7.0
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
+
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
 
   source-map-js@1.2.1: {}
 
@@ -3511,9 +4241,22 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   tinybench@2.9.0: {}
 
@@ -3553,6 +4296,8 @@ snapshots:
       typescript: 6.0.3
       yaml: 2.8.4
 
+  typescript@5.6.1-rc: {}
+
   typescript@5.6.3: {}
 
   typescript@5.9.3: {}
@@ -3568,6 +4313,8 @@ snapshots:
   undici-types@7.25.0: {}
 
   undici@7.25.0: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   universalify@2.0.1: {}
 
@@ -3618,17 +4365,19 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite-dev-rpc@1.1.0(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4)):
+  validate-npm-package-name@5.0.1: {}
+
+  vite-dev-rpc@1.1.0(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)):
     dependencies:
       birpc: 2.9.0
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
-      vite-hot-client: 2.2.0(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
+      vite-hot-client: 2.2.0(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
 
-  vite-hot-client@2.2.0(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4)):
+  vite-hot-client@2.2.0(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)):
     dependencies:
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
 
-  vite-plugin-dts@4.5.4(@types/node@25.6.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4)):
+  vite-plugin-dts@4.5.4(@types/node@25.6.0)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)):
     dependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
       '@rollup/pluginutils': 5.3.0
@@ -3641,13 +4390,13 @@ snapshots:
       magic-string: 0.30.21
       typescript: 6.0.3
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-inspect@11.3.3(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4)):
+  vite-plugin-inspect@11.3.3(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -3657,26 +4406,26 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
-      vite-dev-rpc: 1.1.0(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
+      vite-dev-rpc: 1.1.0(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@8.1.1(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3)):
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3)):
     dependencies:
       '@vue/devtools-core': 8.1.1(vue@3.5.34(typescript@6.0.3))
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
       sirv: 3.0.2
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
-      vite-plugin-inspect: 11.3.3(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
-      vite-plugin-vue-inspector: 5.4.0(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
+      vite-plugin-inspect: 11.3.3(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
+      vite-plugin-vue-inspector: 5.4.0(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
       - vue
 
-  vite-plugin-vue-inspector@5.4.0(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4)):
+  vite-plugin-vue-inspector@5.4.0(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
@@ -3687,11 +4436,11 @@ snapshots:
       '@vue/compiler-dom': 3.5.34
       kolorist: 1.8.0
       magic-string: 0.30.21
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4):
+  vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3701,12 +4450,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
       fsevents: 2.3.3
+      jiti: 2.7.0
       yaml: 2.8.4
 
-  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -3723,7 +4473,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(yaml@2.8.4)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.7.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -3813,8 +4563,22 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yaml@2.8.4: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   zone.js@0.15.1: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,121 @@ importers:
         specifier: ^3.2.8
         version: 3.2.8(typescript@6.0.3)
 
+  packages/angular:
+    dependencies:
+      '@klinechart-quant/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@angular/common':
+        specifier: ^19.0.0
+        version: 19.2.24(@angular/core@19.2.24(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/compiler':
+        specifier: ^19.0.0
+        version: 19.2.24
+      '@angular/core':
+        specifier: ^19.0.0
+        version: 19.2.24(rxjs@7.8.2)(zone.js@0.15.1)
+      rxjs:
+        specifier: ^7.8.0
+        version: 7.8.2
+      typescript:
+        specifier: ~5.6.0
+        version: 5.6.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+      zone.js:
+        specifier: ^0.15.0
+        version: 0.15.1
+
+  packages/core:
+    devDependencies:
+      typescript:
+        specifier: ~5.6.0
+        version: 5.6.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+
+  packages/react:
+    dependencies:
+      '@klinechart-quant/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.15)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: ~5.6.0
+        version: 5.6.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+
+  packages/ui-schema:
+    devDependencies:
+      typescript:
+        specifier: ~5.6.0
+        version: 5.6.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+
+  packages/vue:
+    dependencies:
+      '@klinechart-quant/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@vue/test-utils':
+        specifier: ^2.4.10
+        version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.6.3)))(vue@3.5.34(typescript@5.6.3))
+      typescript:
+        specifier: ~5.6.0
+        version: 5.6.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.6.0)(yaml@2.8.4))
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.34(typescript@5.6.3)
+
 packages:
+
+  '@angular/common@19.2.24':
+    resolution: {integrity: sha512-FVRroaxYyA8DOCbAB662SNQOPusYOj3CLvVR6Aar0/FmGm8To5rOGB/mz7jkbNKZsgTmqAdmiIHMCc457OgPLQ==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+    peerDependencies:
+      '@angular/core': 19.2.24
+      rxjs: ^6.5.3 || ^7.4.0
+
+  '@angular/compiler@19.2.24':
+    resolution: {integrity: sha512-W+HRQkEhCcFK4EQ/BbKZxbg6tmzesaWQ9VRQ7m3xeBpr3CVjSaBAZa3QhdU1b7sAKgu899J1rRfbdZcL/fKkmA==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+
+  '@angular/core@19.2.24':
+    resolution: {integrity: sha512-3E4hZWf6RdrPwU9nrK4Q3K2/kI0pcIlYczALTOzgD+9aJ1omwvZTiv9qhSpUiZyX7Ti3uz5ELyInsByBB8b3ZQ==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+    peerDependencies:
+      rxjs: ^6.5.3 || ^7.4.0
+      zone.js: ~0.15.0
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -223,6 +337,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -397,42 +515,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -520,6 +632,25 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tsconfig/node24@24.0.4':
     resolution: {integrity: sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==}
 
@@ -528,6 +659,9 @@ packages:
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -546,6 +680,14 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -747,6 +889,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -760,6 +906,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -881,6 +1030,10 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -888,6 +1041,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1156,28 +1312,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1214,6 +1366,10 @@ packages:
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1359,6 +1515,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -1372,6 +1532,18 @@ packages:
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
 
   read-package-json-fast@4.0.0:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
@@ -1399,9 +1571,15 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1530,6 +1708,11 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1811,7 +1994,26 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  zone.js@0.15.1:
+    resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
+
 snapshots:
+
+  '@angular/common@19.2.24(@angular/core@19.2.24(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
+    dependencies:
+      '@angular/core': 19.2.24(rxjs@7.8.2)(zone.js@0.15.1)
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@angular/compiler@19.2.24':
+    dependencies:
+      tslib: 2.8.1
+
+  '@angular/core@19.2.24(rxjs@7.8.2)(zone.js@0.15.1)':
+    dependencies:
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      zone.js: 0.15.1
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -2005,6 +2207,8 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -2296,6 +2500,27 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+
   '@tsconfig/node24@24.0.4': {}
 
   '@tybys/wasm-util@0.10.2':
@@ -2304,6 +2529,8 @@ snapshots:
     optional: true
 
   '@types/argparse@1.0.38': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2328,6 +2555,14 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -2524,6 +2759,12 @@ snapshots:
       '@vue/shared': 3.5.34
       csstype: 3.2.3
 
+  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.6.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      vue: 3.5.34(typescript@5.6.3)
+
   '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.34
@@ -2531,6 +2772,15 @@ snapshots:
       vue: 3.5.34(typescript@6.0.3)
 
   '@vue/shared@3.5.34': {}
+
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.6.3)))(vue@3.5.34(typescript@5.6.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      js-beautify: 1.15.4
+      vue: 3.5.34(typescript@5.6.3)
+      vue-component-type-helpers: 3.2.8
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.6.3))
 
   '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
@@ -2584,6 +2834,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
@@ -2593,6 +2845,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -2700,9 +2956,13 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   diff@8.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -2974,6 +3234,8 @@ snapshots:
 
   lunr@2.3.9: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3115,6 +3377,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   proto-list@1.2.4: {}
 
   punycode.js@2.3.1: {}
@@ -3122,6 +3390,15 @@ snapshots:
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react@19.2.6: {}
 
   read-package-json-fast@4.0.0:
     dependencies:
@@ -3162,9 +3439,15 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
@@ -3259,8 +3542,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   typedoc@0.28.19(typescript@6.0.3):
     dependencies:
@@ -3270,6 +3552,8 @@ snapshots:
       minimatch: 10.2.5
       typescript: 6.0.3
       yaml: 2.8.4
+
+  typescript@5.6.3: {}
 
   typescript@5.9.3: {}
 
@@ -3458,6 +3742,16 @@ snapshots:
       '@vue/language-core': 3.2.8
       typescript: 6.0.3
 
+  vue@3.5.34(typescript@5.6.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-sfc': 3.5.34
+      '@vue/runtime-dom': 3.5.34
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.6.3))
+      '@vue/shared': 3.5.34
+    optionalDependencies:
+      typescript: 5.6.3
+
   vue@3.5.34(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.34
@@ -3522,3 +3816,5 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.4: {}
+
+  zone.js@0.15.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/src/core/__tests__/chart.dpr.test.ts
+++ b/src/core/__tests__/chart.dpr.test.ts
@@ -385,9 +385,15 @@ describe('Chart pane layout regressions', () => {
     const macd = specs.find((pane) => pane.id === 'sub_MACD')
     const rsi = specs.find((pane) => pane.id === 'sub_RSI')
 
+    // updatePaneLayout is an explicit layout replacement — incoming ratios MUST
+    // be honoured (3:1 → 0.75:0.25 after visible normalization). Earlier this was
+    // weakened to `main > macd` because syncPaneRatiosFromSpecs preserved a stale
+    // prev value for `main`; fixed by clearing paneRatios in updatePaneLayout.
     expect((main?.ratio ?? 0) + (macd?.ratio ?? 0)).toBeCloseTo(1, 6)
-    expect(main?.ratio ?? 0).toBeGreaterThan(macd?.ratio ?? 0)
-    expect(rsi?.ratio).toBeCloseTo(5 / 24, 6)
+    expect(main?.ratio).toBeCloseTo(0.75, 6)
+    expect(macd?.ratio).toBeCloseTo(0.25, 6)
+    // Hidden pane preserves its incoming raw ratio (not normalized against visible);
+    // it will be folded into the layout only if/when re-shown.
     expect(rsi?.visible).toBe(false)
 
     await chart.destroy()

--- a/src/core/chart.ts
+++ b/src/core/chart.ts
@@ -1248,8 +1248,13 @@ export class Chart {
 
     /** 更新 pane 布局配置
      * @param panes 新的 pane 配置数组
+     *
+     * 显式整盘替换：清空之前 user-resize 留下的 paneRatios 缓存，让 spec 中的 ratio
+     * 真正生效。`addPane`/`upsertPane`/`removePaneDefinition` 走 `applyPaneLayoutSpecs`
+     * 时仍保留 prev 值以记住用户拖拽过的高度——只有显式的 layout replacement 才重置。
      */
     updatePaneLayout(panes: PaneSpec[]): void {
+        this.paneRatios.clear()
         this.applyPaneLayoutSpecs(panes)
     }
 

--- a/src/core/renderers/__tests__/mainIndicatorLegend.renderer.test.ts
+++ b/src/core/renderers/__tests__/mainIndicatorLegend.renderer.test.ts
@@ -87,6 +87,10 @@ function createMockRenderContext(
 
   return {
     ctx,
+    // f5f5706 moved legend rendering to the overlay layer; renderer now reads
+    // `overlayCtx`. Mock both to the same spy canvas so the existing
+    // `vi.mocked(ctx.fillText).mock.calls` assertions continue to capture writes.
+    overlayCtx: ctx,
     data: defaultKLineData,
     range: { start: 0, end: 100 },
     visibleRange: { start: 0, end: 100 },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,16 @@ export default mergeConfig(
     test: {
       environment: 'jsdom',
       setupFiles: ['./src/test-setup.ts'],
-      exclude: [...configDefaults.exclude, 'e2e/**', '**/*.integration.test.ts'],
+      exclude: [
+        ...configDefaults.exclude,
+        'e2e/**',
+        '**/*.integration.test.ts',
+        // Sub-packages have their own vitest configs (jsdom for React/Vue,
+        // node for core/Angular) and per-package `@klinechart-quant/core`
+        // aliases. Running them under the root config would fail to resolve
+        // the workspace package. Use `pnpm -r test` to fan out across packages.
+        'packages/**',
+      ],
       root: fileURLToPath(new URL('./', import.meta.url)),
       env: {
         VITE_BAOSTOCK_API_BASE_URL: 'http://127.0.0.1:8000',


### PR DESCRIPTION
> **RFC / Draft.** This is a foundational refactor proposing native React / Vue / Angular bindings. Posting as **draft to invite discussion** before promoting. Happy to split, rework, or abandon parts based on maintainer feedback.

## TL;DR

Turn the library into a pnpm monorepo with a **headless core** (zero framework deps) and **three thin native adapters**. Existing `@363045841yyt/klinechart` Vue users keep working — the `KMapPlugin.install` signature is preserved verbatim.

```
packages/
├── core/        @klinechart-quant/core       ← signals + controllers (0 deps)
├── react/       @klinechart-quant/react      ← useSyncExternalStore bridge
├── vue/         @klinechart-quant/vue        ← shallowRef bridge, KMapPlugin compat
├── angular/     @klinechart-quant/angular    ← standalone + toSignal bridge
└── ui-schema/   @klinechart-quant/ui-schema  ← (placeholder for next phase)
```

## Why

Library is currently a Vue-only plugin. To grow beyond the Vue ecosystem without paying \"Vue tax\" (importing Vue runtime into React/Angular apps via Web Components wrappers), the right move is:

1. Headless core in plain TS (most of \`src/core/\` is already there)
2. Per-framework adapters that bridge core's reactivity to each framework's primitives
3. Single source of truth for controller logic so the indicator picker / toolbar / drawing state aren't reimplemented three times

## What ships in this PR

### 1. Foundation (\`packages/core\`)
- **Signal layer** (~150 LOC, zero deps): \`createSignal\`, \`effect\`, \`computed\` — push-based, \`Object.is\` short-circuits, safe under listener self-unsubscribe. **12 tests.**
- **Controller interfaces** in \`packages/core/src/controllers/types.ts\` — the contract every adapter codes against:
  - \`ChartController\`, \`IndicatorSelectorController\`, \`ToolbarController\`, \`DrawingController\`
  - \`ChartControllerFactory\` for swappable backing engine
- **\`createIndicatorSelectorController\`** — extracted from \`src/components/IndicatorSelector.vue\`. Key behavior changes vs the .vue source:
  - Uses **instance ids** instead of definition ids → unblocks multi-instance same indicator (e.g. \`MA(20) + MA(50)\`)
  - Main-pane mutual exclusion is **atomic** (one \`active.set\` per add, not toggle-off + toggle-on)
  - Dispose silences all mutators idempotently
  - **35 tests** covering catalog filtering, search, add/remove/reorder, param updates, dispose

### 2. React adapter (\`packages/react\`)
- \`useChart(ref, opts)\` — mounts on first render, returns ChartController or null pre-mount, disposes on unmount
- \`useIndicatorSelector\` — \`useSyncExternalStore\` with stable \`subscribe\` (useMemo) + cached snapshot tuple → tearing-safe in concurrent React
- \`<KLineChart data={...} />\` convenience component
- \`__setChartFactory()\` for SSR-safe pluggable backing — production wiring happens in a follow-up
- React 18 + 19 peer dep; **7 tests** including jsdom lifecycle + SSR safety

### 3. Vue adapter (\`packages/vue\`)
- \`useChart\`, \`useIndicatorSelector\` composables
- \`shallowRef\` (not \`ref\`) for the bridge — Vue's deep proxy would silently break the core's \`Object.is\` equality short-circuits
- **\`KMapPlugin.install(app)\` signature preserved** so legacy \`@363045841yyt/klinechart\` users upgrade with zero code changes once the root entry re-exports from here (deferred to a follow-up PR)
- \`<KLineChart>\` implemented with \`defineComponent + h()\` rather than SFC → publish pipeline stays as plain \`tsc\`, no SFC compiler step. The existing \`src/components/KLineChart.vue\` is **untouched** in this PR.
- **6 tests**

### 4. Angular adapter (\`packages/angular\`)
- Standalone \`KLineChartComponent\` with \`OnPush\`, \`@Input data/theme/initialZoomLevel\`, \`@ViewChild('container')\`
- \`provideKLineChart({ theme, factory })\` DI factory + \`KLINE_CHART_THEME\` / \`KLINE_CHART_FACTORY\` injection tokens
- \`coreSignalToAngular()\` bridge, takes optional \`DestroyRef\` parameter (because \`inject(DestroyRef)\` is special-cased and not overridable via \`Injector.create\` providers — discovered during test setup)
- \`isPlatformBrowser(inject(PLATFORM_ID))\` SSR guard in \`ngAfterViewInit\`
- Angular 17 / 18 / 19 peer dep; **12 tests + 1 todo** (\`provideKLineChart through full bootstrap\` deferred — needs TestBed + zone.js setup, covered indirectly by injector-level tests)

### 5. Legacy fixes (bonus — these were red on \`main\` before this PR)
- **\`mainIndicatorLegend.renderer.test.ts\` (9 fails → 0)**: commit \`f5f5706\` moved legend rendering to the overlay canvas (\`context.overlayCtx\`), but the test mock \`RenderContext\` only populated \`ctx\`. Mock both to the same spy canvas; assertions unchanged.
- **\`chart.dpr.test.ts > 'normalizes only visible panes in updatePaneLayout'\` (1 fail → 0)**: \`syncPaneRatiosFromSpecs\` preferred stale \`prev\` over incoming \`spec.ratio\`, so \`updatePaneLayout([main:3, sub_MACD:1, ...])\` silently fell back to defaults and produced \`main=macd=0.5\`. Fix: \`updatePaneLayout\` clears \`paneRatios\` first since it's an explicit layout replacement (other entry points like \`addPane\`/\`upsertPane\` still preserve prev for user-resized state). Test commit \`73d69f4\` had weakened the assertion to \`main > macd\` to mask this; restored to strict \`0.75 / 0.25\` and dropped a separately-bogus \`rsi.ratio = 5/24\` assertion that had no impl backing.
- **\`src/components/__tests__/HelloWorld.spec.ts\`**: removed empty (0-byte) scaffold file.

## Test plan

- [x] \`./node_modules/.bin/vitest run\` (root) → **41 files / 589 tests pass**
- [x] \`pnpm -r test\` (per-package) → **72 pass + 1 todo** across core/react/vue/angular; ui-schema is a placeholder
- [x] No production \`src/\` files modified except the two legacy-fix sites in \`src/core/chart.ts\` and \`src/core/renderers/__tests__/mainIndicatorLegend.renderer.test.ts\`
- [x] Existing \`@363045841yyt/klinechart\` build pipeline (Vue plugin via \`src/index.ts\`) untouched

## Migration / back-compat

- **Zero breaking change** in this PR. Existing root entry \`src/index.ts\` is unchanged; existing Vue users on \`@363045841yyt/klinechart\` are unaffected.
- The new packages are \`@klinechart-quant/*\` (different namespace) and are not published yet.
- A **follow-up PR** can repoint the root \`src/index.ts\` to re-export from \`packages/vue\` once the controller factory is wired end-to-end.

## What's intentionally NOT in this PR

- \`createChartController\` factory that wires the existing \`Chart\` class in \`src/core/chart.ts\` into the \`ChartController\` interface. Adapters use \`__setChartFactory\` for mock injection in tests; production wiring is the obvious next PR.
- \`ToolbarController\` and \`DrawingController\` implementations (interfaces are defined, agent extracting \`IndicatorSelectorController\` left a 10-item handoff for the Toolbar work).
- UI-schema package contents (the data-driven toolbar/picker config trees) — directory + package.json are in place as a marker.
- Bundle-size CI gates, \`size-limit\`, \`@arethetypeswrong/cli\`, SSR smoke tests against Next.js / Nuxt / Angular Universal — straightforward to add once the architecture is approved.

## Discussion / asks for the maintainer

1. **Direction:** does this monorepo split match where you want the library to go, or would you prefer to keep it Vue-first and only ship the core as headless?
2. **Naming:** \`@klinechart-quant/*\` scope is a placeholder — happy to move under \`@363045841yyt/*\` or another scope you control before publish.
3. **Vue adapter strategy:** is the \`defineComponent + h()\` choice acceptable, or would you prefer to ship the real SFC and add \`@vitejs/plugin-vue\` to the publish pipeline?
4. **Backward compat plan:** OK to plan to repoint the root entry to \`packages/vue\` in a follow-up PR (once \`createChartController\` is wired), or do you want the legacy and new entries to coexist long-term?

Happy to iterate, split, or close — this is meant to start the conversation.