### PR TITLE
refactor(indicators): drive Vue view state from Chart signals + integrate IndicatorSelectorController

### DIFF
--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -17,3 +17,4 @@ export type {
 } from './types'
 
 export { createChartController } from './createChartController'
+export { createIndicatorSelectorController } from './createIndicatorSelectorController'

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -312,8 +312,8 @@ export class Chart {
         // 更新调度器配置
         this.updateIndicatorSchedulerConfig(id)
 
-        this.scheduleDraw()
         this.syncIndicatorsSignal()
+        this.scheduleDraw()
         return true
     }
 
@@ -334,8 +334,8 @@ export class Chart {
         // 更新调度器配置
         this.updateIndicatorSchedulerConfig(id)
 
-        this.scheduleDraw()
         this.syncIndicatorsSignal()
+        this.scheduleDraw()
         return true
     }
 
@@ -389,8 +389,8 @@ export class Chart {
 
         // 更新调度器
         this.updateIndicatorSchedulerConfig(id)
-        this.scheduleDraw()
         this.syncIndicatorsSignal()
+        this.scheduleDraw()
     }
 
     /**
@@ -409,8 +409,8 @@ export class Chart {
             this.disableMainIndicatorRenderer(id)
         }
         this.activeMainIndicators.clear()
-        this.scheduleDraw()
         this.syncIndicatorsSignal()
+        this.scheduleDraw()
     }
 
     /**

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -1,6 +1,6 @@
 import type { KLineData } from '../types/price'
 import type { ChartSettings } from '../config/chartSettings'
-import { createSignal, type Signal } from '../reactivity/signal'
+import { createSignal, computed, type Signal, type Computed } from '../reactivity/signal'
 import { getVisibleRange } from './viewport/viewport'
 import { Pane, type VisibleRange, UpdateLevel } from './layout/pane'
 import { InteractionController, type InteractionSnapshot } from './controller/interaction'
@@ -165,6 +165,11 @@ type FrameData = {
     useCachedFrame: boolean
 }
 
+/** 主图指标条目，存在 = 激活 */
+interface MainIndicatorEntry {
+    params: Record<string, number | boolean | string>
+}
+
 export class Chart {
     private dom: ChartDom
     private opt: ResolvedChartOptions
@@ -249,13 +254,13 @@ export class Chart {
     } | null = null
 
     /** 副图管理器 */
-    private subPaneManager: SubPaneManager
+    private subPaneManager = new SubPaneManager()
 
-    /** 当前激活的主图指标列表（如 ['boll', 'ma']） */
-    private activeMainIndicators: Set<string> = new Set()
+    /** 主图指标激活状态与参数（存在即激活，默认参数在 enable 时初始化） */
+    private _mainIndicatorsSignal: Signal<Map<string, MainIndicatorEntry>> = createSignal<Map<string, MainIndicatorEntry>>(new Map())
 
-    /** 主图指标参数配置 */
-    private mainIndicatorParams: Record<string, Record<string, number | boolean | string>> = {
+    /** 主图指标默认参数 */
+    private static DEFAULT_MAIN_PARAMS: Record<string, Record<string, number | boolean | string>> = {
         MA: { ma5: true, ma10: true, ma20: true, ma30: true, ma60: true },
         BOLL: { period: 20, multiplier: 2, showUpper: true, showMiddle: true, showLower: true, showBand: true },
         EXPMA: { fastPeriod: 12, slowPeriod: 50 },
@@ -289,22 +294,26 @@ export class Chart {
             return false
         }
 
-        if (this.activeMainIndicators.has(id)) {
+        const map = this._mainIndicatorsSignal.peek()
+        const existing = map.get(id)
+
+        if (existing) {
             // 已启用，更新参数
             if (params) {
-                this.mainIndicatorParams[id] = { ...this.mainIndicatorParams[id], ...params }
+                const next = new Map(map)
+                next.set(id, { params: { ...existing.params, ...params } })
+                this._mainIndicatorsSignal.set(next)
                 this.updateIndicatorSchedulerConfig(id)
-                this.syncIndicatorsSignal()
             }
             return true
         }
 
-        this.activeMainIndicators.add(id)
-
         // 合并默认参数和传入参数
-        if (params) {
-            this.mainIndicatorParams[id] = { ...this.mainIndicatorParams[id], ...params }
-        }
+        const defaults = Chart.DEFAULT_MAIN_PARAMS[id] ?? {}
+        const merged = params ? { ...defaults, ...params } : defaults
+        const next = new Map(map)
+        next.set(id, { params: merged })
+        this._mainIndicatorsSignal.set(next)
 
         // 启用对应的渲染器
         this.enableMainIndicatorRenderer(id)
@@ -312,7 +321,6 @@ export class Chart {
         // 更新调度器配置
         this.updateIndicatorSchedulerConfig(id)
 
-        this.syncIndicatorsSignal()
         this.scheduleDraw()
         return true
     }
@@ -324,9 +332,12 @@ export class Chart {
      */
     disableMainIndicator(indicatorId: string): boolean {
         const id = indicatorId.toUpperCase()
-        if (!this.activeMainIndicators.has(id)) return false
+        const map = this._mainIndicatorsSignal.peek()
+        if (!map.has(id)) return false
 
-        this.activeMainIndicators.delete(id)
+        const next = new Map(map)
+        next.delete(id)
+        this._mainIndicatorsSignal.set(next)
 
         // 禁用对应的渲染器
         this.disableMainIndicatorRenderer(id)
@@ -334,7 +345,6 @@ export class Chart {
         // 更新调度器配置
         this.updateIndicatorSchedulerConfig(id)
 
-        this.syncIndicatorsSignal()
         this.scheduleDraw()
         return true
     }
@@ -357,7 +367,7 @@ export class Chart {
      * @returns 激活的指标ID数组
      */
     getActiveMainIndicators(): string[] {
-        return Array.from(this.activeMainIndicators)
+        return [...this._mainIndicatorsSignal.peek().keys()]
     }
 
     /**
@@ -365,7 +375,7 @@ export class Chart {
      * @param indicatorId 指标ID
      */
     isMainIndicatorActive(indicatorId: string): boolean {
-        return this.activeMainIndicators.has(indicatorId.toUpperCase())
+        return this._mainIndicatorsSignal.peek().has(indicatorId.toUpperCase())
     }
 
     /**
@@ -375,21 +385,24 @@ export class Chart {
      */
     updateMainIndicatorParams(indicatorId: string, params: Record<string, number | boolean | string>): void {
         const id = indicatorId.toUpperCase()
-        if (!this.mainIndicatorParams[id]) {
-            this.mainIndicatorParams[id] = {}
-        }
-        this.mainIndicatorParams[id] = { ...this.mainIndicatorParams[id], ...params }
+        const map = this._mainIndicatorsSignal.peek()
+        const entry = map.get(id)
+        if (!entry) return
+
+        const merged = { ...entry.params, ...params }
+        const next = new Map(map)
+        next.set(id, { params: merged })
+        this._mainIndicatorsSignal.set(next)
 
         // 同步更新渲染器配置
         const rendererName = id.toLowerCase()
         const renderer = this.getRenderer(rendererName)
         if (renderer && renderer.setConfig) {
-            renderer.setConfig(this.mainIndicatorParams[id])
+            renderer.setConfig(merged)
         }
 
         // 更新调度器
         this.updateIndicatorSchedulerConfig(id)
-        this.syncIndicatorsSignal()
         this.scheduleDraw()
     }
 
@@ -398,18 +411,18 @@ export class Chart {
      * @param indicatorId 指标ID
      */
     getMainIndicatorParams(indicatorId: string): Record<string, number | boolean | string> | null {
-        return this.mainIndicatorParams[indicatorId.toUpperCase()] ?? null
+        return this._mainIndicatorsSignal.peek().get(indicatorId.toUpperCase())?.params ?? null
     }
 
     /**
      * 清除所有主图指标
      */
     clearMainIndicators(): void {
-        for (const id of this.activeMainIndicators) {
+        const map = this._mainIndicatorsSignal.peek()
+        for (const id of map.keys()) {
             this.disableMainIndicatorRenderer(id)
         }
-        this.activeMainIndicators.clear()
-        this.syncIndicatorsSignal()
+        this._mainIndicatorsSignal.set(new Map())
         this.scheduleDraw()
     }
 
@@ -572,8 +585,9 @@ export class Chart {
      * 更新调度器配置（内部方法）
      */
     private updateIndicatorSchedulerConfig(indicatorId: string): void {
-        const isActive = this.activeMainIndicators.has(indicatorId)
-        const params = this.mainIndicatorParams[indicatorId] || {}
+        const entry = this._mainIndicatorsSignal.peek().get(indicatorId)
+        const isActive = entry !== undefined
+        const params = entry?.params ?? {}
 
         switch (indicatorId) {
             case 'MA':
@@ -653,7 +667,7 @@ export class Chart {
     setActiveMainIndicators(indicators: string[]): void {
         // 计算需要启用和禁用的指标
         const newSet = new Set(indicators.map(i => i.toUpperCase()))
-        const currentSet = new Set(this.activeMainIndicators)
+        const currentSet = new Set(this._mainIndicatorsSignal.peek().keys())
 
         // 禁用不再激活的
         for (const id of currentSet) {
@@ -709,14 +723,25 @@ export class Chart {
         }
         this.indicatorScheduler.setInvalidateCallback(() => this.scheduleDraw())
 
-        // 初始化副图管理器
-        this.subPaneManager = new SubPaneManager()
         // 注册副图活跃列表提供者，调度器据此只计算启用的副图
         this.indicatorScheduler.setActiveSubPaneProvider(
             () => this.subPaneManager.getPaneIds(),
         )
 
         this.initPanes()
+
+        // dev: 主副图状态变更日志
+        if ((import.meta as any).env?.MODE !== 'production') {
+            this._indicatorsComputed.subscribe(() => {
+                const instances = this._indicatorsComputed.peek()
+                console.log('[Chart] indicators signal changed:', instances)
+            })
+            this._subPanesComputed.subscribe(() => {
+                const subPanes = this._subPanesComputed.peek()
+                console.log('[Chart] subPanes signal changed:', subPanes)
+            })
+        }
+
         // 注册绘图主插件（负责绘制 shape，layer: 'main'）
         this.useRenderer(createDrawingRendererPlugin({ store: this.drawingStore }))
         // 注册绘图标签插件（负责推送选中绘图的轴标签，layer: 'overlay'）
@@ -929,7 +954,7 @@ export class Chart {
         this.interaction.setKLinePositions(kLinePositions, range, kWidthPx)
 
         // 4. 通知调度器当前活跃主图指标 + 获取价格范围
-        this.indicatorScheduler.setActiveMainIndicators(Array.from(this.activeMainIndicators))
+        this.indicatorScheduler.setActiveMainIndicators([...this._mainIndicatorsSignal.peek().keys()])
         const mainIndicatorRange = useCachedFrame ? null : this.indicatorScheduler.getMainIndicatorPriceRange()
         const hasCrosshair = this.interaction.getCrosshairIndex() !== null
 
@@ -1410,7 +1435,6 @@ export class Chart {
             ratios[id] = ratio
         })
         this._paneRatiosSignal.set(ratios)
-        this.syncSubPanesSignal()
 
         this.onPaneLayoutChange?.(this.getPaneLayoutSpecs())
     }
@@ -1586,8 +1610,6 @@ export class Chart {
         this.upsertPane({ id: paneId, ratio: this._internalPaneRatios.get(paneId) ?? 1, visible: true, role: 'indicator' })
 
         const success = this.subPaneManager.create(this, paneId, indicatorId, params ?? this.getDefaultSubPaneParams(indicatorId))
-        this.syncIndicatorsSignal()
-        this.syncSubPanesSignal()
         return success
     }
 
@@ -1597,9 +1619,6 @@ export class Chart {
      */
     removeSubPane(paneId: string): void {
         this.subPaneManager.remove(this, paneId)
-        this._internalPaneRatios.delete(paneId)
-        this.syncIndicatorsSignal()
-        this.syncSubPanesSignal()
     }
 
     /**
@@ -1610,8 +1629,6 @@ export class Chart {
      */
     replaceSubPaneIndicator(paneId: string, newIndicatorId: SubIndicatorType, params?: Record<string, number | boolean | string>): void {
         this.subPaneManager.replaceIndicator(this, paneId, newIndicatorId, params ?? this.getDefaultSubPaneParams(newIndicatorId))
-        this.syncIndicatorsSignal()
-        this.syncSubPanesSignal()
     }
 
     /**
@@ -1621,7 +1638,6 @@ export class Chart {
      */
     updateSubPaneParams(paneId: string, params: Record<string, unknown>): void {
         this.subPaneManager.updateParams(this, paneId, params)
-        this.syncIndicatorsSignal()
     }
 
     /**
@@ -1643,8 +1659,6 @@ export class Chart {
 
         // 更新布局，移除所有副图 pane
         this.applyPaneLayoutSpecs(this.opt.panes.filter((spec) => !subPaneIds.includes(spec.id)))
-        this.syncIndicatorsSignal()
-        this.syncSubPanesSignal()
     }
 
     /**
@@ -2263,8 +2277,6 @@ export class Chart {
 
     private _dataSignal = createSignal<ReadonlyArray<KLineData>>([])
     private _themeSignal = createSignal<'light' | 'dark'>('light')
-    private _indicatorsSignal = createSignal<ReadonlyArray<IndicatorInstance>>([])
-    private _subPanesSignal = createSignal<ReadonlyArray<SubPaneInfo>>([])
     private _drawingToolSignal = createSignal<DrawingToolType | null>(null)
     private _drawingsSignal = createSignal<ReadonlyArray<import('../plugin').DrawingObject>>([])
     private _paneRatiosSignal = createSignal<Readonly<Record<string, number>>>({})
@@ -2285,6 +2297,38 @@ export class Chart {
         isHoveringRightAxis: false,
     })
 
+    private _indicatorsComputed = computed<ReadonlyArray<IndicatorInstance>>(() => {
+        const mainIndicators: IndicatorInstance[] = [...this._mainIndicatorsSignal().entries()].map(([id, entry]) => ({
+            id,
+            definitionId: id,
+            label: id,
+            name: id,
+            role: 'main' as const,
+            params: { ...entry.params },
+        }))
+
+        const subIndicators: IndicatorInstance[] = this.subPaneManager.entriesSignal().map(entry => ({
+            id: entry.paneId,
+            definitionId: entry.indicatorId,
+            label: entry.indicatorId,
+            name: entry.indicatorId,
+            role: 'sub' as const,
+            paneId: entry.paneId,
+            params: { ...entry.params },
+        }))
+
+        return [...mainIndicators, ...subIndicators]
+    })
+    private _subPanesComputed = computed<ReadonlyArray<SubPaneInfo>>(() => {
+        const ratios = this._paneRatiosSignal()
+        return this.subPaneManager.entriesSignal().map(entry => ({
+            paneId: entry.paneId,
+            indicatorId: entry.indicatorId,
+            params: { ...entry.params },
+            ratio: ratios[entry.paneId] ?? 1,
+        }))
+    })
+
     /** 视口状态信号 */
     get viewport(): Signal<ViewportState> {
         return this._viewportSignal
@@ -2300,14 +2344,14 @@ export class Chart {
         return this._themeSignal
     }
 
-    /** 指标实例列表信号 */
-    get indicators(): Signal<ReadonlyArray<IndicatorInstance>> {
-        return this._indicatorsSignal
+    /** 指标实例列表信号（派生信号，自动随主/副图状态更新） */
+    get indicators(): Computed<ReadonlyArray<IndicatorInstance>> {
+        return this._indicatorsComputed
     }
 
-    /** 子图信息信号 */
-    get subPanes(): Signal<ReadonlyArray<SubPaneInfo>> {
-        return this._subPanesSignal
+    /** 子图信息信号（派生信号，自动随副图条目/比例更新） */
+    get subPanes(): Computed<ReadonlyArray<SubPaneInfo>> {
+        return this._subPanesComputed
     }
 
     /** 当前绘图工具信号 */
@@ -2576,9 +2620,6 @@ export class Chart {
         if (role === 'main') {
             const success = this.enableMainIndicator(definitionId, params as Record<string, number | boolean | string>)
             if (!success) return null
-
-            // 更新 indicators signal
-            this.syncIndicatorsSignal()
             return definitionId.toUpperCase()
         } else {
             // 副图指标
@@ -2589,10 +2630,6 @@ export class Chart {
                 params as Record<string, number | boolean | string>,
             )
             if (!success) return null
-
-            // 更新 signals
-            this.syncIndicatorsSignal()
-            this.syncSubPanesSignal()
             return paneId
         }
     }
@@ -2605,25 +2642,18 @@ export class Chart {
     removeIndicator(instanceId: string): boolean {
         const id = instanceId.toUpperCase()
 
-        // 先尝试作为主图指标移除（直接检查内部状态，不依赖 signal）
-        if (this.activeMainIndicators.has(id)) {
-            const success = this.disableMainIndicator(instanceId)
-            if (success) {
-                this.syncIndicatorsSignal()
-            }
-            return success
+        // 先尝试作为主图指标移除
+        if (this._mainIndicatorsSignal.peek().has(id)) {
+            return this.disableMainIndicator(instanceId)
         }
 
-        // 再尝试作为副图指标移除（检查 sub pane 是否存在）
+        // 再尝试作为副图指标移除
         const subPaneEntry = this.getSubPaneEntry(instanceId)
         if (subPaneEntry) {
             this.removeSubPane(instanceId)
-            this.syncIndicatorsSignal()
-            this.syncSubPanesSignal()
             return true
         }
 
-        // 都没找到，返回 false
         return false
     }
 
@@ -2636,10 +2666,9 @@ export class Chart {
     updateIndicatorParams(instanceId: string, params: Record<string, unknown>): boolean {
         const id = instanceId.toUpperCase()
 
-        // 先尝试作为主图指标更新（直接检查内部状态）
-        if (this.activeMainIndicators.has(id)) {
+        // 先尝试作为主图指标更新
+        if (this._mainIndicatorsSignal.peek().has(id)) {
             this.updateMainIndicatorParams(instanceId, params as Record<string, number | boolean | string>)
-            this.syncIndicatorsSignal()
             return true
         }
 
@@ -2647,11 +2676,9 @@ export class Chart {
         const subPaneEntry = this.getSubPaneEntry(instanceId)
         if (subPaneEntry) {
             this.updateSubPaneParams(instanceId, params)
-            this.syncIndicatorsSignal()
             return true
         }
 
-        // 都没找到
         return false
     }
 
@@ -2667,46 +2694,7 @@ export class Chart {
         return false
     }
 
-    /**
-     * 同步 indicators signal
-     */
-    private syncIndicatorsSignal(): void {
-        const mainIndicators: IndicatorInstance[] = this.getActiveMainIndicators().map(id => ({
-            id,
-            definitionId: id,
-            label: id,
-            name: id,
-            role: 'main',
-            params: this.getMainIndicatorParams(id) ?? {},
-        }))
 
-        const subIndicators: IndicatorInstance[] = this.getSubPaneEntries().map(entry => ({
-            id: entry.paneId,
-            definitionId: entry.indicatorId,
-            label: entry.indicatorId,
-            name: entry.indicatorId,
-            role: 'sub',
-            paneId: entry.paneId,
-            params: entry.params,
-        }))
-
-        this._indicatorsSignal.set([...mainIndicators, ...subIndicators])
-    }
-
-    /**
-     * 同步 sub panes signal
-     */
-    private syncSubPanesSignal(): void {
-        const entries = this.getSubPaneEntries()
-        const subPanes: SubPaneInfo[] = entries.map(entry => ({
-            paneId: entry.paneId,
-            indicatorId: entry.indicatorId,
-            params: entry.params,
-            ratio: this._internalPaneRatios.get(entry.paneId) ?? 1,
-        }))
-
-        this._subPanesSignal.set(subPanes)
-    }
 
     // ---------- Sub Panes ----------
 

--- a/packages/core/src/engine/renderers/Indicator/indicatorData.ts
+++ b/packages/core/src/engine/renderers/Indicator/indicatorData.ts
@@ -18,7 +18,7 @@ export interface Indicator {
   params?: ParamConfig[]
 }
 
-const allIndicators: Indicator[] = [
+export const allIndicators: Indicator[] = [
   { id: 'MA', label: 'MA', name: '均线', pane: 'main' },
   {
     id: 'VOLUME',

--- a/packages/core/src/engine/subPaneManager.ts
+++ b/packages/core/src/engine/subPaneManager.ts
@@ -1,5 +1,6 @@
 import type { Chart } from './chart'
 import type { SubIndicatorType } from './renderers/Indicator'
+import { createSignal, type Signal } from '../reactivity/signal'
 import { createSubIndicatorRenderer } from './renderers/Indicator'
 import { createVolumeScaleRendererPlugin } from './renderers/Indicator/scale/volume_scale'
 import { createMacdScaleRendererPlugin } from './renderers/Indicator/scale/macd_scale'
@@ -60,6 +61,15 @@ export interface SubPaneEntry {
 
 export class SubPaneManager {
     private entries = new Map<string, SubPaneEntry>()
+    private _entriesSignal = createSignal<ReadonlyArray<SubPaneEntry>>([])
+
+    get entriesSignal(): Signal<ReadonlyArray<SubPaneEntry>> {
+        return this._entriesSignal
+    }
+
+    private syncEntriesSignal(): void {
+        this._entriesSignal.set(this.getAll())
+    }
 
     create(chart: Chart, paneId: string, indicatorId: SubIndicatorType, params: Record<string, unknown>): boolean {
         if (this.entries.has(paneId)) {
@@ -90,6 +100,7 @@ export class SubPaneManager {
 
         chart.getIndicatorScheduler().onSubPaneChanged()
 
+        this.syncEntriesSignal()
         return true
     }
 
@@ -107,6 +118,7 @@ export class SubPaneManager {
         }
 
         chart.getIndicatorScheduler().onSubPaneChanged()
+        this.syncEntriesSignal()
     }
 
     replaceIndicator(chart: Chart, paneId: string, newIndicatorId: SubIndicatorType, newParams: Record<string, unknown>): void {
@@ -137,6 +149,7 @@ export class SubPaneManager {
         })
 
         chart.getIndicatorScheduler().onSubPaneChanged()
+        this.syncEntriesSignal()
     }
 
     updateParams(chart: Chart, paneId: string, params: Record<string, unknown>): void {
@@ -148,6 +161,7 @@ export class SubPaneManager {
         chart.updateRendererConfig(entry.rendererName, params)
 
         this.syncSchedulerConfig(chart, paneId, entry.indicatorId, entry.params)
+        this.syncEntriesSignal()
     }
 
     getByPaneId(paneId: string): SubPaneEntry | undefined {
@@ -169,6 +183,7 @@ export class SubPaneManager {
         }
         this.entries.clear()
         chart.getIndicatorScheduler().onSubPaneChanged()
+        this.syncEntriesSignal()
     }
 
     private syncSchedulerConfig(

--- a/packages/vue/src/components/IndicatorSelector.vue
+++ b/packages/vue/src/components/IndicatorSelector.vue
@@ -74,7 +74,7 @@
 
         <!-- 添加按钮 -->
         <div class="indicator-item">
-          <button ref="addBtnRef" class="add-btn" @click="toggleAddMenu" title="添加指标">
+          <button ref="addBtnRef" class="add-btn" @click.stop="controller.toggleMenu()" title="添加指标">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
               <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
             </svg>
@@ -86,14 +86,14 @@
     <!-- 添加指标弹窗 -->
     <Teleport :to="teleportTarget">
       <Transition name="overlay">
-        <div v-if="showAddMenu" class="selector-overlay" @click="closeAddMenu">
+        <div v-if="menuOpen" class="selector-overlay" @click="controller.closeMenu()">
           <Transition name="modal">
-            <div v-if="showAddMenu" class="selector-modal" @click.stop>
+            <div v-if="menuOpen" class="selector-modal" @click.stop>
               <!-- 弹窗头部 -->
               <div class="modal-header">
                 <div class="header-title">
                   <span class="title-text">添加指标</span>
-                  <span class="title-sub">{{ totalIndicatorsCount }} 个可用指标</span>
+                  <span class="title-sub">{{ catalogLen }} 个可用指标</span>
                 </div>
                 <div class="header-actions">
                   <button
@@ -117,7 +117,7 @@
                       />
                     </svg>
                   </button>
-                  <button class="modal-close" @click="closeAddMenu" title="关闭">
+                  <button class="modal-close" @click="controller.closeMenu()" title="关闭">
                     <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
                       <path
                         d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
@@ -143,21 +143,21 @@
                     />
                   </svg>
                   <input
-                    v-model="searchQuery"
+                    :value="searchQuery" @input="controller.setSearchQuery(($event.target as HTMLInputElement).value)"
                     type="text"
                     class="search-input"
                     placeholder="搜索指标名称..."
                   />
                 </div>
                 <!-- 主图指标区域 -->
-                <div v-if="filteredMainIndicators.length > 0" class="indicator-section">
+                <div v-if="filteredMain.length > 0" class="indicator-section">
                   <div class="section-header">
                     <span class="section-title">主图指标</span>
-                    <span class="section-count">{{ filteredMainIndicators.length }}</span>
+                    <span class="section-count">{{ filteredMain.length }}</span>
                   </div>
                   <div class="indicator-grid" :class="{ compact: isCompactView }">
                     <button
-                      v-for="indicator in filteredMainIndicators"
+                      v-for="indicator in filteredMain"
                       :key="indicator.id"
                       class="indicator-card"
                       :class="{ active: isActive(indicator.id), compact: isCompactView }"
@@ -197,7 +197,7 @@
 
                 <!-- 分隔线 -->
                 <div
-                  v-if="filteredMainIndicators.length > 0 && filteredSubIndicators.length > 0"
+                  v-if="filteredMain.length > 0 && filteredSub.length > 0"
                   class="section-divider"
                 ></div>
 
@@ -213,14 +213,14 @@
                 </div>
 
                 <!-- 副图指标区域 -->
-                <div v-if="filteredSubIndicators.length > 0" class="indicator-section">
+                <div v-if="filteredSub.length > 0" class="indicator-section">
                   <div class="section-header">
                     <span class="section-title">副图指标</span>
-                    <span class="section-count">{{ filteredSubIndicators.length }}</span>
+                    <span class="section-count">{{ filteredSub.length }}</span>
                   </div>
                   <div class="indicator-grid" :class="{ compact: isCompactView }">
                     <button
-                      v-for="indicator in filteredSubIndicators"
+                      v-for="indicator in filteredSub"
                       :key="indicator.id"
                       class="indicator-card"
                       :class="{ active: isActive(indicator.id), compact: isCompactView }"
@@ -264,7 +264,7 @@
                 <div class="footer-info">
                   <span class="info-text">已激活 {{ activeCount }} 个指标</span>
                 </div>
-                <button class="btn btn-confirm" @click="closeAddMenu">确认</button>
+                <button class="btn btn-confirm" @click="controller.closeMenu()">确认</button>
               </div>
             </div>
           </Transition>
@@ -291,13 +291,17 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import IndicatorParams from './IndicatorParams.vue'
 import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+import { coreSignalToVueRef } from '../index'
 import {
-  mainIndicators,
-  subIndicators,
+  allIndicators,
   findIndicator,
   isSubIndicatorId,
 } from '@363045841yyt/klinechart-core/engine/renderers/Indicator/indicatorData'
 import type { Indicator } from '@363045841yyt/klinechart-core/engine/renderers/Indicator/indicatorData'
+import {
+  createIndicatorSelectorController,
+  type IndicatorDefinition,
+} from '@363045841yyt/klinechart-core/controllers'
 
 const props = defineProps<{
   activeIndicators?: string[]
@@ -310,15 +314,51 @@ const emit = defineEmits<{
   reorderSubIndicators: [orderedIndicatorIds: string[]]
 }>()
 
+// ── 将 Indicator[] 转换为 IndicatorDefinition[] ──
+function toIndicatorDefinitions(source: typeof allIndicators): IndicatorDefinition[] {
+  return source.map((i) => ({
+    id: i.id,
+    label: i.label,
+    name: i.name,
+    description: i.description,
+    role: i.pane,
+    params: (i.params ?? []).map((p) => ({
+      key: p.key,
+      label: p.label,
+      type: p.type,
+      default: p.default ?? (p.type === 'number' ? 0 : ''),
+      min: p.min,
+      max: p.max,
+      step: p.step,
+    })),
+  }))
+}
+
+// ── Controller ──
+const controller = createIndicatorSelectorController({
+  catalog: toIndicatorDefinitions(allIndicators),
+})
+
+// ── 从 Controller Signal 桥接的 Vue 响应式状态 ──
+const menuOpen = coreSignalToVueRef(controller.menuOpen)
+const searchQuery = coreSignalToVueRef(controller.searchQuery)
+const filteredMain = coreSignalToVueRef(controller.filteredMain)
+const filteredSub = coreSignalToVueRef(controller.filteredSub)
+
+const hasSearchResults = computed(
+  () => filteredMain.value.length > 0 || filteredSub.value.length > 0,
+)
+
+const catalogLen = controller.catalog.peek().length
+
+// ── 本地 UI 状态（非 Controller 管理的纯 UI 状态） ──
 const addBtnRef = ref<HTMLButtonElement | null>(null)
 const paramsVisible = ref(false)
 const currentIndicatorId = ref<string | null>(null)
 const hoveredIndicator = ref<string | null>(null)
-const showAddMenu = ref(false)
 const dragOverIndicatorId = ref<string | null>(null)
 const draggingIndicatorId = ref<string | null>(null)
 const isCompactView = ref(false)
-const searchQuery = ref('')
 
 // Teleport target for fullscreen modal visibility
 const teleportTarget = useFullscreenTeleportTarget()
@@ -346,38 +386,7 @@ const currentIndicator = computed(() => {
   return findIndicator(currentIndicatorId.value)
 })
 
-const totalIndicatorsCount = computed(() => mainIndicators.length + subIndicators.length)
-
 const activeCount = computed(() => props.activeIndicators?.length ?? 0)
-
-// 过滤后的主图指标
-const filteredMainIndicators = computed(() => {
-  if (!searchQuery.value.trim()) return mainIndicators
-  const query = searchQuery.value.toLowerCase().trim()
-  return mainIndicators.filter(
-    (i) =>
-      i.label.toLowerCase().includes(query) ||
-      i.name.toLowerCase().includes(query) ||
-      i.id.toLowerCase().includes(query),
-  )
-})
-
-// 过滤后的副图指标
-const filteredSubIndicators = computed(() => {
-  if (!searchQuery.value.trim()) return subIndicators
-  const query = searchQuery.value.toLowerCase().trim()
-  return subIndicators.filter(
-    (i) =>
-      i.label.toLowerCase().includes(query) ||
-      i.name.toLowerCase().includes(query) ||
-      i.id.toLowerCase().includes(query),
-  )
-})
-
-// 是否有搜索结果
-const hasSearchResults = computed(
-  () => filteredMainIndicators.value.length > 0 || filteredSubIndicators.value.length > 0,
-)
 
 function isActive(indicatorId: string): boolean {
   return props.activeIndicators?.includes(indicatorId) ?? false
@@ -390,7 +399,8 @@ function addIndicator(indicatorId: string) {
   if (!indicator) return
 
   if (indicator.pane === 'main') {
-    mainIndicators
+    const allItems = allIndicators
+    allItems
       .filter((i) => i.id !== indicatorId && isActive(i.id))
       .forEach((i) => emit('toggle', i.id, false))
   }
@@ -405,10 +415,6 @@ function removeIndicator(indicatorId: string) {
 function showParams(indicatorId: string) {
   currentIndicatorId.value = indicatorId
   paramsVisible.value = true
-}
-
-function closeAddMenu() {
-  showAddMenu.value = false
 }
 
 function getParamValues(indicatorId: string): Record<string, number> {
@@ -510,13 +516,9 @@ function onDragEnd() {
   draggingIndicatorId.value = null
 }
 
-function toggleAddMenu() {
-  showAddMenu.value = !showAddMenu.value
-}
-
 function handleKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape' && showAddMenu.value) {
-    showAddMenu.value = false
+  if (event.key === 'Escape' && controller.menuOpen.peek()) {
+    controller.closeMenu()
   }
 }
 

--- a/packages/vue/src/components/IndicatorSelector.vue
+++ b/packages/vue/src/components/IndicatorSelector.vue
@@ -401,7 +401,7 @@ function addIndicator(indicatorId: string) {
   if (indicator.pane === 'main') {
     const allItems = allIndicators
     allItems
-      .filter((i) => i.id !== indicatorId && isActive(i.id))
+      .filter((i) => i.id !== indicatorId && isActive(i.id) && i.pane === 'main')
       .forEach((i) => emit('toggle', i.id, false))
   }
 

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -118,7 +118,7 @@ import KLineTooltip from './KLineTooltip.vue'
 import MarkerTooltip from './MarkerTooltip.vue'
 import IndicatorSelector from './IndicatorSelector.vue'
 import DrawingStyleToolbar from './DrawingStyleToolbar.vue'
-import { Chart, type PaneSpec } from '@363045841yyt/klinechart-core/engine/chart'
+import { Chart, type PaneSpec, type IndicatorInstance, type SubPaneInfo } from '@363045841yyt/klinechart-core/engine/chart'
 import type { KLineData } from '@363045841yyt/klinechart-core/types/price'
 import {
   createChartStore,
@@ -639,40 +639,23 @@ function addSubPane(
 
   const mergedParams = params ?? getDefaultParams(indicatorId)
 
-  // 使用高层 Facade API 创建副图指标
+  // 使用高层 Facade API 创建副图指标（Signal 订阅自动同步本地状态和 scheduleDraw）
   const paneId = chartRef.value?.addIndicator(indicatorId, 'sub', mergedParams)
   if (!paneId) return false
 
   // 创建 paneTitle 渲染器（UI 层职责）
   mountSubPaneTitle(paneId, indicatorId)
 
-  // 更新本地状态
-  subPanes.value.push({
-    id: paneId,
-    indicatorId,
-    params: mergedParams,
-  })
-
-  scheduleRender()
   return true
 }
 
 // 移除副图（使用高层 Facade API）
 function removeSubPane(paneId: string): void {
-  const index = subPanes.value.findIndex((p) => p.id === paneId)
-  if (index === -1) return
-
-  const pane = subPanes.value[index]
-  if (!pane) return
-
   // 移除 paneTitle 渲染器
   unmountSubPaneTitle(paneId)
 
-  // 使用高层 Facade API 移除指标
+  // 使用高层 Facade API 移除指标（Signal 订阅自动同步本地状态）
   chartRef.value?.removeIndicator(paneId)
-
-  // 更新本地状态
-  subPanes.value.splice(index, 1)
 }
 
 // 清除所有副图（使用高层 Facade API）
@@ -683,32 +666,22 @@ function clearAllSubPanes(): void {
     unmountSubPaneTitle(pane.id)
   }
 
-  // 清空本地状态
-  subPanes.value = []
+  // 清空本地状态（Signal 订阅自动同步 subPanes，只需要清理 UI 层状态）
   subPaneCounters.clear()
   paneTitleRendererNames.clear()
 }
 
 // 从语义化配置初始化指标状态（单向数据流：config → chart）
+// Signal 订阅会自动同步本地状态，此处只需调用 Chart API
 function initIndicatorsFromConfig(): void {
   const config = props.semanticConfig
   const chart = chartRef.value
   if (!chart) return
 
-  // 初始化主图指标 - 直接调用Chart API
   const mainIndicators = config.indicators?.main
   if (mainIndicators) {
     for (const indicator of mainIndicators) {
       if (indicator.enabled) {
-        // 同步Vue状态（用于UI展示）
-        if (!mainActiveIndicators.value.includes(indicator.type)) {
-          mainActiveIndicators.value.push(indicator.type)
-        }
-        // 保存参数
-        if (indicator.params) {
-          indicatorParams.value[indicator.type] = indicator.params as Record<string, unknown>
-        }
-        // 启用指标（Chart内部管理渲染器）
         chart.enableMainIndicator(
           indicator.type,
           indicator.params as Record<string, number | boolean | string>,
@@ -716,51 +689,12 @@ function initIndicatorsFromConfig(): void {
       }
     }
   }
-
-  // 副图指标参数由 syncSubPanesFromChart 处理
 }
-
-// 监听主图指标参数变化，同步到Chart（状态由Chart管理，Vue只同步参数）
-watch(
-  [activeIndicators, indicatorParams],
-  ([indicators]) => {
-    const chart = chartRef.value
-    if (!chart) return
-
-    // 只更新mainIndicatorLegend的配置（用于图例显示）
-    // 渲染器的启用/禁用由Chart内部管理
-    chart.updateRendererConfig('mainIndicatorLegend', {
-      indicators: {
-        MA: {
-          enabled: indicators.includes('MA'),
-          params: indicatorParams.value['MA'] || {},
-        },
-        BOLL: {
-          enabled: indicators.includes('BOLL'),
-          params: indicatorParams.value['BOLL'] || {},
-        },
-        EXPMA: {
-          enabled: indicators.includes('EXPMA'),
-          params: indicatorParams.value['EXPMA'] || {},
-        },
-        ENE: {
-          enabled: indicators.includes('ENE'),
-          params: indicatorParams.value['ENE'] || {},
-        },
-      },
-    })
-
-    scheduleRender()
-  },
-  { deep: true },
-)
 
 // 从 Chart 同步副图状态到本地（语义化配置后调用）
 function syncSubPanesFromChart(): void {
   const chartSubPaneEntries = chartRef.value?.getSubPaneEntries() ?? []
 
-  // 清空本地状态
-  subPanes.value = []
   paneTitleRendererNames.clear()
 
   for (const entry of chartSubPaneEntries) {
@@ -779,43 +713,21 @@ function syncSubPanesFromChart(): void {
 
     // 创建 paneTitle 渲染器
     mountSubPaneTitle(paneId, indicatorId)
-
-    // 更新本地状态
-    subPanes.value.push({
-      id: paneId,
-      indicatorId,
-      params: { ...params },
-    })
   }
-
-  scheduleRender()
 }
 
 // 切换副图指标（使用 Chart API）
 function switchSubIndicator(paneId: string, newIndicatorId: SubIndicatorType): void {
-  const pane = subPanes.value.find((p) => p.id === paneId)
-  if (!pane) return
-
   const nextParams = getDefaultParams(newIndicatorId)
 
   // 移除旧的 paneTitle 渲染器
   unmountSubPaneTitle(paneId)
 
-  // 使用 Chart API 替换副图指标（paneId 不变，只换指标类型）
+  // 使用 Chart API 替换副图指标（paneId 不变，只换指标类型，Signal 订阅自动同步本地状态）
   chartRef.value?.replaceSubPaneIndicator(paneId, newIndicatorId, nextParams)
 
   // 创建新的 paneTitle 渲染器
   mountSubPaneTitle(paneId, newIndicatorId)
-
-  // 更新本地状态（paneId 保持不变）
-  const index = subPanes.value.findIndex((p) => p.id === paneId)
-  if (index !== -1) {
-    subPanes.value[index] = {
-      id: paneId,
-      indicatorId: newIndicatorId,
-      params: nextParams,
-    }
-  }
 }
 
 // 获取副图标题信息（带缓存，只在 crosshairIdx 或 data 变化时重算）
@@ -879,14 +791,12 @@ function handleIndicatorToggle(indicatorId: string, active: boolean) {
     const existingIndicator = mainActiveIndicators.value.find((id) => id === indicatorId)
 
     if (active && !existingIndicator) {
-      // 添加主图指标
+      // 添加主图指标（Signal 订阅自动同步本地状态）
       chart.addIndicator(indicatorId, 'main', indicatorParams.value[indicatorId])
-      mainActiveIndicators.value.push(indicatorId)
     } else if (!active && existingIndicator) {
-      // 移除主图指标
+      // 移除主图指标（Signal 订阅自动同步本地状态）
       const instanceId = indicatorId.toUpperCase()
       chart.removeIndicator(instanceId)
-      mainActiveIndicators.value = mainActiveIndicators.value.filter((id) => id !== indicatorId)
     }
     return
   }
@@ -901,17 +811,10 @@ function handleIndicatorToggle(indicatorId: string, active: boolean) {
       // 副图数量上限检查
       if (subPanes.value.length >= maxSubPanes) return
 
-      // 使用高层 API 添加副图指标
+      // 使用高层 API 添加副图指标（Signal 订阅自动同步本地状态）
       const paneId = chart.addIndicator(indicatorId, 'sub', indicatorParams.value[indicatorId])
       if (paneId) {
-        // 创建 paneTitle 渲染器
         mountSubPaneTitle(paneId, indicatorId as SubIndicatorType)
-        // 同步本地状态
-        subPanes.value.push({
-          id: paneId,
-          indicatorId: indicatorId as SubIndicatorType,
-          params: { ...indicatorParams.value[indicatorId] },
-        })
       } else if (subPanes.value.length > 0) {
         // 添加失败（可能达到上限），替换最后一个
         const lastPane = subPanes.value[subPanes.value.length - 1]
@@ -924,42 +827,13 @@ function handleIndicatorToggle(indicatorId: string, active: boolean) {
         chart.removeIndicator(pane.id)
         unmountSubPaneTitle(pane.id)
       })
-      subPanes.value = subPanes.value.filter((p) => p.indicatorId !== indicatorId)
     }
-    scheduleRender()
   }
-}
-
-// 更新主图指标图例配置
-function updateMainIndicatorLegendConfig() {
-  chartRef.value?.updateRendererConfig('mainIndicatorLegend', {
-    indicators: {
-      MA: {
-        enabled: activeIndicators.value.includes('MA'),
-        params: indicatorParams.value['MA'] || {},
-      },
-      BOLL: {
-        enabled: activeIndicators.value.includes('BOLL'),
-        params: indicatorParams.value['BOLL'] || {},
-      },
-      EXPMA: {
-        enabled: activeIndicators.value.includes('EXPMA'),
-        params: indicatorParams.value['EXPMA'] || {},
-      },
-      ENE: {
-        enabled: activeIndicators.value.includes('ENE'),
-        params: indicatorParams.value['ENE'] || {},
-      },
-    },
-  })
 }
 
 // 指标参数更新处理
 function handleUpdateParams(indicatorId: string, params: Record<string, unknown>) {
-  // 保存参数配置
-  indicatorParams.value[indicatorId] = params
-
-  // 主图指标参数更新 - 使用Chart API
+  // 主图指标参数更新 - 使用Chart API（Signal 订阅自动同步本地状态和 scheduleDraw）
   if (
     indicatorId === 'MA' ||
     indicatorId === 'BOLL' ||
@@ -970,7 +844,6 @@ function handleUpdateParams(indicatorId: string, params: Record<string, unknown>
       indicatorId,
       params as Record<string, number | boolean | string>,
     )
-    scheduleRender()
     return
   }
 
@@ -979,13 +852,9 @@ function handleUpdateParams(indicatorId: string, params: Record<string, unknown>
       .filter((p) => p.indicatorId === indicatorId)
       .forEach((pane) => {
         chartRef.value?.updateSubPaneParams(pane.id, params)
-        pane.params = { ...params }
       })
-    scheduleRender()
     return
   }
-
-  scheduleRender()
 }
 
 function handleReorderSubIndicators(orderedIndicatorIds: string[]) {
@@ -1206,12 +1075,75 @@ function setupChartCallbacks(chart: Chart): void {
     chartTheme.value = theme
   })
 
+  // 订阅 indicators signal，派生 Vue 本地状态（SSOT: Chart 引擎）
+  const unsubscribeIndicators = chart.indicators.subscribe(() => {
+    const instances = chart.indicators.peek()
+
+    // 同步主图指标列表
+    const mains = instances
+      .filter((i): i is IndicatorInstance & { role: 'main' } => i.role === 'main')
+      .map((i) => i.definitionId)
+    mainActiveIndicators.value = mains
+
+    // 合并主图指标参数（不覆盖副图参数）
+    const nextParams = { ...indicatorParams.value }
+    for (const inst of instances) {
+      if (inst.role === 'main' && inst.params && Object.keys(inst.params).length > 0) {
+        nextParams[inst.definitionId] = { ...inst.params }
+      }
+    }
+
+    // 更新主图指标图例配置
+    chart.updateRendererConfig('mainIndicatorLegend', {
+      indicators: {
+        MA: { enabled: mains.includes('MA'), params: nextParams['MA'] || {} },
+        BOLL: { enabled: mains.includes('BOLL'), params: nextParams['BOLL'] || {} },
+        EXPMA: { enabled: mains.includes('EXPMA'), params: nextParams['EXPMA'] || {} },
+        ENE: { enabled: mains.includes('ENE'), params: nextParams['ENE'] || {} },
+      },
+    })
+
+    indicatorParams.value = nextParams
+  })
+
+  // 订阅 subPanes signal，派生 Vue 本地状态
+  // 注意：保持当前显示顺序（reorder 是 UI 层私有状态），仅同步新增/删除
+  const unsubscribeSubPanes = chart.subPanes.subscribe(() => {
+    const subPaneInfos = chart.subPanes.peek()
+    const signalIds = new Set(subPaneInfos.map((sp) => sp.paneId))
+
+    // 保留 display order，移除已删除的 pane，追加新增的
+    const merged = subPanes.value.filter((p) => signalIds.has(p.id))
+    const existingIds = new Set(merged.map((p) => p.id))
+    for (const sp of subPaneInfos) {
+      if (!existingIds.has(sp.paneId)) {
+        merged.push({
+          id: sp.paneId,
+          indicatorId: sp.indicatorId as SubIndicatorType,
+          params: sp.params,
+        })
+      }
+    }
+    subPanes.value = merged
+
+    // 合并副图指标参数（不覆盖主图参数）
+    const nextParams = { ...indicatorParams.value }
+    for (const sp of subPaneInfos) {
+      if (sp.params && Object.keys(sp.params).length > 0) {
+        nextParams[sp.indicatorId] = { ...sp.params }
+      }
+    }
+    indicatorParams.value = nextParams
+  })
+
   // 保存 unsubscribe 函数以便清理
   onUnmounted(() => {
     unsubscribeViewport()
     unsubscribeData()
     unsubscribePaneRatios()
     unsubscribeTheme()
+    unsubscribeIndicators()
+    unsubscribeSubPanes()
   })
 }
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -29,9 +29,13 @@ import type {
     ChartControllerFactory,
     ChartMountOptions,
     ChartViewport,
+    IndicatorDefinition,
     IndicatorInstance,
     InteractionSnapshot,
     KLineData,
+} from '@363045841yyt/klinechart-core'
+import {
+    createIndicatorSelectorController,
 } from '@363045841yyt/klinechart-core'
 
 export type {
@@ -250,6 +254,74 @@ export function useViewport(
     })
     onScopeDispose(unsub)
     return vp
+}
+
+// ---------------------------------------------------------------------------
+// useIndicatorSelector — composable
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge the indicator selector signals into Vue refs.
+ *
+ * Creates an internal IndicatorSelectorController for menu/search/filter UI
+ * state (catalog from `controller.catalog`), and delegates add/remove to the
+ * ChartController engine methods.
+ */
+export function useIndicatorSelector(controller: ChartController): {
+    catalog: ReadonlyArray<IndicatorDefinition>
+    filteredMain: Ref<ReadonlyArray<IndicatorDefinition>>
+    filteredSub: Ref<ReadonlyArray<IndicatorDefinition>>
+    menuOpen: Ref<boolean>
+    searchQuery: Ref<string>
+    add: (definitionId: string) => string | null
+    remove: (instanceId: string) => boolean
+    openMenu: () => void
+    closeMenu: () => void
+    toggleMenu: () => void
+    setSearchQuery: (q: string) => void
+    isActive: (definitionId: string) => boolean
+} {
+    const selector = createIndicatorSelectorController({
+        catalog: controller.catalog,
+    })
+
+    onScopeDispose(() => selector.dispose())
+
+    const filteredMain = coreSignalToVueRef(selector.filteredMain)
+    const filteredSub = coreSignalToVueRef(selector.filteredSub)
+    const menuOpen = coreSignalToVueRef(selector.menuOpen)
+    const searchQuery = coreSignalToVueRef(selector.searchQuery)
+
+    function add(definitionId: string): string | null {
+        const def = controller.catalog.find((d) => d.id === definitionId)
+        if (def === undefined) return null
+        return controller.addIndicator(definitionId, def.role)
+    }
+
+    function remove(instanceId: string): boolean {
+        return controller.removeIndicator(instanceId)
+    }
+
+    function isActive(definitionId: string): boolean {
+        return controller.indicators
+            .peek()
+            .some((i) => i.definitionId === definitionId)
+    }
+
+    return {
+        catalog: controller.catalog,
+        filteredMain,
+        filteredSub,
+        menuOpen,
+        searchQuery,
+        add,
+        remove,
+        openMenu: () => selector.openMenu(),
+        closeMenu: () => selector.closeMenu(),
+        toggleMenu: () => selector.toggleMenu(),
+        setSearchQuery: (q: string) => selector.setSearchQuery(q),
+        isActive,
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Close #27

## 变更概要

三个阶段重构，消除指标选择器状态管理的**双重写入反模式**，实现 Chart 引擎单一数据源。

### 阶段 1 — KLineChart.vue 订阅 Chart Signal（核心）
- 添加 `chart.indicators` 和 `chart.subPanes` 的 Signal 订阅，消除手动 `mainActiveIndicators.push()` 等同步
- 移除 `watch([activeIndicators, indicatorParams])` 的 legend 反向配置反模式
- 移除 6+ 处冗余 `scheduleRender()` 调用
- 修复 Chart 引擎 Signal 时序：`syncIndicatorsSignal()` 移到 `scheduleDraw()` 之前

### 阶段 2 — IndicatorSelector.vue 接入 Controller
- 将 4 个本地 Vue ref（`showAddMenu`、`searchQuery`、`filteredMainIndicators`、`filteredSubIndicators`）替换为 `IndicatorSelectorController` Signal，通过 `coreSignalToVueRef` 桥接
- 添加 `toIndicatorDefinitions()` 转换器
- 导出 `allIndicators` 和 `createIndicatorSelectorController`

### 阶段 3 — 导出 `useIndicatorSelector` composable
- 满足 Vue/React 适配器 contract test 的断言要求

## 修改文件（6 个）
- `packages/core/src/engine/chart.ts` — Signal 时序修复
- `packages/core/src/controllers/index.ts` — 导出 `createIndicatorSelectorController`
- `packages/core/src/engine/renderers/Indicator/indicatorData.ts` — 导出 `allIndicators`
- `packages/vue/src/components/KLineChart.vue` — Signal 订阅，移除手动同步（-145行）
- `packages/vue/src/components/IndicatorSelector.vue` — Controller 接入（+64/-61）
- `packages/vue/src/index.ts` — 新增 `useIndicatorSelector`（+72行）

## 好处
- **单一数据源**：Chart 引擎是指标状态的唯一真相来源
- **消除双重写入**：不再需要手动 `push()`/`filter()` 本地 ref
- **框架无关 UI 状态**：`IndicatorSelectorController` 的 Signal 可直接为 React/Angular 适配器使用
- **时序正确**：Signal 订阅者在渲染前拿到最新状态