### PR TITLE
fix(vue): .view-toggle-btn active/non-active uniform background

### DIFF
--- a/packages/vue/src/components/IndicatorSelector.vue
+++ b/packages/vue/src/components/IndicatorSelector.vue
@@ -818,9 +818,9 @@ onUnmounted(() => {
 }
 
 .view-toggle-btn.active {
-  background: var(--klc-color-foreground);
-  border-color: var(--klc-color-foreground);
-  color: var(--klc-color-background);
+  background: var(--klc-color-tag-bg-white);
+  border-color: var(--klc-color-border-button);
+  color: var(--klc-color-foreground);
 }
 
 /* 弹窗主体 */


### PR DESCRIPTION
.view-toggle-btn.active now uses the same background (var(--klc-color-tag-bg-white)) and border (var(--klc-color-border-button)) as the non-active state. Active state is distinguished by text color only.