### PR TITLE
refactor(core): descriptor-driven indicator pipeline (P0-P5)

### DIFF
--- a/.omo/run-continuation/ses_1534c8138ffez138dk15Ch1jkh.json
+++ b/.omo/run-continuation/ses_1534c8138ffez138dk15Ch1jkh.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_1534c8138ffez138dk15Ch1jkh",
+  "updatedAt": "2026-06-09T14:35:33.761Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-06-09T14:35:33.761Z"
+    }
+  }
+}

--- a/.omo/run-continuation/ses_1535c2d27ffeYQZ6Zi41bd3on8.json
+++ b/.omo/run-continuation/ses_1535c2d27ffeYQZ6Zi41bd3on8.json
@@ -1,0 +1,10 @@
+{
+  "sessionID": "ses_1535c2d27ffeYQZ6Zi41bd3on8",
+  "updatedAt": "2026-06-09T14:32:00.121Z",
+  "sources": {
+    "background-task": {
+      "state": "idle",
+      "updatedAt": "2026-06-09T14:32:00.121Z"
+    }
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,7 +224,7 @@ type IndicatorVisibleStateComposer = (context: {
 
 ### 新增副图指标
 
-新增副图指标必须在 `@Indicator(...)` 中提供 `visibleState: { compose: ... }`，并将 ID 加入 `METADATA_VISIBLE_STATE_INDICATOR_IDS`。
+新增副图指标只需在 `@Indicator(...)` 中提供 `visibleState: { compose: ... }`，`stateComposer.ts` 通过 `getRegisteredIndicatorDefinitions()` 自动发现所有已注册指标，无需手动维护 ID 列表。
 
 ---
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@363045841yyt/klinechart-core",
-  "version": "0.7.12-alpha.1",
+  "version": "0.7.12",
   "description": "Headless K-line chart engine + reactive controllers. Zero framework dependencies.",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/engine/indicators/__tests__/registerBuiltins.test.ts
+++ b/packages/core/src/engine/indicators/__tests__/registerBuiltins.test.ts
@@ -49,9 +49,7 @@ describe('builtin indicator registration', () => {
 
   it('routes stage 4A metadata config updates to scheduler methods', () => {
     const scheduler = {
-      updateRSIConfig: vi.fn(),
-      updateMACDConfig: vi.fn(),
-      updateVolumeProfileConfig: vi.fn(),
+      updateIndicatorConfig: vi.fn(),
     }
 
     getRegisteredIndicatorDefinition('RSI')?.updateConfig?.(scheduler, { period1: 7 }, 'RSI_0')
@@ -59,17 +57,14 @@ describe('builtin indicator registration', () => {
     getRegisteredIndicatorDefinition('VOLUME_PROFILE')?.updateConfig?.(scheduler, { bins: 32 }, 'VP_0')
     getRegisteredIndicatorDefinition('VOL')?.updateConfig?.(scheduler, {}, 'VOL_0')
 
-    expect(scheduler.updateRSIConfig).toHaveBeenCalledWith({ period1: 7 }, 'RSI_0')
-    expect(scheduler.updateMACDConfig).toHaveBeenCalledWith({ fastPeriod: 8 }, 'MACD_0')
-    expect(scheduler.updateVolumeProfileConfig).toHaveBeenCalledWith({ bins: 32 }, 'VP_0')
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('rsi', { period1: 7 }, 'RSI_0')
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('macd', { fastPeriod: 8 }, 'MACD_0')
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('volumeProfile', { bins: 32 }, 'VP_0')
   })
 
   it('routes stage 4B metadata config updates to scheduler methods', () => {
     const scheduler = {
-      updateCCIConfig: vi.fn(),
-      updateATRConfig: vi.fn(),
-      updateChaikinVolConfig: vi.fn(),
-      updateZonesConfig: vi.fn(),
+      updateIndicatorConfig: vi.fn(),
     }
 
     getRegisteredIndicatorDefinition('CCI')?.updateConfig?.(scheduler, { period: 14 }, 'CCI_0')
@@ -77,10 +72,10 @@ describe('builtin indicator registration', () => {
     getRegisteredIndicatorDefinition('CHAIKIN_VOL')?.updateConfig?.(scheduler, { emaPeriod: 10 }, 'CV_0')
     getRegisteredIndicatorDefinition('ZONES')?.updateConfig?.(scheduler, { showFVG: true }, 'Z_0')
 
-    expect(scheduler.updateCCIConfig).toHaveBeenCalledWith({ period: 14 }, 'CCI_0')
-    expect(scheduler.updateATRConfig).toHaveBeenCalledWith({ period: 10 }, 'ATR_0')
-    expect(scheduler.updateChaikinVolConfig).toHaveBeenCalledWith({ emaPeriod: 10 }, 'CV_0')
-    expect(scheduler.updateZonesConfig).toHaveBeenCalledWith({ showFVG: true }, 'Z_0')
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('cci', { period: 14 }, 'CCI_0')
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('atr', { period: 10 }, 'ATR_0')
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('chaikinVol', { emaPeriod: 10 }, 'CV_0')
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('zones', { showFVG: true }, 'Z_0')
   })
 
   it('registers dedicated scale renderer factories for stage 5A indicators', () => {
@@ -265,10 +260,7 @@ describe('builtin indicator registration', () => {
 
   it('routes base main metadata config updates to scheduler methods', () => {
     const scheduler = {
-      updateMAConfig: vi.fn(),
-      updateBOLLConfig: vi.fn(),
-      updateEXPMAConfig: vi.fn(),
-      updateENEConfig: vi.fn(),
+      updateIndicatorConfig: vi.fn(),
     }
 
     getRegisteredIndicatorDefinition('MA')?.updateConfig?.(scheduler, { ma5: true }, 'main')
@@ -276,10 +268,10 @@ describe('builtin indicator registration', () => {
     getRegisteredIndicatorDefinition('EXPMA')?.updateConfig?.(scheduler, { fastPeriod: 12 }, 'main')
     getRegisteredIndicatorDefinition('ENE')?.updateConfig?.(scheduler, { period: 10 }, 'main')
 
-    expect(scheduler.updateMAConfig).toHaveBeenCalledWith({ ma5: true })
-    expect(scheduler.updateBOLLConfig).toHaveBeenCalledWith({ period: 20 })
-    expect(scheduler.updateEXPMAConfig).toHaveBeenCalledWith({ fastPeriod: 12 })
-    expect(scheduler.updateENEConfig).toHaveBeenCalledWith({ period: 10 })
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('ma', { ma5: true })
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('boll', { period: 20 })
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('expma', { fastPeriod: 12 })
+    expect(scheduler.updateIndicatorConfig).toHaveBeenCalledWith('ene', { period: 10 })
   })
 
   it('registers semantic apply metadata for stage 7A main indicators', () => {

--- a/packages/core/src/engine/indicators/__tests__/stateComposer.test.ts
+++ b/packages/core/src/engine/indicators/__tests__/stateComposer.test.ts
@@ -152,12 +152,15 @@ describe('stateComposer', () => {
     expect(definitions.get('ma')?.mainPane?.composeRenderState).toHaveBeenCalledWith(bundle, visibleRange, timestamp)
   })
 
-  it('throws when main render state composer metadata is missing', () => {
+  it('falls back to registry composeRenderState when metadata is partial', () => {
+    const bundle = createBundle()
+    const timestamp = 1234
+    const visibleRange = { start: 1, end: 3 }
     const definition = { ...createDefinition(null), mainPane: { rendererName: 'ma' } }
 
-    expect(() => composeRenderStates(createBundle(), { start: 0, end: 1 }, 1, (id) => id === 'ma' ? definition : undefined)).toThrow(
-      '[StateComposer] Missing mainPane.composeRenderState for ma',
-    )
+    const states = composeRenderStates(bundle, visibleRange, timestamp, (id) => id === 'ma' ? definition : undefined)
+
+    expect(states.ma).toBeDefined()
   })
 
 

--- a/packages/core/src/engine/indicators/indicator.worker.ts
+++ b/packages/core/src/engine/indicators/indicator.worker.ts
@@ -7,10 +7,12 @@ import type {
     IndicatorWorkerRequest,
     IndicatorWorkerResponse,
     IndicatorConfigSnapshot,
+    SerializedRuntimeDescriptor,
 } from './workerProtocol'
 import { PROTOCOL_VERSION } from './workerProtocol'
 import type { KLineData } from '../../types/price'
-import { IndicatorRuntime } from './indicatorRuntime'
+import { IndicatorRuntime, CALCULATOR_MAP, createWorkerCompute } from './indicatorRuntime'
+import type { IndicatorRuntimeDescriptor } from './indicatorMetadata'
 
 // Worker 全局作用域
 const ctx = self as unknown as Worker
@@ -28,11 +30,37 @@ function postResponse(response: IndicatorWorkerResponse): void {
 /**
  * 处理初始化
  */
-function handleInit(): void {
-    runtime = new IndicatorRuntime()
+function handleInit(msg?: { descriptors?: SerializedRuntimeDescriptor[] }): void {
+    const serializedDescs = msg?.descriptors ?? []
+    const descriptors: IndicatorRuntimeDescriptor[] = serializedDescs.map(d => ({
+        configKey: d.configKey as any,
+        paneIdKey: d.paneIdKey as any,
+        defaultConfig: d.defaultConfig,
+        computeKey: d.computeKey,
+        compute: createWorkerCompute(d),
+    }))
+    runtime = new IndicatorRuntime(descriptors)
     postResponse({
         type: 'ready',
         protocolVersion: PROTOCOL_VERSION,
+    })
+}
+
+function handleAddDescriptor(descriptor: SerializedRuntimeDescriptor): void {
+    if (!runtime) {
+        postResponse({
+            type: 'error',
+            stage: 'init',
+            message: 'Runtime not initialized',
+        })
+        return
+    }
+    runtime.addDescriptor({
+        configKey: descriptor.configKey as any,
+        paneIdKey: descriptor.paneIdKey as any,
+        defaultConfig: descriptor.defaultConfig,
+        computeKey: descriptor.computeKey,
+        compute: createWorkerCompute(descriptor),
     })
 }
 
@@ -135,7 +163,11 @@ ctx.onmessage = (event: MessageEvent<IndicatorWorkerRequest>) => {
 
     switch (msg.type) {
         case 'init':
-            handleInit()
+            handleInit(msg)
+            break
+
+        case 'addDescriptor':
+            handleAddDescriptor(msg.descriptor)
             break
 
         case 'setData':

--- a/packages/core/src/engine/indicators/indicatorDefinitionRegistry.ts
+++ b/packages/core/src/engine/indicators/indicatorDefinitionRegistry.ts
@@ -16,7 +16,7 @@ export type IndicatorDefinitionConfig<T = unknown> = {
     category: IndicatorCategory
     stateKey: StateKey
     defaultPaneId: string
-    paneIdField?: keyof import('./workerProtocol').IndicatorConfigSnapshot
+    paneIdField?: string
     allowMainPane?: boolean
     scaleRendererFactory?: ScaleRendererFactory
     scale?: IndicatorMetadata['scale']

--- a/packages/core/src/engine/indicators/indicatorDefinitionRegistry.ts
+++ b/packages/core/src/engine/indicators/indicatorDefinitionRegistry.ts
@@ -5,6 +5,7 @@ import type {
     RendererFactory,
     ScaleRendererFactory,
     IndicatorConfigUpdater,
+    IndicatorRuntimeDescriptor,
 } from './indicatorMetadata'
 import type { PluginHost } from '../../plugin'
 
@@ -23,6 +24,7 @@ export type IndicatorDefinitionConfig<T = unknown> = {
     applyResult?: (host: PluginHost, state: unknown, paneId: string) => void
     mainPane?: IndicatorMetadata['mainPane']
     visibleState?: IndicatorMetadata['visibleState']
+    runtime?: IndicatorRuntimeDescriptor
     semantic?: IndicatorMetadata<T>['semantic']
 }
 

--- a/packages/core/src/engine/indicators/indicatorMetadata.ts
+++ b/packages/core/src/engine/indicators/indicatorMetadata.ts
@@ -7,6 +7,7 @@
 
 import type { PluginHost, RendererPluginWithHost } from '../../plugin'
 import type { IndicatorConfigSnapshot, IndicatorSeriesBundle } from './workerProtocol'
+import type { KLineData } from '../../types/price'
 
 export type IndicatorId = string
 
@@ -84,6 +85,27 @@ export interface IndicatorVisibleStateComposeContext {
 export type IndicatorVisibleStateComposer = (
     context: IndicatorVisibleStateComposeContext,
 ) => unknown
+
+/**
+ * 指标计算描述符
+ * 描述每个指标的计算逻辑，供 IndicatorRuntime 驱动
+ *
+ * - 主线程：直接调用 compute
+ * - Worker：用 computeKey 从 calculators 模块映射到实际函数
+ * - 自定义运行时指标：无 computeKey，仅主线程 inline 运行
+ */
+export interface IndicatorRuntimeDescriptor<C = any> {
+    /** configSnapshot 中的 key，通常等于 name（如 'macd'） */
+    configKey: keyof IndicatorConfigSnapshot
+    /** paneId 在 configSnapshot 中的 key（如 'macdPaneId'），可省略 */
+    paneIdKey?: keyof IndicatorConfigSnapshot
+    /** 默认配置值 */
+    defaultConfig: C
+    /** 计算函数（主线程直接调用，Worker 用 computeKey 桥接） */
+    compute: (data: KLineData[], config: C) => unknown
+    /** Worker 端计算键名，映射到 calculators 模块的导出 */
+    computeKey: string
+}
 
 /**
  * 指标元数据接口
@@ -189,6 +211,12 @@ export interface IndicatorMetadata<T = unknown> {
     visibleState?: {
         compose: IndicatorVisibleStateComposer
     }
+
+    /**
+     * 计算描述符（可选）
+     * 提供后，IndicatorRuntime 可据此自动调度计算，无需手写展开
+     */
+    runtime?: IndicatorRuntimeDescriptor
 
     /**
      * 语义配置应用入口。

--- a/packages/core/src/engine/indicators/indicatorMetadata.ts
+++ b/packages/core/src/engine/indicators/indicatorMetadata.ts
@@ -96,9 +96,9 @@ export type IndicatorVisibleStateComposer = (
  */
 export interface IndicatorRuntimeDescriptor<C = any> {
     /** configSnapshot 中的 key，通常等于 name（如 'macd'） */
-    configKey: keyof IndicatorConfigSnapshot
+    configKey: string
     /** paneId 在 configSnapshot 中的 key（如 'macdPaneId'），可省略 */
-    paneIdKey?: keyof IndicatorConfigSnapshot
+    paneIdKey?: string
     /** 默认配置值 */
     defaultConfig: C
     /** 计算函数（主线程直接调用，Worker 用 computeKey 桥接） */
@@ -143,7 +143,7 @@ export interface IndicatorMetadata<T = unknown> {
      * 在 configSnapshot 中的 paneId 字段名
      * 用于从配置中获取当前 pane ID
      */
-    paneIdField?: keyof IndicatorConfigSnapshot
+    paneIdField?: string
 
     /**
      * 渲染器工厂函数

--- a/packages/core/src/engine/indicators/indicatorRuntime.ts
+++ b/packages/core/src/engine/indicators/indicatorRuntime.ts
@@ -1,9 +1,3 @@
-/**
- * Indicator 纯计算运行时
- * 不依赖 PluginHost/StateStore，只负责计算和缓存
- * 可被主线程（inline fallback）或 Worker 使用
- */
-
 import type { KLineData } from '../../types/price'
 import {
     calcMAData,
@@ -46,401 +40,107 @@ import {
     calcZonesData,
     calcVolumeProfileData,
     DEFAULT_MA_PERIODS,
-    DEFAULT_ATR_PERIOD,
-    DEFAULT_VMA_PERIOD,
-    DEFAULT_STRUCTURE_LEFT,
-    DEFAULT_STRUCTURE_RIGHT,
-    DEFAULT_ZONES_OB_LOOKBACK,
-    DEFAULT_VP_BINS,
-    DEFAULT_VP_LOOKBACK,
-    DEFAULT_VP_VALUE_AREA,
-    DEFAULT_VWAP_SESSION_GAP_MS,
-    DEFAULT_CMF_PERIOD,
-    DEFAULT_MFI_PERIOD,
-    DEFAULT_FIB_PERIOD,
-    DEFAULT_WMA_PERIOD,
-    DEFAULT_DEMA_PERIOD,
-    DEFAULT_TEMA_PERIOD,
-    DEFAULT_HMA_PERIOD,
-    DEFAULT_KAMA_PERIOD,
-    DEFAULT_KAMA_FAST_PERIOD,
-    DEFAULT_KAMA_SLOW_PERIOD,
-    DEFAULT_SAR_STEP,
-    DEFAULT_SAR_MAX_STEP,
-    DEFAULT_SUPERTREND_ATR_PERIOD,
-    DEFAULT_SUPERTREND_MULTIPLIER,
-    DEFAULT_KELTNER_EMA_PERIOD,
-    DEFAULT_KELTNER_ATR_PERIOD,
-    DEFAULT_KELTNER_MULTIPLIER,
-    DEFAULT_DONCHIAN_PERIOD,
-    DEFAULT_ICHIMOKU_TENKAN,
-    DEFAULT_ICHIMOKU_KIJUN,
-    DEFAULT_ICHIMOKU_SPAN_B,
-    DEFAULT_ICHIMOKU_DISPLACEMENT,
-    DEFAULT_ROC_PERIOD,
-    DEFAULT_TRIX_PERIOD,
-    DEFAULT_TRIX_SIGNAL_PERIOD,
-    DEFAULT_HV_PERIOD,
-    DEFAULT_HV_ANNUALIZATION,
-    DEFAULT_PARKINSON_PERIOD,
-    DEFAULT_PARKINSON_ANNUALIZATION,
-    DEFAULT_CHAIKIN_VOL_EMA_PERIOD,
-    DEFAULT_CHAIKIN_VOL_ROC_PERIOD,
-    type MAFlags,
-    type BOLLPoint,
-    type EXPMAPoint,
-    type ENEPoint,
-    type STOCHPoint,
-    type KSTPoint,
-    type MACDPoint,
-    type SARPoint,
-    type SuperTrendPoint,
-    type KeltnerPoint,
-    type DonchianPoint,
-    type IchimokuPoint,
-    type PivotPoint,
-    type FibPoint,
-    type StructureSnapshot,
-    type Zone,
-    type VolumeProfileResult,
 } from './calculators'
-import type {
-    BOLLSchedulerConfig,
-    EXPMASchedulerConfig,
-    ENESchedulerConfig,
-    RSISchedulerConfig,
-    CCISchedulerConfig,
-    STOCHSchedulerConfig,
-    MOMSchedulerConfig,
-    WMSRSchedulerConfig,
-    KSTSchedulerConfig,
-    FASTKSchedulerConfig,
-    MACDSchedulerConfig,
-    ATRSchedulerConfig,
-    WMASchedulerConfig,
-    DEMASchedulerConfig,
-    TEMASchedulerConfig,
-    HMASchedulerConfig,
-    KAMASchedulerConfig,
-    SARSchedulerConfig,
-    SuperTrendSchedulerConfig,
-    KeltnerSchedulerConfig,
-    DonchianSchedulerConfig,
-    IchimokuSchedulerConfig,
-    ROCSchedulerConfig,
-    TRIXSchedulerConfig,
-    HVSchedulerConfig,
-    ParkinsonSchedulerConfig,
-    ChaikinVolSchedulerConfig,
-    VMASchedulerConfig,
-    OBVSchedulerConfig,
-    PVTSchedulerConfig,
-    VWAPSchedulerConfig,
-    CMFSchedulerConfig,
-    MFISchedulerConfig,
-    PivotSchedulerConfig,
-    FibSchedulerConfig,
-    StructureSchedulerConfig,
-    ZonesSchedulerConfig,
-    VolumeProfileSchedulerConfig,
-    IndicatorConfigSnapshot,
-    IndicatorSeriesBundle,
-} from './workerProtocol'
+import type { IndicatorRuntimeDescriptor } from './indicatorMetadata'
+import type { IndicatorConfigSnapshot, IndicatorSeriesBundle } from './workerProtocol'
 
-/**
- * 可见范围
- */
-interface VisibleRange {
-    start: number
-    end: number
+export const CALCULATOR_MAP: Record<string, (data: KLineData[], config: any) => unknown> = {
+    calcCCIData: (data, c) => calcCCIData(data, c.period),
+    calcMACDData: (data, c) => calcMACDData(data, c.fastPeriod, c.slowPeriod, c.signalPeriod),
+    calcMAData: (data, c) => {
+        const r: Record<number, (number | undefined)[]> = {}
+        for (const p of DEFAULT_MA_PERIODS) {
+            if ((c as any)['ma' + p]) r[p] = calcMAData(data, p)
+        }
+        return { series: r, enabledPeriods: Object.keys(r).map(Number) }
+    },
+    calcRSIData: (data, c) => {
+        const p = [c.period1, c.period2, c.period3]
+        const s = [c.showRSI1, c.showRSI2, c.showRSI3]
+        const r: Record<number, (number | undefined)[]> = {}
+        for (let i = 0; i < 3; i++) {
+            if (s[i]) r[p[i]] = calcRSIData(data, p[i])
+        }
+        return { series: r, enabledPeriods: Object.keys(r).map(Number) }
+    },
+    calcTRIXData: (data, c) => calcTRIXData(data, c.period, c.signalPeriod),
+    calcBOLLData: (data, c) => calcBOLLData(data, c.period, c.multiplier),
+    calcEXPMAData: (data, c) => calcEXPMAData(data, c.fastPeriod, c.slowPeriod),
+    calcENEData: (data, c) => calcENEData(data, c.period, c.deviation),
+    calcSTOCHData: (data, c) => calcSTOCHData(data, c.n, c.m),
+    calcMOMData: (data, c) => calcMOMData(data, c.period),
+    calcWMSRData: (data, c) => calcWMSRData(data, c.period),
+    calcKSTData: (data, c) => calcKSTData(data, c.roc1, c.roc2, c.roc3, c.roc4, c.signalPeriod),
+    calcFASTKData: (data, c) => calcFASTKData(data, c.period),
+    calcATRData: (data, c) => calcATRData(data, c.period),
+    calcWMAData: (data, c) => calcWMAData(data, c.period),
+    calcDEMAData: (data, c) => calcDEMAData(data, c.period),
+    calcTEMAData: (data, c) => calcTEMAData(data, c.period),
+    calcHMAData: (data, c) => calcHMAData(data, c.period),
+    calcKAMAData: (data, c) => calcKAMAData(data, c.period, c.fastPeriod, c.slowPeriod),
+    calcSARData: (data, c) => calcSARData(data, c.step, c.maxStep),
+    calcSuperTrendData: (data, c) => calcSuperTrendData(data, c.atrPeriod, c.multiplier),
+    calcKeltnerData: (data, c) => calcKeltnerData(data, c.emaPeriod, c.atrPeriod, c.multiplier),
+    calcDonchianData: (data, c) => calcDonchianData(data, c.period),
+    calcIchimokuData: (data, c) => calcIchimokuData(data, c.tenkanPeriod, c.kijunPeriod, c.spanBPeriod, c.displacement),
+    calcROCData: (data, c) => calcROCData(data, c.period),
+    calcHVData: (data, c) => calcHVData(data, c.period, c.annualizationFactor),
+    calcParkinsonData: (data, c) => calcParkinsonData(data, c.period, c.annualizationFactor),
+    calcChaikinVolData: (data, c) => calcChaikinVolData(data, c.emaPeriod, c.rocPeriod),
+    calcVMAData: (data, c) => calcVMAData(data, c.period),
+    calcOBVData: (data, c) => calcOBVData(data),
+    calcPVTData: (data, c) => calcPVTData(data),
+    calcVWAPData: (data, c) => calcVWAPData(data, c.sessionResetGapMs),
+    calcCMFData: (data, c) => calcCMFData(data, c.period),
+    calcMFIData: (data, c) => calcMFIData(data, c.period),
+    calcPivotData: (data, c) => calcPivotData(data),
+    calcFibData: (data, c) => calcFibData(data, c.period),
+    calcStructureData: (data, c) => calcStructureData(data, c.leftWindow, c.rightWindow, c.breakoutSource),
+    calcZonesData: (data, c) => calcZonesData(data, c.obLookback, 5, 2, 'close'),
+    calcVolumeProfileData: (data, c) => calcVolumeProfileData(data, c.bins, c.lookback, c.valueAreaPercent),
 }
 
-/**
- * 计算运行时
- * 管理数据、配置、缓存和脏标记
- */
+export function createWorkerCompute(descriptor: { computeKey: string }): (data: KLineData[], config: any) => unknown {
+    return CALCULATOR_MAP[descriptor.computeKey] ?? ((_data: KLineData[], _config: any) => {
+        console.warn(`[IndicatorRuntime] Unknown computeKey: ${descriptor.computeKey}`)
+        return []
+    })
+}
+
 export class IndicatorRuntime {
-    // 数据
     private currentData: KLineData[] = []
     private dataVersion = 0
-
-    // 配置
-    private config: IndicatorConfigSnapshot = this.getDefaultConfig()
     private configVersion = 0
+    private dataDirty = true
+    private configMap = new Map<string, any>()
+    private paneIdMap = new Map<string, string>()
+    private seriesMap = new Map<string, unknown>()
+    private dirtyFlags = new Map<string, boolean>()
+    private descriptorMap = new Map<string, IndicatorRuntimeDescriptor>()
 
-    // 缓存的 series
-    private cachedSeries: Record<number, (number | undefined)[]> = {}
-    private cachedBollSeries: BOLLPoint[] = []
-    private cachedExpmaSeries: EXPMAPoint[] = []
-    private cachedEneSeries: ENEPoint[] = []
-    private cachedRsiSeries: Record<number, (number | undefined)[]> = {}
-    private cachedCciSeries: (number | undefined)[] = []
-    private cachedStochSeries: STOCHPoint[] = []
-    private cachedMomSeries: (number | undefined)[] = []
-    private cachedWmsrSeries: (number | undefined)[] = []
-    private cachedKstSeries: KSTPoint[] = []
-    private cachedFastkSeries: (number | undefined)[] = []
-    private cachedMacdSeries: MACDPoint[] = []
-    private cachedAtrSeries: (number | undefined)[] = []
-    private cachedWmaSeries: (number | undefined)[] = []
-    private cachedDemaSeries: (number | undefined)[] = []
-    private cachedTemaSeries: (number | undefined)[] = []
-    private cachedHmaSeries: (number | undefined)[] = []
-    private cachedKamaSeries: (number | undefined)[] = []
-    private cachedSarSeries: (SARPoint | undefined)[] = []
-    private cachedSupertrendSeries: (SuperTrendPoint | undefined)[] = []
-    private cachedKeltnerSeries: (KeltnerPoint | undefined)[] = []
-    private cachedDonchianSeries: (DonchianPoint | undefined)[] = []
-    private cachedIchimokuSeries: (IchimokuPoint | undefined)[] = []
-    private cachedRocSeries: (number | undefined)[] = []
-    private cachedTrixSeries: (number | undefined)[] = []
-    private cachedTrixSignalSeries: (number | undefined)[] = []
-    private cachedHvSeries: (number | undefined)[] = []
-    private cachedParkinsonSeries: (number | undefined)[] = []
-    private cachedChaikinVolSeries: (number | undefined)[] = []
-    private cachedVmaSeries: (number | undefined)[] = []
-    private cachedObvSeries: (number | undefined)[] = []
-    private cachedPvtSeries: (number | undefined)[] = []
-    private cachedVwapSeries: (number | undefined)[] = []
-    private cachedCmfSeries: (number | undefined)[] = []
-    private cachedMfiSeries: (number | undefined)[] = []
-    private cachedPivotSeries: (PivotPoint | undefined)[] = []
-    private cachedFibSeries: (FibPoint | undefined)[] = []
-    private cachedStructureSeries: StructureSnapshot = { swings: [], events: [], trend: 'range' }
-    private cachedZonesSeries: Zone[] = []
-    private cachedVolumeProfileSeries: VolumeProfileResult = { bins: [], poc: 0, vah: 0, val: 0, totalVolume: 0 }
-
-    // 脏标记
-    private dirtyData = true
-    private dirtyMAConfig = true
-    private dirtyBollConfig = true
-    private dirtyExpmaConfig = true
-    private dirtyEneConfig = true
-    private dirtyRsiConfig = true
-    private dirtyCciConfig = true
-    private dirtyStochConfig = true
-    private dirtyMomConfig = true
-    private dirtyWmsrConfig = true
-    private dirtyKstConfig = true
-    private dirtyFastkConfig = true
-    private dirtyMacdConfig = true
-    private dirtyAtrConfig = true
-    private dirtyWmaConfig = true
-    private dirtyDemaConfig = true
-    private dirtyTemaConfig = true
-    private dirtyHmaConfig = true
-    private dirtyKamaConfig = true
-    private dirtySarConfig = true
-    private dirtySupertrendConfig = true
-    private dirtyKeltnerConfig = true
-    private dirtyDonchianConfig = true
-    private dirtyIchimokuConfig = true
-    private dirtyRocConfig = true
-    private dirtyTrixConfig = true
-    private dirtyHvConfig = true
-    private dirtyParkinsonConfig = true
-    private dirtyChaikinVolConfig = true
-    private dirtyVmaConfig = true
-    private dirtyObvConfig = true
-    private dirtyPvtConfig = true
-    private dirtyVwapConfig = true
-    private dirtyCmfConfig = true
-    private dirtyMfiConfig = true
-    private dirtyPivotConfig = true
-    private dirtyFibConfig = true
-    private dirtyStructureConfig = true
-    private dirtyZonesConfig = true
-    private dirtyVolumeProfileConfig = true
-
-    private getDefaultConfig(): IndicatorConfigSnapshot {
-        return {
-            ma: { ma5: true, ma10: true, ma20: true, ma30: true, ma60: true },
-            boll: {
-                period: 20,
-                multiplier: 2,
-                showUpper: true,
-                showMiddle: true,
-                showLower: true,
-                showBand: true,
-            },
-            expma: { fastPeriod: 12, slowPeriod: 50 },
-            ene: { period: 10, deviation: 11 },
-            rsi: {
-                period1: 6,
-                period2: 12,
-                period3: 24,
-                showRSI1: true,
-                showRSI2: true,
-                showRSI3: true,
-            },
-            cci: { period: 14, showCCI: true },
-            stoch: { n: 9, m: 3, showK: true, showD: true },
-            mom: { period: 10, showMOM: true },
-            wmsr: { period: 14, showWMSR: true },
-            kst: {
-                roc1: 10,
-                roc2: 15,
-                roc3: 20,
-                roc4: 30,
-                signalPeriod: 9,
-                showKST: true,
-                showSignal: true,
-            },
-            fastk: { period: 9, showFASTK: true },
-            macd: {
-                fastPeriod: 12,
-                slowPeriod: 26,
-                signalPeriod: 9,
-                showDIF: true,
-                showDEA: true,
-                showBAR: true,
-            },
-            atr: { period: DEFAULT_ATR_PERIOD, showATR: true },
-            wma: { period: DEFAULT_WMA_PERIOD, showWMA: true },
-            dema: { period: DEFAULT_DEMA_PERIOD, showDEMA: true },
-            tema: { period: DEFAULT_TEMA_PERIOD, showTEMA: true },
-            hma: { period: DEFAULT_HMA_PERIOD, showHMA: true },
-            kama: {
-                period: DEFAULT_KAMA_PERIOD,
-                fastPeriod: DEFAULT_KAMA_FAST_PERIOD,
-                slowPeriod: DEFAULT_KAMA_SLOW_PERIOD,
-                showKAMA: true,
-            },
-            sar: { step: DEFAULT_SAR_STEP, maxStep: DEFAULT_SAR_MAX_STEP, showSAR: true },
-            supertrend: {
-                atrPeriod: DEFAULT_SUPERTREND_ATR_PERIOD,
-                multiplier: DEFAULT_SUPERTREND_MULTIPLIER,
-                showSuperTrend: true,
-            },
-            keltner: {
-                emaPeriod: DEFAULT_KELTNER_EMA_PERIOD,
-                atrPeriod: DEFAULT_KELTNER_ATR_PERIOD,
-                multiplier: DEFAULT_KELTNER_MULTIPLIER,
-                showUpper: true,
-                showMiddle: true,
-                showLower: true,
-            },
-            donchian: {
-                period: DEFAULT_DONCHIAN_PERIOD,
-                showUpper: true,
-                showMiddle: true,
-                showLower: true,
-            },
-            ichimoku: {
-                tenkanPeriod: DEFAULT_ICHIMOKU_TENKAN,
-                kijunPeriod: DEFAULT_ICHIMOKU_KIJUN,
-                spanBPeriod: DEFAULT_ICHIMOKU_SPAN_B,
-                displacement: DEFAULT_ICHIMOKU_DISPLACEMENT,
-                showTenkan: true,
-                showKijun: true,
-                showSpanA: true,
-                showSpanB: true,
-                showCloud: true,
-                showChikou: true,
-            },
-            roc: { period: DEFAULT_ROC_PERIOD, showROC: true },
-            trix: {
-                period: DEFAULT_TRIX_PERIOD,
-                signalPeriod: DEFAULT_TRIX_SIGNAL_PERIOD,
-                showTRIX: true,
-                showSignal: true,
-            },
-            hv: {
-                period: DEFAULT_HV_PERIOD,
-                annualizationFactor: DEFAULT_HV_ANNUALIZATION,
-                showHV: true,
-            },
-            parkinson: {
-                period: DEFAULT_PARKINSON_PERIOD,
-                annualizationFactor: DEFAULT_PARKINSON_ANNUALIZATION,
-                showParkinson: true,
-            },
-            chaikinVol: {
-                emaPeriod: DEFAULT_CHAIKIN_VOL_EMA_PERIOD,
-                rocPeriod: DEFAULT_CHAIKIN_VOL_ROC_PERIOD,
-                showChaikinVol: true,
-            },
-            vma: { period: DEFAULT_VMA_PERIOD, showVMA: true },
-            obv: { showOBV: true },
-            pvt: { showPVT: true },
-            vwap: { sessionResetGapMs: DEFAULT_VWAP_SESSION_GAP_MS, showVWAP: true },
-            cmf: { period: DEFAULT_CMF_PERIOD, showCMF: true },
-            mfi: { period: DEFAULT_MFI_PERIOD, showMFI: true },
-            pivot: { showPP: true, showR1: true, showR2: true, showR3: false, showS1: true, showS2: true, showS3: false },
-            fib: { period: DEFAULT_FIB_PERIOD, showLevels: true },
-            structure: {
-                leftWindow: DEFAULT_STRUCTURE_LEFT,
-                rightWindow: DEFAULT_STRUCTURE_RIGHT,
-                breakoutSource: 'close',
-                showSwingLabels: true,
-                showBOS: true,
-                showCHOCH: true,
-                showProvisional: false,
-            },
-            zones: {
-                showFVG: true,
-                showOB: true,
-                showFilledZones: false,
-                obLookback: DEFAULT_ZONES_OB_LOOKBACK,
-            },
-            volumeProfile: {
-                bins: DEFAULT_VP_BINS,
-                lookback: DEFAULT_VP_LOOKBACK,
-                valueAreaPercent: DEFAULT_VP_VALUE_AREA,
-                showPOC: true,
-                showValueArea: true,
-            },
-            rsiPaneId: 'sub_RSI',
-            cciPaneId: 'sub_CCI',
-            stochPaneId: 'sub_STOCH',
-            momPaneId: 'sub_MOM',
-            wmsrPaneId: 'sub_WMSR',
-            kstPaneId: 'sub_KST',
-            fastkPaneId: 'sub_FASTK',
-            macdPaneId: 'sub_MACD',
-            atrPaneId: 'sub_ATR',
-            wmaPaneId: 'sub_WMA',
-            demaPaneId: 'sub_DEMA',
-            temaPaneId: 'sub_TEMA',
-            hmaPaneId: 'sub_HMA',
-            kamaPaneId: 'sub_KAMA',
-            sarPaneId: 'sub_SAR',
-            supertrendPaneId: 'sub_SuperTrend',
-            keltnerPaneId: 'sub_Keltner',
-            donchianPaneId: 'sub_Donchian',
-            ichimokuPaneId: 'sub_Ichimoku',
-            rocPaneId: 'sub_ROC',
-            trixPaneId: 'sub_TRIX',
-            hvPaneId: 'sub_HV',
-            parkinsonPaneId: 'sub_Parkinson',
-            chaikinVolPaneId: 'sub_ChaikinVol',
-            vmaPaneId: 'sub_VMA',
-            obvPaneId: 'sub_OBV',
-            pvtPaneId: 'sub_PVT',
-            vwapPaneId: 'sub_VWAP',
-            cmfPaneId: 'sub_CMF',
-            mfiPaneId: 'sub_MFI',
-            pivotPaneId: 'sub_Pivot',
-            fibPaneId: 'sub_Fib',
-            structurePaneId: 'sub_Structure',
-            zonesPaneId: 'sub_Zones',
-            volumeProfilePaneId: 'sub_VolumeProfile',
+    constructor(descriptors: IndicatorRuntimeDescriptor[] = []) {
+        for (const d of descriptors) {
+            this.addDescriptor(d)
         }
     }
 
-    /**
-     * 更新数据
-     */
-    setData(data: KLineData[], version: number): void {
-        if (this.dataVersion === version && !this.dirtyData) return
-        this.currentData = data
-        this.dataVersion = version
-        this.dirtyData = true
+    addDescriptor(d: IndicatorRuntimeDescriptor): void {
+        if (this.descriptorMap.has(d.configKey as string)) return
+        this.descriptorMap.set(d.configKey as string, d)
+        const def = typeof d.defaultConfig === 'function'
+            ? (d.defaultConfig as () => any)()
+            : d.defaultConfig
+        this.configMap.set(d.configKey as string, { ...def })
+        this.dirtyFlags.set(d.configKey as string, true)
     }
 
-    /**
-     * 更新配置
-     */
+    setData(data: KLineData[], version: number): void {
+        if (this.dataVersion === version && !this.dataDirty) return
+        this.currentData = data
+        this.dataVersion = version
+        this.dataDirty = true
+    }
+
     private shallowEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
         const keysA = Object.keys(a)
         const keysB = Object.keys(b)
@@ -451,1098 +151,80 @@ export class IndicatorRuntime {
         return true
     }
 
-    /**
-     * 更新配置（仅值变更时才设置脏标记）
-     */
     setConfig(config: Partial<IndicatorConfigSnapshot>, version: number): void {
-        // 合并配置（仅值变更时才标记脏）
-        if (config.ma !== undefined && !this.shallowEqual(config.ma as unknown as Record<string, unknown>, this.config.ma as unknown as Record<string, unknown>)) {
-            this.config.ma = { ...this.config.ma, ...config.ma }
-            this.dirtyMAConfig = true
+        for (const [key, value] of Object.entries(config)) {
+            if (value === undefined) continue
+            const desc = this.descriptorMap.get(key)
+            if (desc) {
+                const current = this.configMap.get(key)
+                if (!current || !this.shallowEqual(value as Record<string, unknown>, current as Record<string, unknown>)) {
+                    this.configMap.set(key, { ...(current ?? {}), ...(value as any) })
+                    this.dirtyFlags.set(key, true)
+                }
+                continue
+            }
+            if (typeof value === 'string') {
+                for (const d of this.descriptorMap.values()) {
+                    if (d.paneIdKey === key) {
+                        this.paneIdMap.set(key, value)
+                        break
+                    }
+                }
+            }
         }
-        if (config.boll !== undefined && !this.shallowEqual(config.boll as unknown as Record<string, unknown>, this.config.boll as unknown as Record<string, unknown>)) {
-            this.config.boll = { ...this.config.boll, ...config.boll }
-            this.dirtyBollConfig = true
-        }
-        if (config.expma !== undefined && !this.shallowEqual(config.expma as unknown as Record<string, unknown>, this.config.expma as unknown as Record<string, unknown>)) {
-            this.config.expma = { ...this.config.expma, ...config.expma }
-            this.dirtyExpmaConfig = true
-        }
-        if (config.ene !== undefined && !this.shallowEqual(config.ene as unknown as Record<string, unknown>, this.config.ene as unknown as Record<string, unknown>)) {
-            this.config.ene = { ...this.config.ene, ...config.ene }
-            this.dirtyEneConfig = true
-        }
-        if (config.rsi !== undefined && !this.shallowEqual(config.rsi as unknown as Record<string, unknown>, this.config.rsi as unknown as Record<string, unknown>)) {
-            this.config.rsi = { ...this.config.rsi, ...config.rsi }
-            this.dirtyRsiConfig = true
-        }
-        if (config.cci !== undefined && !this.shallowEqual(config.cci as unknown as Record<string, unknown>, this.config.cci as unknown as Record<string, unknown>)) {
-            this.config.cci = { ...this.config.cci, ...config.cci }
-            this.dirtyCciConfig = true
-        }
-        if (config.stoch !== undefined && !this.shallowEqual(config.stoch as unknown as Record<string, unknown>, this.config.stoch as unknown as Record<string, unknown>)) {
-            this.config.stoch = { ...this.config.stoch, ...config.stoch }
-            this.dirtyStochConfig = true
-        }
-        if (config.mom !== undefined && !this.shallowEqual(config.mom as unknown as Record<string, unknown>, this.config.mom as unknown as Record<string, unknown>)) {
-            this.config.mom = { ...this.config.mom, ...config.mom }
-            this.dirtyMomConfig = true
-        }
-        if (config.wmsr !== undefined && !this.shallowEqual(config.wmsr as unknown as Record<string, unknown>, this.config.wmsr as unknown as Record<string, unknown>)) {
-            this.config.wmsr = { ...this.config.wmsr, ...config.wmsr }
-            this.dirtyWmsrConfig = true
-        }
-        if (config.kst !== undefined && !this.shallowEqual(config.kst as unknown as Record<string, unknown>, this.config.kst as unknown as Record<string, unknown>)) {
-            this.config.kst = { ...this.config.kst, ...config.kst }
-            this.dirtyKstConfig = true
-        }
-        if (config.fastk !== undefined && !this.shallowEqual(config.fastk as unknown as Record<string, unknown>, this.config.fastk as unknown as Record<string, unknown>)) {
-            this.config.fastk = { ...this.config.fastk, ...config.fastk }
-            this.dirtyFastkConfig = true
-        }
-        if (config.macd !== undefined && !this.shallowEqual(config.macd as unknown as Record<string, unknown>, this.config.macd as unknown as Record<string, unknown>)) {
-            this.config.macd = { ...this.config.macd, ...config.macd }
-            this.dirtyMacdConfig = true
-        }
-        if (config.atr !== undefined && !this.shallowEqual(config.atr as unknown as Record<string, unknown>, this.config.atr as unknown as Record<string, unknown>)) {
-            this.config.atr = { ...this.config.atr, ...config.atr }
-            this.dirtyAtrConfig = true
-        }
-        if (config.wma !== undefined && !this.shallowEqual(config.wma as unknown as Record<string, unknown>, this.config.wma as unknown as Record<string, unknown>)) {
-            this.config.wma = { ...this.config.wma, ...config.wma }
-            this.dirtyWmaConfig = true
-        }
-        if (config.dema !== undefined && !this.shallowEqual(config.dema as unknown as Record<string, unknown>, this.config.dema as unknown as Record<string, unknown>)) {
-            this.config.dema = { ...this.config.dema, ...config.dema }
-            this.dirtyDemaConfig = true
-        }
-        if (config.tema !== undefined && !this.shallowEqual(config.tema as unknown as Record<string, unknown>, this.config.tema as unknown as Record<string, unknown>)) {
-            this.config.tema = { ...this.config.tema, ...config.tema }
-            this.dirtyTemaConfig = true
-        }
-        if (config.hma !== undefined && !this.shallowEqual(config.hma as unknown as Record<string, unknown>, this.config.hma as unknown as Record<string, unknown>)) {
-            this.config.hma = { ...this.config.hma, ...config.hma }
-            this.dirtyHmaConfig = true
-        }
-        if (config.kama !== undefined && !this.shallowEqual(config.kama as unknown as Record<string, unknown>, this.config.kama as unknown as Record<string, unknown>)) {
-            this.config.kama = { ...this.config.kama, ...config.kama }
-            this.dirtyKamaConfig = true
-        }
-        if (config.sar !== undefined && !this.shallowEqual(config.sar as unknown as Record<string, unknown>, this.config.sar as unknown as Record<string, unknown>)) {
-            this.config.sar = { ...this.config.sar, ...config.sar }
-            this.dirtySarConfig = true
-        }
-        if (config.supertrend !== undefined && !this.shallowEqual(config.supertrend as unknown as Record<string, unknown>, this.config.supertrend as unknown as Record<string, unknown>)) {
-            this.config.supertrend = { ...this.config.supertrend, ...config.supertrend }
-            this.dirtySupertrendConfig = true
-        }
-        if (config.keltner !== undefined && !this.shallowEqual(config.keltner as unknown as Record<string, unknown>, this.config.keltner as unknown as Record<string, unknown>)) {
-            this.config.keltner = { ...this.config.keltner, ...config.keltner }
-            this.dirtyKeltnerConfig = true
-        }
-        if (config.donchian !== undefined && !this.shallowEqual(config.donchian as unknown as Record<string, unknown>, this.config.donchian as unknown as Record<string, unknown>)) {
-            this.config.donchian = { ...this.config.donchian, ...config.donchian }
-            this.dirtyDonchianConfig = true
-        }
-        if (config.ichimoku !== undefined && !this.shallowEqual(config.ichimoku as unknown as Record<string, unknown>, this.config.ichimoku as unknown as Record<string, unknown>)) {
-            this.config.ichimoku = { ...this.config.ichimoku, ...config.ichimoku }
-            this.dirtyIchimokuConfig = true
-        }
-        if (config.roc !== undefined && !this.shallowEqual(config.roc as unknown as Record<string, unknown>, this.config.roc as unknown as Record<string, unknown>)) {
-            this.config.roc = { ...this.config.roc, ...config.roc }
-            this.dirtyRocConfig = true
-        }
-        if (config.trix !== undefined && !this.shallowEqual(config.trix as unknown as Record<string, unknown>, this.config.trix as unknown as Record<string, unknown>)) {
-            this.config.trix = { ...this.config.trix, ...config.trix }
-            this.dirtyTrixConfig = true
-        }
-        if (config.hv !== undefined && !this.shallowEqual(config.hv as unknown as Record<string, unknown>, this.config.hv as unknown as Record<string, unknown>)) {
-            this.config.hv = { ...this.config.hv, ...config.hv }
-            this.dirtyHvConfig = true
-        }
-        if (config.parkinson !== undefined && !this.shallowEqual(config.parkinson as unknown as Record<string, unknown>, this.config.parkinson as unknown as Record<string, unknown>)) {
-            this.config.parkinson = { ...this.config.parkinson, ...config.parkinson }
-            this.dirtyParkinsonConfig = true
-        }
-        if (config.chaikinVol !== undefined && !this.shallowEqual(config.chaikinVol as unknown as Record<string, unknown>, this.config.chaikinVol as unknown as Record<string, unknown>)) {
-            this.config.chaikinVol = { ...this.config.chaikinVol, ...config.chaikinVol }
-            this.dirtyChaikinVolConfig = true
-        }
-        if (config.vma !== undefined && !this.shallowEqual(config.vma as unknown as Record<string, unknown>, this.config.vma as unknown as Record<string, unknown>)) {
-            this.config.vma = { ...this.config.vma, ...config.vma }
-            this.dirtyVmaConfig = true
-        }
-        if (config.obv !== undefined && !this.shallowEqual(config.obv as unknown as Record<string, unknown>, this.config.obv as unknown as Record<string, unknown>)) {
-            this.config.obv = { ...this.config.obv, ...config.obv }
-            this.dirtyObvConfig = true
-        }
-        if (config.pvt !== undefined && !this.shallowEqual(config.pvt as unknown as Record<string, unknown>, this.config.pvt as unknown as Record<string, unknown>)) {
-            this.config.pvt = { ...this.config.pvt, ...config.pvt }
-            this.dirtyPvtConfig = true
-        }
-        if (config.vwap !== undefined && !this.shallowEqual(config.vwap as unknown as Record<string, unknown>, this.config.vwap as unknown as Record<string, unknown>)) {
-            this.config.vwap = { ...this.config.vwap, ...config.vwap }
-            this.dirtyVwapConfig = true
-        }
-        if (config.cmf !== undefined && !this.shallowEqual(config.cmf as unknown as Record<string, unknown>, this.config.cmf as unknown as Record<string, unknown>)) {
-            this.config.cmf = { ...this.config.cmf, ...config.cmf }
-            this.dirtyCmfConfig = true
-        }
-        if (config.mfi !== undefined && !this.shallowEqual(config.mfi as unknown as Record<string, unknown>, this.config.mfi as unknown as Record<string, unknown>)) {
-            this.config.mfi = { ...this.config.mfi, ...config.mfi }
-            this.dirtyMfiConfig = true
-        }
-        if (config.pivot !== undefined && !this.shallowEqual(config.pivot as unknown as Record<string, unknown>, this.config.pivot as unknown as Record<string, unknown>)) {
-            this.config.pivot = { ...this.config.pivot, ...config.pivot }
-            this.dirtyPivotConfig = true
-        }
-        if (config.fib !== undefined && !this.shallowEqual(config.fib as unknown as Record<string, unknown>, this.config.fib as unknown as Record<string, unknown>)) {
-            this.config.fib = { ...this.config.fib, ...config.fib }
-            this.dirtyFibConfig = true
-        }
-        if (config.structure !== undefined && !this.shallowEqual(config.structure as unknown as Record<string, unknown>, this.config.structure as unknown as Record<string, unknown>)) {
-            this.config.structure = { ...this.config.structure, ...config.structure }
-            this.dirtyStructureConfig = true
-        }
-        if (config.zones !== undefined && !this.shallowEqual(config.zones as unknown as Record<string, unknown>, this.config.zones as unknown as Record<string, unknown>)) {
-            this.config.zones = { ...this.config.zones, ...config.zones }
-            this.dirtyZonesConfig = true
-        }
-        if (config.volumeProfile !== undefined && !this.shallowEqual(config.volumeProfile as unknown as Record<string, unknown>, this.config.volumeProfile as unknown as Record<string, unknown>)) {
-            this.config.volumeProfile = { ...this.config.volumeProfile, ...config.volumeProfile }
-            this.dirtyVolumeProfileConfig = true
-        }
-        // pane IDs
-        if (config.rsiPaneId !== undefined) this.config.rsiPaneId = config.rsiPaneId
-        if (config.cciPaneId !== undefined) this.config.cciPaneId = config.cciPaneId
-        if (config.stochPaneId !== undefined) this.config.stochPaneId = config.stochPaneId
-        if (config.momPaneId !== undefined) this.config.momPaneId = config.momPaneId
-        if (config.wmsrPaneId !== undefined) this.config.wmsrPaneId = config.wmsrPaneId
-        if (config.kstPaneId !== undefined) this.config.kstPaneId = config.kstPaneId
-        if (config.fastkPaneId !== undefined) this.config.fastkPaneId = config.fastkPaneId
-        if (config.macdPaneId !== undefined) this.config.macdPaneId = config.macdPaneId
-        if (config.atrPaneId !== undefined) this.config.atrPaneId = config.atrPaneId
-        if (config.wmaPaneId !== undefined) this.config.wmaPaneId = config.wmaPaneId
-        if (config.demaPaneId !== undefined) this.config.demaPaneId = config.demaPaneId
-        if (config.temaPaneId !== undefined) this.config.temaPaneId = config.temaPaneId
-        if (config.hmaPaneId !== undefined) this.config.hmaPaneId = config.hmaPaneId
-        if (config.kamaPaneId !== undefined) this.config.kamaPaneId = config.kamaPaneId
-        if (config.sarPaneId !== undefined) this.config.sarPaneId = config.sarPaneId
-        if (config.supertrendPaneId !== undefined) this.config.supertrendPaneId = config.supertrendPaneId
-        if (config.keltnerPaneId !== undefined) this.config.keltnerPaneId = config.keltnerPaneId
-        if (config.donchianPaneId !== undefined) this.config.donchianPaneId = config.donchianPaneId
-        if (config.ichimokuPaneId !== undefined) this.config.ichimokuPaneId = config.ichimokuPaneId
-        if (config.rocPaneId !== undefined) this.config.rocPaneId = config.rocPaneId
-        if (config.trixPaneId !== undefined) this.config.trixPaneId = config.trixPaneId
-        if (config.hvPaneId !== undefined) this.config.hvPaneId = config.hvPaneId
-        if (config.parkinsonPaneId !== undefined) this.config.parkinsonPaneId = config.parkinsonPaneId
-        if (config.chaikinVolPaneId !== undefined) this.config.chaikinVolPaneId = config.chaikinVolPaneId
-        if (config.vmaPaneId !== undefined) this.config.vmaPaneId = config.vmaPaneId
-        if (config.obvPaneId !== undefined) this.config.obvPaneId = config.obvPaneId
-        if (config.pvtPaneId !== undefined) this.config.pvtPaneId = config.pvtPaneId
-        if (config.vwapPaneId !== undefined) this.config.vwapPaneId = config.vwapPaneId
-        if (config.cmfPaneId !== undefined) this.config.cmfPaneId = config.cmfPaneId
-        if (config.mfiPaneId !== undefined) this.config.mfiPaneId = config.mfiPaneId
-        if (config.pivotPaneId !== undefined) this.config.pivotPaneId = config.pivotPaneId
-        if (config.fibPaneId !== undefined) this.config.fibPaneId = config.fibPaneId
-        if (config.structurePaneId !== undefined) this.config.structurePaneId = config.structurePaneId
-        if (config.zonesPaneId !== undefined) this.config.zonesPaneId = config.zonesPaneId
-        if (config.volumeProfilePaneId !== undefined) this.config.volumeProfilePaneId = config.volumeProfilePaneId
-
         this.configVersion = version
     }
 
-    /**
-     * 强制所有指标标记为脏（用于 recompute）
-     */
     forceDirty(): void {
-        this.dirtyData = true
-        this.dirtyMAConfig = true
-        this.dirtyBollConfig = true
-        this.dirtyExpmaConfig = true
-        this.dirtyEneConfig = true
-        this.dirtyRsiConfig = true
-        this.dirtyCciConfig = true
-        this.dirtyStochConfig = true
-        this.dirtyMomConfig = true
-        this.dirtyWmsrConfig = true
-        this.dirtyKstConfig = true
-        this.dirtyFastkConfig = true
-        this.dirtyMacdConfig = true
-        this.dirtyAtrConfig = true
-        this.dirtyWmaConfig = true
-        this.dirtyDemaConfig = true
-        this.dirtyTemaConfig = true
-        this.dirtyHmaConfig = true
-        this.dirtyKamaConfig = true
-        this.dirtySarConfig = true
-        this.dirtySupertrendConfig = true
-        this.dirtyKeltnerConfig = true
-        this.dirtyDonchianConfig = true
-        this.dirtyIchimokuConfig = true
-        this.dirtyRocConfig = true
-        this.dirtyTrixConfig = true
-        this.dirtyHvConfig = true
-        this.dirtyParkinsonConfig = true
-        this.dirtyChaikinVolConfig = true
-        this.dirtyVmaConfig = true
-        this.dirtyObvConfig = true
-        this.dirtyPvtConfig = true
-        this.dirtyVwapConfig = true
-        this.dirtyCmfConfig = true
-        this.dirtyMfiConfig = true
-        this.dirtyPivotConfig = true
-        this.dirtyFibConfig = true
-        this.dirtyStructureConfig = true
-        this.dirtyZonesConfig = true
-        this.dirtyVolumeProfileConfig = true
+        this.dataDirty = true
+        for (const key of this.dirtyFlags.keys()) {
+            this.dirtyFlags.set(key, true)
+        }
     }
 
-    /**
-     * 获取当前数据版本
-     */
     getDataVersion(): number {
         return this.dataVersion
     }
 
-    /**
-     * 获取当前配置版本
-     */
     getConfigVersion(): number {
         return this.configVersion
     }
 
-    /**
-     * 计算所有指标的 series（如果脏了）
-     * 返回结果包，供主线程组装成 render states
-     */
     computeSeries(): IndicatorSeriesBundle {
         const data = this.currentData
         const changed: string[] = []
 
-        // MA
-        if (this.dirtyData || this.dirtyMAConfig) {
-            this.cachedSeries = {}
-            for (const period of DEFAULT_MA_PERIODS) {
-                const flagKey = `ma${period}` as keyof MAFlags
-                if (this.config.ma[flagKey]) {
-                    this.cachedSeries[period] = calcMAData(data, period)
+        for (const [configKey, desc] of this.descriptorMap) {
+            if (this.dataDirty || this.dirtyFlags.get(configKey)) {
+                const config = this.configMap.get(configKey)
+                this.seriesMap.set(configKey, desc.compute(data, config))
+                changed.push(configKey)
+            }
+        }
+
+        this.dataDirty = false
+        for (const key of this.dirtyFlags.keys()) {
+            this.dirtyFlags.set(key, false)
+        }
+
+        const bundle: Record<string, unknown> = { _changed: changed }
+        for (const [configKey] of this.descriptorMap) {
+            const raw = this.seriesMap.get(configKey)
+            const params = { ...(this.configMap.get(configKey) ?? {}) }
+            const entry: Record<string, unknown> = {}
+
+            if (raw && typeof raw === 'object' && 'series' in (raw as Record<string, unknown>)) {
+                Object.assign(entry, raw as Record<string, unknown>)
+            } else {
+                entry.series = raw
+                if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+                    entry.enabledPeriods = Object.keys(raw).map(Number)
                 }
             }
-            changed.push('ma')
+            entry.params = params
+            bundle[configKey] = entry
         }
 
-        // BOLL
-        if (this.dirtyData || this.dirtyBollConfig) {
-            this.cachedBollSeries = calcBOLLData(
-                data,
-                this.config.boll.period,
-                this.config.boll.multiplier
-            )
-            changed.push('boll')
-        }
-
-        // EXPMA
-        if (this.dirtyData || this.dirtyExpmaConfig) {
-            this.cachedExpmaSeries = calcEXPMAData(
-                data,
-                this.config.expma.fastPeriod,
-                this.config.expma.slowPeriod
-            )
-            changed.push('expma')
-        }
-
-        // ENE
-        if (this.dirtyData || this.dirtyEneConfig) {
-            this.cachedEneSeries = calcENEData(
-                data,
-                this.config.ene.period,
-                this.config.ene.deviation
-            )
-            changed.push('ene')
-        }
-
-        // RSI
-        if (this.dirtyData || this.dirtyRsiConfig) {
-            this.cachedRsiSeries = {}
-            const periods = [this.config.rsi.period1, this.config.rsi.period2, this.config.rsi.period3]
-            const shows = [this.config.rsi.showRSI1, this.config.rsi.showRSI2, this.config.rsi.showRSI3]
-            for (let i = 0; i < periods.length; i++) {
-                if (shows[i]) {
-                    this.cachedRsiSeries[periods[i]] = calcRSIData(data, periods[i])
-                }
-            }
-            changed.push('rsi')
-        }
-
-        // CCI
-        if (this.dirtyData || this.dirtyCciConfig) {
-            if (this.config.cci.showCCI) {
-                this.cachedCciSeries = calcCCIData(data, this.config.cci.period)
-            } else {
-                this.cachedCciSeries = []
-            }
-            changed.push('cci')
-        }
-
-        // STOCH
-        if (this.dirtyData || this.dirtyStochConfig) {
-            if (this.config.stoch.showK || this.config.stoch.showD) {
-                this.cachedStochSeries = calcSTOCHData(data, this.config.stoch.n, this.config.stoch.m)
-            } else {
-                this.cachedStochSeries = []
-            }
-            changed.push('stoch')
-        }
-
-        // MOM
-        if (this.dirtyData || this.dirtyMomConfig) {
-            if (this.config.mom.showMOM) {
-                this.cachedMomSeries = calcMOMData(data, this.config.mom.period)
-            } else {
-                this.cachedMomSeries = []
-            }
-            changed.push('mom')
-        }
-
-        // WMSR
-        if (this.dirtyData || this.dirtyWmsrConfig) {
-            if (this.config.wmsr.showWMSR) {
-                this.cachedWmsrSeries = calcWMSRData(data, this.config.wmsr.period)
-            } else {
-                this.cachedWmsrSeries = []
-            }
-            changed.push('wmsr')
-        }
-
-        // KST
-        if (this.dirtyData || this.dirtyKstConfig) {
-            if (this.config.kst.showKST || this.config.kst.showSignal) {
-                this.cachedKstSeries = calcKSTData(
-                    data,
-                    this.config.kst.roc1,
-                    this.config.kst.roc2,
-                    this.config.kst.roc3,
-                    this.config.kst.roc4,
-                    this.config.kst.signalPeriod
-                )
-            } else {
-                this.cachedKstSeries = []
-            }
-            changed.push('kst')
-        }
-
-        // FASTK
-        if (this.dirtyData || this.dirtyFastkConfig) {
-            if (this.config.fastk.showFASTK) {
-                this.cachedFastkSeries = calcFASTKData(data, this.config.fastk.period)
-            } else {
-                this.cachedFastkSeries = []
-            }
-            changed.push('fastk')
-        }
-
-        // MACD
-        if (this.dirtyData || this.dirtyMacdConfig) {
-            if (this.config.macd.showDIF || this.config.macd.showDEA || this.config.macd.showBAR) {
-                this.cachedMacdSeries = calcMACDData(
-                    data,
-                    this.config.macd.fastPeriod,
-                    this.config.macd.slowPeriod,
-                    this.config.macd.signalPeriod
-                )
-            } else {
-                this.cachedMacdSeries = []
-            }
-            changed.push('macd')
-        }
-
-        // ATR
-        if (this.dirtyData || this.dirtyAtrConfig) {
-            if (this.config.atr.showATR) {
-                this.cachedAtrSeries = calcATRData(data, this.config.atr.period)
-            } else {
-                this.cachedAtrSeries = []
-            }
-            changed.push('atr')
-        }
-
-        // WMA
-        if (this.dirtyData || this.dirtyWmaConfig) {
-            if (this.config.wma.showWMA) {
-                this.cachedWmaSeries = calcWMAData(data, this.config.wma.period)
-            } else {
-                this.cachedWmaSeries = []
-            }
-            changed.push('wma')
-        }
-
-        // DEMA
-        if (this.dirtyData || this.dirtyDemaConfig) {
-            if (this.config.dema.showDEMA) {
-                this.cachedDemaSeries = calcDEMAData(data, this.config.dema.period)
-            } else {
-                this.cachedDemaSeries = []
-            }
-            changed.push('dema')
-        }
-
-        // TEMA
-        if (this.dirtyData || this.dirtyTemaConfig) {
-            if (this.config.tema.showTEMA) {
-                this.cachedTemaSeries = calcTEMAData(data, this.config.tema.period)
-            } else {
-                this.cachedTemaSeries = []
-            }
-            changed.push('tema')
-        }
-
-        // HMA
-        if (this.dirtyData || this.dirtyHmaConfig) {
-            if (this.config.hma.showHMA) {
-                this.cachedHmaSeries = calcHMAData(data, this.config.hma.period)
-            } else {
-                this.cachedHmaSeries = []
-            }
-            changed.push('hma')
-        }
-
-        // KAMA
-        if (this.dirtyData || this.dirtyKamaConfig) {
-            if (this.config.kama.showKAMA) {
-                this.cachedKamaSeries = calcKAMAData(
-                    data,
-                    this.config.kama.period,
-                    this.config.kama.fastPeriod,
-                    this.config.kama.slowPeriod,
-                )
-            } else {
-                this.cachedKamaSeries = []
-            }
-            changed.push('kama')
-        }
-
-        // SAR
-        if (this.dirtyData || this.dirtySarConfig) {
-            if (this.config.sar.showSAR) {
-                this.cachedSarSeries = calcSARData(
-                    data,
-                    this.config.sar.step,
-                    this.config.sar.maxStep,
-                )
-            } else {
-                this.cachedSarSeries = []
-            }
-            changed.push('sar')
-        }
-
-        // SuperTrend
-        if (this.dirtyData || this.dirtySupertrendConfig) {
-            if (this.config.supertrend.showSuperTrend) {
-                this.cachedSupertrendSeries = calcSuperTrendData(
-                    data,
-                    this.config.supertrend.atrPeriod,
-                    this.config.supertrend.multiplier,
-                )
-            } else {
-                this.cachedSupertrendSeries = []
-            }
-            changed.push('supertrend')
-        }
-
-        // Keltner
-        if (this.dirtyData || this.dirtyKeltnerConfig) {
-            if (this.config.keltner.showUpper || this.config.keltner.showMiddle || this.config.keltner.showLower) {
-                this.cachedKeltnerSeries = calcKeltnerData(
-                    data,
-                    this.config.keltner.emaPeriod,
-                    this.config.keltner.atrPeriod,
-                    this.config.keltner.multiplier,
-                )
-            } else {
-                this.cachedKeltnerSeries = []
-            }
-            changed.push('keltner')
-        }
-
-        // Donchian
-        if (this.dirtyData || this.dirtyDonchianConfig) {
-            if (this.config.donchian.showUpper || this.config.donchian.showMiddle || this.config.donchian.showLower) {
-                this.cachedDonchianSeries = calcDonchianData(data, this.config.donchian.period)
-            } else {
-                this.cachedDonchianSeries = []
-            }
-            changed.push('donchian')
-        }
-
-        // Ichimoku
-        if (this.dirtyData || this.dirtyIchimokuConfig) {
-            const ic = this.config.ichimoku
-            if (ic.showTenkan || ic.showKijun || ic.showSpanA || ic.showSpanB || ic.showCloud || ic.showChikou) {
-                this.cachedIchimokuSeries = calcIchimokuData(
-                    data,
-                    ic.tenkanPeriod,
-                    ic.kijunPeriod,
-                    ic.spanBPeriod,
-                    ic.displacement,
-                )
-            } else {
-                this.cachedIchimokuSeries = []
-            }
-            changed.push('ichimoku')
-        }
-
-        // ROC
-        if (this.dirtyData || this.dirtyRocConfig) {
-            if (this.config.roc.showROC) {
-                this.cachedRocSeries = calcROCData(data, this.config.roc.period)
-            } else {
-                this.cachedRocSeries = []
-            }
-            changed.push('roc')
-        }
-
-        // TRIX
-        if (this.dirtyData || this.dirtyTrixConfig) {
-            if (this.config.trix.showTRIX || this.config.trix.showSignal) {
-                const result = calcTRIXData(data, this.config.trix.period, this.config.trix.signalPeriod)
-                this.cachedTrixSeries = result.series
-                this.cachedTrixSignalSeries = result.signalSeries
-            } else {
-                this.cachedTrixSeries = []
-                this.cachedTrixSignalSeries = []
-            }
-            changed.push('trix')
-        }
-
-        // HV
-        if (this.dirtyData || this.dirtyHvConfig) {
-            if (this.config.hv.showHV) {
-                this.cachedHvSeries = calcHVData(data, this.config.hv.period, this.config.hv.annualizationFactor)
-            } else {
-                this.cachedHvSeries = []
-            }
-            changed.push('hv')
-        }
-
-        // Parkinson
-        if (this.dirtyData || this.dirtyParkinsonConfig) {
-            if (this.config.parkinson.showParkinson) {
-                this.cachedParkinsonSeries = calcParkinsonData(
-                    data,
-                    this.config.parkinson.period,
-                    this.config.parkinson.annualizationFactor,
-                )
-            } else {
-                this.cachedParkinsonSeries = []
-            }
-            changed.push('parkinson')
-        }
-
-        // Chaikin Volatility
-        if (this.dirtyData || this.dirtyChaikinVolConfig) {
-            if (this.config.chaikinVol.showChaikinVol) {
-                this.cachedChaikinVolSeries = calcChaikinVolData(
-                    data,
-                    this.config.chaikinVol.emaPeriod,
-                    this.config.chaikinVol.rocPeriod,
-                )
-            } else {
-                this.cachedChaikinVolSeries = []
-            }
-            changed.push('chaikinVol')
-        }
-
-        // VMA
-        if (this.dirtyData || this.dirtyVmaConfig) {
-            if (this.config.vma.showVMA) {
-                this.cachedVmaSeries = calcVMAData(data, this.config.vma.period)
-            } else {
-                this.cachedVmaSeries = []
-            }
-            changed.push('vma')
-        }
-
-        // OBV
-        if (this.dirtyData || this.dirtyObvConfig) {
-            if (this.config.obv.showOBV) {
-                this.cachedObvSeries = calcOBVData(data)
-            } else {
-                this.cachedObvSeries = []
-            }
-            changed.push('obv')
-        }
-
-        // PVT
-        if (this.dirtyData || this.dirtyPvtConfig) {
-            if (this.config.pvt.showPVT) {
-                this.cachedPvtSeries = calcPVTData(data)
-            } else {
-                this.cachedPvtSeries = []
-            }
-            changed.push('pvt')
-        }
-
-        // VWAP
-        if (this.dirtyData || this.dirtyVwapConfig) {
-            if (this.config.vwap.showVWAP) {
-                this.cachedVwapSeries = calcVWAPData(data, this.config.vwap.sessionResetGapMs)
-            } else {
-                this.cachedVwapSeries = []
-            }
-            changed.push('vwap')
-        }
-
-        // CMF
-        if (this.dirtyData || this.dirtyCmfConfig) {
-            if (this.config.cmf.showCMF) {
-                this.cachedCmfSeries = calcCMFData(data, this.config.cmf.period)
-            } else {
-                this.cachedCmfSeries = []
-            }
-            changed.push('cmf')
-        }
-
-        // MFI
-        if (this.dirtyData || this.dirtyMfiConfig) {
-            if (this.config.mfi.showMFI) {
-                this.cachedMfiSeries = calcMFIData(data, this.config.mfi.period)
-            } else {
-                this.cachedMfiSeries = []
-            }
-            changed.push('mfi')
-        }
-
-        // Pivot
-        if (this.dirtyData || this.dirtyPivotConfig) {
-            const p = this.config.pivot
-            if (p.showPP || p.showR1 || p.showR2 || p.showR3 || p.showS1 || p.showS2 || p.showS3) {
-                this.cachedPivotSeries = calcPivotData(data)
-            } else {
-                this.cachedPivotSeries = []
-            }
-            changed.push('pivot')
-        }
-
-        // Fibonacci
-        if (this.dirtyData || this.dirtyFibConfig) {
-            if (this.config.fib.showLevels) {
-                this.cachedFibSeries = calcFibData(data, this.config.fib.period)
-            } else {
-                this.cachedFibSeries = []
-            }
-            changed.push('fib')
-        }
-
-        // SMC Structure
-        if (this.dirtyData || this.dirtyStructureConfig) {
-            const s = this.config.structure
-            if (s.showSwingLabels || s.showBOS || s.showCHOCH) {
-                this.cachedStructureSeries = calcStructureData(data, s.leftWindow, s.rightWindow, s.breakoutSource)
-            } else {
-                this.cachedStructureSeries = { swings: [], events: [], trend: 'range' }
-            }
-            changed.push('structure')
-        }
-
-        // SMC Zones
-        if (this.dirtyData || this.dirtyZonesConfig) {
-            const z = this.config.zones
-            if (z.showFVG || z.showOB) {
-                this.cachedZonesSeries = calcZonesData(
-                    data,
-                    z.obLookback,
-                    this.config.structure.leftWindow,
-                    this.config.structure.rightWindow,
-                    this.config.structure.breakoutSource,
-                )
-            } else {
-                this.cachedZonesSeries = []
-            }
-            changed.push('zones')
-        }
-
-        // Volume Profile
-        if (this.dirtyData || this.dirtyVolumeProfileConfig) {
-            const vp = this.config.volumeProfile
-            if (vp.showPOC || vp.showValueArea) {
-                this.cachedVolumeProfileSeries = calcVolumeProfileData(data, vp.bins, vp.lookback, vp.valueAreaPercent)
-            } else {
-                this.cachedVolumeProfileSeries = { bins: [], poc: 0, vah: 0, val: 0, totalVolume: 0 }
-            }
-            changed.push('volumeProfile')
-        }
-
-        // 重置脏标记
-        this.dirtyData = false
-        this.dirtyMAConfig = false
-        this.dirtyBollConfig = false
-        this.dirtyExpmaConfig = false
-        this.dirtyEneConfig = false
-        this.dirtyRsiConfig = false
-        this.dirtyCciConfig = false
-        this.dirtyStochConfig = false
-        this.dirtyMomConfig = false
-        this.dirtyWmsrConfig = false
-        this.dirtyKstConfig = false
-        this.dirtyFastkConfig = false
-        this.dirtyMacdConfig = false
-        this.dirtyAtrConfig = false
-        this.dirtyWmaConfig = false
-        this.dirtyDemaConfig = false
-        this.dirtyTemaConfig = false
-        this.dirtyHmaConfig = false
-        this.dirtyKamaConfig = false
-        this.dirtySarConfig = false
-        this.dirtySupertrendConfig = false
-        this.dirtyKeltnerConfig = false
-        this.dirtyDonchianConfig = false
-        this.dirtyIchimokuConfig = false
-        this.dirtyRocConfig = false
-        this.dirtyTrixConfig = false
-        this.dirtyHvConfig = false
-        this.dirtyParkinsonConfig = false
-        this.dirtyChaikinVolConfig = false
-        this.dirtyVmaConfig = false
-        this.dirtyObvConfig = false
-        this.dirtyPvtConfig = false
-        this.dirtyVwapConfig = false
-        this.dirtyCmfConfig = false
-        this.dirtyMfiConfig = false
-        this.dirtyPivotConfig = false
-        this.dirtyFibConfig = false
-        this.dirtyStructureConfig = false
-        this.dirtyZonesConfig = false
-        this.dirtyVolumeProfileConfig = false
-
-        // 组装结果
-        return {
-            ma: {
-                series: this.cachedSeries,
-                enabledPeriods: Object.keys(this.cachedSeries).map(Number),
-            },
-            boll: {
-                series: this.cachedBollSeries,
-                params: { ...this.config.boll },
-            },
-            expma: {
-                series: this.cachedExpmaSeries,
-                params: { ...this.config.expma },
-            },
-            ene: {
-                series: this.cachedEneSeries,
-                params: { ...this.config.ene },
-            },
-            rsi: {
-                series: this.cachedRsiSeries,
-                enabledPeriods: Object.keys(this.cachedRsiSeries).map(Number),
-                params: { ...this.config.rsi },
-            },
-            cci: {
-                series: this.cachedCciSeries,
-                params: { ...this.config.cci },
-            },
-            stoch: {
-                series: this.cachedStochSeries,
-                params: { ...this.config.stoch },
-            },
-            mom: {
-                series: this.cachedMomSeries,
-                params: { ...this.config.mom },
-            },
-            wmsr: {
-                series: this.cachedWmsrSeries,
-                params: { ...this.config.wmsr },
-            },
-            kst: {
-                series: this.cachedKstSeries,
-                params: { ...this.config.kst },
-            },
-            fastk: {
-                series: this.cachedFastkSeries,
-                params: { ...this.config.fastk },
-            },
-            macd: {
-                series: this.cachedMacdSeries,
-                params: { ...this.config.macd },
-            },
-            atr: {
-                series: this.cachedAtrSeries,
-                params: { ...this.config.atr },
-            },
-            wma: {
-                series: this.cachedWmaSeries,
-                params: { ...this.config.wma },
-            },
-            dema: {
-                series: this.cachedDemaSeries,
-                params: { ...this.config.dema },
-            },
-            tema: {
-                series: this.cachedTemaSeries,
-                params: { ...this.config.tema },
-            },
-            hma: {
-                series: this.cachedHmaSeries,
-                params: { ...this.config.hma },
-            },
-            kama: {
-                series: this.cachedKamaSeries,
-                params: { ...this.config.kama },
-            },
-            sar: {
-                series: this.cachedSarSeries,
-                params: { ...this.config.sar },
-            },
-            supertrend: {
-                series: this.cachedSupertrendSeries,
-                params: { ...this.config.supertrend },
-            },
-            keltner: {
-                series: this.cachedKeltnerSeries,
-                params: { ...this.config.keltner },
-            },
-            donchian: {
-                series: this.cachedDonchianSeries,
-                params: { ...this.config.donchian },
-            },
-            ichimoku: {
-                series: this.cachedIchimokuSeries,
-                params: { ...this.config.ichimoku },
-            },
-            roc: {
-                series: this.cachedRocSeries,
-                params: { ...this.config.roc },
-            },
-            trix: {
-                series: this.cachedTrixSeries,
-                signalSeries: this.cachedTrixSignalSeries,
-                params: { ...this.config.trix },
-            },
-            hv: {
-                series: this.cachedHvSeries,
-                params: { ...this.config.hv },
-            },
-            parkinson: {
-                series: this.cachedParkinsonSeries,
-                params: { ...this.config.parkinson },
-            },
-            chaikinVol: {
-                series: this.cachedChaikinVolSeries,
-                params: { ...this.config.chaikinVol },
-            },
-            vma: {
-                series: this.cachedVmaSeries,
-                params: { ...this.config.vma },
-            },
-            obv: {
-                series: this.cachedObvSeries,
-                params: { ...this.config.obv },
-            },
-            pvt: {
-                series: this.cachedPvtSeries,
-                params: { ...this.config.pvt },
-            },
-            vwap: {
-                series: this.cachedVwapSeries,
-                params: { ...this.config.vwap },
-            },
-            cmf: {
-                series: this.cachedCmfSeries,
-                params: { ...this.config.cmf },
-            },
-            mfi: {
-                series: this.cachedMfiSeries,
-                params: { ...this.config.mfi },
-            },
-            pivot: {
-                series: this.cachedPivotSeries,
-                params: { ...this.config.pivot },
-            },
-            fib: {
-                series: this.cachedFibSeries,
-                params: { ...this.config.fib },
-            },
-            structure: {
-                series: this.cachedStructureSeries,
-                params: { ...this.config.structure },
-            },
-            zones: {
-                series: this.cachedZonesSeries,
-                params: { ...this.config.zones },
-            },
-            volumeProfile: {
-                series: this.cachedVolumeProfileSeries,
-                params: { ...this.config.volumeProfile },
-            },
-            _changed: changed,
-        }
-    }
-
-    /**
-     * 获取缓存的 series（用于 visibleRange 变更时扫描极值）
-     */
-    getCachedSeries(): IndicatorSeriesBundle {
-        return {
-            _changed: [],
-            ma: {
-                series: this.cachedSeries,
-                enabledPeriods: Object.keys(this.cachedSeries).map(Number),
-            },
-            boll: {
-                series: this.cachedBollSeries,
-                params: { ...this.config.boll },
-            },
-            expma: {
-                series: this.cachedExpmaSeries,
-                params: { ...this.config.expma },
-            },
-            ene: {
-                series: this.cachedEneSeries,
-                params: { ...this.config.ene },
-            },
-            rsi: {
-                series: this.cachedRsiSeries,
-                enabledPeriods: Object.keys(this.cachedRsiSeries).map(Number),
-                params: { ...this.config.rsi },
-            },
-            cci: {
-                series: this.cachedCciSeries,
-                params: { ...this.config.cci },
-            },
-            stoch: {
-                series: this.cachedStochSeries,
-                params: { ...this.config.stoch },
-            },
-            mom: {
-                series: this.cachedMomSeries,
-                params: { ...this.config.mom },
-            },
-            wmsr: {
-                series: this.cachedWmsrSeries,
-                params: { ...this.config.wmsr },
-            },
-            kst: {
-                series: this.cachedKstSeries,
-                params: { ...this.config.kst },
-            },
-            fastk: {
-                series: this.cachedFastkSeries,
-                params: { ...this.config.fastk },
-            },
-            macd: {
-                series: this.cachedMacdSeries,
-                params: { ...this.config.macd },
-            },
-            atr: {
-                series: this.cachedAtrSeries,
-                params: { ...this.config.atr },
-            },
-            wma: {
-                series: this.cachedWmaSeries,
-                params: { ...this.config.wma },
-            },
-            dema: {
-                series: this.cachedDemaSeries,
-                params: { ...this.config.dema },
-            },
-            tema: {
-                series: this.cachedTemaSeries,
-                params: { ...this.config.tema },
-            },
-            hma: {
-                series: this.cachedHmaSeries,
-                params: { ...this.config.hma },
-            },
-            kama: {
-                series: this.cachedKamaSeries,
-                params: { ...this.config.kama },
-            },
-            sar: {
-                series: this.cachedSarSeries,
-                params: { ...this.config.sar },
-            },
-            supertrend: {
-                series: this.cachedSupertrendSeries,
-                params: { ...this.config.supertrend },
-            },
-            keltner: {
-                series: this.cachedKeltnerSeries,
-                params: { ...this.config.keltner },
-            },
-            donchian: {
-                series: this.cachedDonchianSeries,
-                params: { ...this.config.donchian },
-            },
-            ichimoku: {
-                series: this.cachedIchimokuSeries,
-                params: { ...this.config.ichimoku },
-            },
-            roc: {
-                series: this.cachedRocSeries,
-                params: { ...this.config.roc },
-            },
-            trix: {
-                series: this.cachedTrixSeries,
-                signalSeries: this.cachedTrixSignalSeries,
-                params: { ...this.config.trix },
-            },
-            hv: {
-                series: this.cachedHvSeries,
-                params: { ...this.config.hv },
-            },
-            parkinson: {
-                series: this.cachedParkinsonSeries,
-                params: { ...this.config.parkinson },
-            },
-            chaikinVol: {
-                series: this.cachedChaikinVolSeries,
-                params: { ...this.config.chaikinVol },
-            },
-            vma: {
-                series: this.cachedVmaSeries,
-                params: { ...this.config.vma },
-            },
-            obv: {
-                series: this.cachedObvSeries,
-                params: { ...this.config.obv },
-            },
-            pvt: {
-                series: this.cachedPvtSeries,
-                params: { ...this.config.pvt },
-            },
-            vwap: {
-                series: this.cachedVwapSeries,
-                params: { ...this.config.vwap },
-            },
-            cmf: {
-                series: this.cachedCmfSeries,
-                params: { ...this.config.cmf },
-            },
-            mfi: {
-                series: this.cachedMfiSeries,
-                params: { ...this.config.mfi },
-            },
-            pivot: {
-                series: this.cachedPivotSeries,
-                params: { ...this.config.pivot },
-            },
-            fib: {
-                series: this.cachedFibSeries,
-                params: { ...this.config.fib },
-            },
-            structure: {
-                series: this.cachedStructureSeries,
-                params: { ...this.config.structure },
-            },
-            zones: {
-                series: this.cachedZonesSeries,
-                params: { ...this.config.zones },
-            },
-            volumeProfile: {
-                series: this.cachedVolumeProfileSeries,
-                params: { ...this.config.volumeProfile },
-            },
-        }
+        return bundle as unknown as IndicatorSeriesBundle
     }
 }

--- a/packages/core/src/engine/indicators/indicatorRuntime.ts
+++ b/packages/core/src/engine/indicators/indicatorRuntime.ts
@@ -113,7 +113,6 @@ export class IndicatorRuntime {
     private configVersion = 0
     private dataDirty = true
     private configMap = new Map<string, any>()
-    private paneIdMap = new Map<string, string>()
     private seriesMap = new Map<string, unknown>()
     private dirtyFlags = new Map<string, boolean>()
     private descriptorMap = new Map<string, IndicatorRuntimeDescriptor>()
@@ -162,14 +161,6 @@ export class IndicatorRuntime {
                     this.dirtyFlags.set(key, true)
                 }
                 continue
-            }
-            if (typeof value === 'string') {
-                for (const d of this.descriptorMap.values()) {
-                    if (d.paneIdKey === key) {
-                        this.paneIdMap.set(key, value)
-                        break
-                    }
-                }
             }
         }
         this.configVersion = version

--- a/packages/core/src/engine/indicators/scheduler.ts
+++ b/packages/core/src/engine/indicators/scheduler.ts
@@ -60,6 +60,7 @@ import type {
     VolumeProfileSchedulerConfig,
     IndicatorConfigSnapshot,
     IndicatorSeriesBundle,
+    SerializedRuntimeDescriptor,
 } from './workerProtocol'
 import type { MAFlags } from './calculators'
 import { IndicatorRegistry } from './indicatorRegistry'
@@ -201,6 +202,21 @@ export class IndicatorScheduler {
             console.warn(`[IndicatorScheduler] '${meta.name}' already registered, overwriting`)
         }
         this.registry.register(meta)
+        if (meta.runtime && this.inlineRuntime) {
+            this.inlineRuntime.addDescriptor(meta.runtime)
+        }
+        if (meta.runtime && this.useWorker && this.worker && this.workerReady) {
+            const rt = meta.runtime
+            this.worker.postMessage({
+                type: 'addDescriptor',
+                descriptor: {
+                    configKey: rt.configKey,
+                    paneIdKey: rt.paneIdKey,
+                    defaultConfig: typeof rt.defaultConfig === 'function' ? (rt.defaultConfig as () => any)() : rt.defaultConfig,
+                    computeKey: rt.computeKey,
+                } as SerializedRuntimeDescriptor,
+            })
+        }
         this.configVersion++
         this.triggerRecompute()
         console.log(`[IndicatorScheduler] Registered indicator '${meta.name}' (${meta.displayName})`)
@@ -464,7 +480,6 @@ export class IndicatorScheduler {
                 console.error('[IndicatorScheduler] Worker error:', err)
                 this.fallbackToInline()
             }
-            // 发送 init
             this.worker.postMessage({
                 type: 'init',
                 protocolVersion: PROTOCOL_VERSION,
@@ -478,7 +493,10 @@ export class IndicatorScheduler {
 
     private initInlineRuntime(): void {
         console.log('[IndicatorScheduler] Using INLINE runtime (fallback)')
-        this.inlineRuntime = new IndicatorRuntime()
+        const runtimeDescs = this.registry.getAll()
+            .filter(m => m.runtime)
+            .map(m => m.runtime!)
+        this.inlineRuntime = new IndicatorRuntime(runtimeDescs)
         this.useWorker = false
         this.workerReady = true
     }
@@ -517,7 +535,19 @@ export class IndicatorScheduler {
                 this.workerReady = true
                 this.useWorker = true
                 console.log('[IndicatorScheduler] Worker READY - using Worker backend')
-                // Worker 就绪后补算一次，但仅在有数据时（避免空数据产出 Infinity 极值）
+                for (const meta of this.registry.getAll()) {
+                    if (!meta.runtime) continue
+                    const rt = meta.runtime
+                    this.worker!.postMessage({
+                        type: 'addDescriptor',
+                        descriptor: {
+                            configKey: rt.configKey,
+                            paneIdKey: rt.paneIdKey,
+                            defaultConfig: typeof rt.defaultConfig === 'function' ? (rt.defaultConfig as () => any)() : rt.defaultConfig,
+                            computeKey: rt.computeKey,
+                        } as SerializedRuntimeDescriptor,
+                    })
+                }
                 if (this.currentData.length > 0) {
                     this.triggerRecompute()
                 }
@@ -747,400 +777,280 @@ export class IndicatorScheduler {
      * MA 配置变更
      */
     updateMAConfig(config: MAFlags): void {
-        this.configSnapshot.ma = { ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('ma', config as unknown as Record<string, unknown>)
     }
 
     /**
      * BOLL 配置变更
      */
     updateBOLLConfig(config: Partial<BOLLSchedulerConfig>): void {
-        this.configSnapshot.boll = { ...this.configSnapshot.boll, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('boll', config as unknown as Record<string, unknown>)
     }
 
     /**
      * EXPMA 配置变更
      */
     updateEXPMAConfig(config: Partial<EXPMASchedulerConfig>): void {
-        this.configSnapshot.expma = { ...this.configSnapshot.expma, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('expma', config as unknown as Record<string, unknown>)
     }
 
     /**
      * ENE 配置变更
      */
     updateENEConfig(config: Partial<ENESchedulerConfig>): void {
-        this.configSnapshot.ene = { ...this.configSnapshot.ene, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('ene', config as unknown as Record<string, unknown>)
     }
 
     /**
      * RSI 配置变更
      */
     updateRSIConfig(config: Partial<RSISchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.rsiPaneId = paneId
-        }
-        this.configSnapshot.rsi = { ...this.configSnapshot.rsi, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('rsi', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * CCI 配置变更
      */
     updateCCIConfig(config: Partial<CCISchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.cciPaneId = paneId
-        }
-        this.configSnapshot.cci = { ...this.configSnapshot.cci, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('cci', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * STOCH 配置变更
      */
     updateSTOCHConfig(config: Partial<STOCHSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.stochPaneId = paneId
-        }
-        this.configSnapshot.stoch = { ...this.configSnapshot.stoch, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('stoch', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * MOM 配置变更
      */
     updateMOMConfig(config: Partial<MOMSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.momPaneId = paneId
-        }
-        this.configSnapshot.mom = { ...this.configSnapshot.mom, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('mom', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * WMSR 配置变更
      */
     updateWMSRConfig(config: Partial<WMSRSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.wmsrPaneId = paneId
-        }
-        this.configSnapshot.wmsr = { ...this.configSnapshot.wmsr, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('wmsr', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * KST 配置变更
      */
     updateKSTConfig(config: Partial<KSTSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.kstPaneId = paneId
-        }
-        this.configSnapshot.kst = { ...this.configSnapshot.kst, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('kst', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * FASTK 配置变更
      */
     updateFASTKConfig(config: Partial<FASTKSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.fastkPaneId = paneId
-        }
-        this.configSnapshot.fastk = { ...this.configSnapshot.fastk, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('fastk', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * MACD 配置变更
      */
     updateMACDConfig(config: Partial<MACDSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.macdPaneId = paneId
-        }
-        this.configSnapshot.macd = { ...this.configSnapshot.macd, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('macd', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * ATR 配置变更
      */
     updateATRConfig(config: Partial<ATRSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.atrPaneId = paneId
-        }
-        this.configSnapshot.atr = { ...this.configSnapshot.atr, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('atr', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * WMA 配置变更
      */
     updateWMAConfig(config: Partial<WMASchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.wmaPaneId = paneId
-        }
-        this.configSnapshot.wma = { ...this.configSnapshot.wma, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('wma', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * DEMA 配置变更
      */
     updateDEMAConfig(config: Partial<DEMASchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.demaPaneId = paneId
-        }
-        this.configSnapshot.dema = { ...this.configSnapshot.dema, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('dema', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * TEMA 配置变更
      */
     updateTEMAConfig(config: Partial<TEMASchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.temaPaneId = paneId
-        }
-        this.configSnapshot.tema = { ...this.configSnapshot.tema, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('tema', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * HMA 配置变更
      */
     updateHMAConfig(config: Partial<HMASchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.hmaPaneId = paneId
-        }
-        this.configSnapshot.hma = { ...this.configSnapshot.hma, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('hma', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * KAMA 配置变更
      */
     updateKAMAConfig(config: Partial<KAMASchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.kamaPaneId = paneId
-        }
-        this.configSnapshot.kama = { ...this.configSnapshot.kama, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('kama', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * SAR 配置变更
      */
     updateSARConfig(config: Partial<SARSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) {
-            this.configSnapshot.sarPaneId = paneId
-        }
-        this.configSnapshot.sar = { ...this.configSnapshot.sar, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('sar', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * SuperTrend 配置变更
      */
     updateSuperTrendConfig(config: Partial<SuperTrendSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.supertrendPaneId = paneId
-        this.configSnapshot.supertrend = { ...this.configSnapshot.supertrend, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('supertrend', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * Keltner 配置变更
      */
     updateKeltnerConfig(config: Partial<KeltnerSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.keltnerPaneId = paneId
-        this.configSnapshot.keltner = { ...this.configSnapshot.keltner, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('keltner', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * Donchian 配置变更
      */
     updateDonchianConfig(config: Partial<DonchianSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.donchianPaneId = paneId
-        this.configSnapshot.donchian = { ...this.configSnapshot.donchian, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('donchian', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * Ichimoku 配置变更
      */
     updateIchimokuConfig(config: Partial<IchimokuSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.ichimokuPaneId = paneId
-        this.configSnapshot.ichimoku = { ...this.configSnapshot.ichimoku, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('ichimoku', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * ROC 配置变更
      */
     updateROCConfig(config: Partial<ROCSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.rocPaneId = paneId
-        this.configSnapshot.roc = { ...this.configSnapshot.roc, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('roc', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * TRIX 配置变更
      */
     updateTRIXConfig(config: Partial<TRIXSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.trixPaneId = paneId
-        this.configSnapshot.trix = { ...this.configSnapshot.trix, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('trix', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * HV 配置变更
      */
     updateHVConfig(config: Partial<HVSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.hvPaneId = paneId
-        this.configSnapshot.hv = { ...this.configSnapshot.hv, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('hv', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * Parkinson 配置变更
      */
     updateParkinsonConfig(config: Partial<ParkinsonSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.parkinsonPaneId = paneId
-        this.configSnapshot.parkinson = { ...this.configSnapshot.parkinson, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('parkinson', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * ChaikinVol 配置变更
      */
     updateChaikinVolConfig(config: Partial<ChaikinVolSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.chaikinVolPaneId = paneId
-        this.configSnapshot.chaikinVol = { ...this.configSnapshot.chaikinVol, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('chaikinVol', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * VMA 配置变更
      */
     updateVMAConfig(config: Partial<VMASchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.vmaPaneId = paneId
-        this.configSnapshot.vma = { ...this.configSnapshot.vma, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('vma', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * OBV 配置变更
      */
     updateOBVConfig(config: Partial<OBVSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.obvPaneId = paneId
-        this.configSnapshot.obv = { ...this.configSnapshot.obv, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('obv', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * PVT 配置变更
      */
     updatePVTConfig(config: Partial<PVTSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.pvtPaneId = paneId
-        this.configSnapshot.pvt = { ...this.configSnapshot.pvt, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('pvt', config as unknown as Record<string, unknown>, paneId)
     }
 
     /**
      * VWAP 配置变更
      */
     updateVWAPConfig(config: Partial<VWAPSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.vwapPaneId = paneId
-        this.configSnapshot.vwap = { ...this.configSnapshot.vwap, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('vwap', config as unknown as Record<string, unknown>, paneId)
     }
 
     /** CMF 配置变更 */
     updateCMFConfig(config: Partial<CMFSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.cmfPaneId = paneId
-        this.configSnapshot.cmf = { ...this.configSnapshot.cmf, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('cmf', config as unknown as Record<string, unknown>, paneId)
     }
 
     /** MFI 配置变更 */
     updateMFIConfig(config: Partial<MFISchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.mfiPaneId = paneId
-        this.configSnapshot.mfi = { ...this.configSnapshot.mfi, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('mfi', config as unknown as Record<string, unknown>, paneId)
     }
 
     /** Pivot 配置变更 */
     updatePivotConfig(config: Partial<PivotSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.pivotPaneId = paneId
-        this.configSnapshot.pivot = { ...this.configSnapshot.pivot, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('pivot', config as unknown as Record<string, unknown>, paneId)
     }
 
     /** Fib 配置变更 */
     updateFibConfig(config: Partial<FibSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.fibPaneId = paneId
-        this.configSnapshot.fib = { ...this.configSnapshot.fib, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('fib', config as unknown as Record<string, unknown>, paneId)
     }
 
     /** Structure 配置变更 */
     updateStructureConfig(config: Partial<StructureSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.structurePaneId = paneId
-        this.configSnapshot.structure = { ...this.configSnapshot.structure, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('structure', config as unknown as Record<string, unknown>, paneId)
     }
 
     /** Zones 配置变更 */
     updateZonesConfig(config: Partial<ZonesSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.zonesPaneId = paneId
-        this.configSnapshot.zones = { ...this.configSnapshot.zones, ...config }
-        this.configVersion++
-        this.triggerRecompute()
+        this.updateIndicatorConfig('zones', config as unknown as Record<string, unknown>, paneId)
     }
 
     /** Volume Profile 配置变更 */
     updateVolumeProfileConfig(config: Partial<VolumeProfileSchedulerConfig>, paneId?: string): void {
-        if (paneId !== undefined) this.configSnapshot.volumeProfilePaneId = paneId
-        this.configSnapshot.volumeProfile = { ...this.configSnapshot.volumeProfile, ...config }
+        this.updateIndicatorConfig('volumeProfile', config as unknown as Record<string, unknown>, paneId)
+    }
+
+    /**
+     * 通用指标配置变更入口
+     */
+    updateIndicatorConfig(indicatorId: string, config: Record<string, unknown>, paneId?: string): void {
+        const meta = this.registry.get(indicatorId)
+        if (!meta?.runtime) {
+            console.warn(`[IndicatorScheduler] Unknown or unregistered indicator: ${indicatorId}`)
+            return
+        }
+        const rt = meta.runtime
+        // Update paneId if provided
+        if (rt.paneIdKey && paneId !== undefined) {
+            ;(this.configSnapshot as any)[rt.paneIdKey] = paneId
+        }
+        // Merge config
+        ;(this.configSnapshot as any)[rt.configKey] = {
+            ...((this.configSnapshot as any)[rt.configKey] ?? {}),
+            ...config,
+        }
         this.configVersion++
         this.triggerRecompute()
     }
@@ -1229,7 +1139,10 @@ export class IndicatorScheduler {
 
     private computeWithInline(): void {
         if (!this.inlineRuntime) {
-            this.inlineRuntime = new IndicatorRuntime()
+            const runtimeDescs = this.registry.getAll()
+                .filter(m => m.runtime)
+                .map(m => m.runtime!)
+            this.inlineRuntime = new IndicatorRuntime(runtimeDescs)
         }
 
         console.log(`[IndicatorScheduler] >> INLINE compute: dataV=${this.dataVersion} configV=${this.configVersion}`)

--- a/packages/core/src/engine/indicators/scheduler.ts
+++ b/packages/core/src/engine/indicators/scheduler.ts
@@ -159,6 +159,7 @@ export class IndicatorScheduler {
     // 当前数据和配置快照
     private currentData: KLineData[] = []
     private configSnapshot: IndicatorConfigSnapshot = this.getDefaultConfig()
+    private paneIdOverrides = new Map<string, string>()
 
     // Worker 相关
     private worker: Worker | null = null
@@ -418,41 +419,6 @@ export class IndicatorScheduler {
                 showPOC: true,
                 showValueArea: true,
             },
-            rsiPaneId: 'sub_RSI',
-            cciPaneId: 'sub_CCI',
-            stochPaneId: 'sub_STOCH',
-            momPaneId: 'sub_MOM',
-            wmsrPaneId: 'sub_WMSR',
-            kstPaneId: 'sub_KST',
-            fastkPaneId: 'sub_FASTK',
-            macdPaneId: 'sub_MACD',
-            atrPaneId: 'sub_ATR',
-            wmaPaneId: 'sub_WMA',
-            demaPaneId: 'sub_DEMA',
-            temaPaneId: 'sub_TEMA',
-            hmaPaneId: 'sub_HMA',
-            kamaPaneId: 'sub_KAMA',
-            sarPaneId: 'sub_SAR',
-            supertrendPaneId: 'sub_SuperTrend',
-            keltnerPaneId: 'sub_Keltner',
-            donchianPaneId: 'sub_Donchian',
-            ichimokuPaneId: 'sub_Ichimoku',
-            rocPaneId: 'sub_ROC',
-            trixPaneId: 'sub_TRIX',
-            hvPaneId: 'sub_HV',
-            parkinsonPaneId: 'sub_Parkinson',
-            chaikinVolPaneId: 'sub_ChaikinVol',
-            vmaPaneId: 'sub_VMA',
-            obvPaneId: 'sub_OBV',
-            pvtPaneId: 'sub_PVT',
-            vwapPaneId: 'sub_VWAP',
-            cmfPaneId: 'sub_CMF',
-            mfiPaneId: 'sub_MFI',
-            pivotPaneId: 'sub_Pivot',
-            fibPaneId: 'sub_Fib',
-            structurePaneId: 'sub_Structure',
-            zonesPaneId: 'sub_Zones',
-            volumeProfilePaneId: 'sub_VolumeProfile',
         }
     }
 
@@ -633,9 +599,7 @@ export class IndicatorScheduler {
                 meta.displayName,
             )
 
-            const paneId = meta.paneIdField
-                ? (this.configSnapshot as unknown as Record<string, string>)[meta.paneIdField as string]
-                : meta.defaultPaneId
+            const paneId = this.paneIdOverrides.get(meta.name) ?? meta.defaultPaneId
 
             meta.applyResult(this.pluginHost, state as BaseIndicatorState, paneId)
         }
@@ -662,9 +626,7 @@ export class IndicatorScheduler {
 
             let state: unknown
             if (meta.category === 'main') {
-                const paneId = meta.paneIdField
-                    ? (this.configSnapshot as unknown as Record<string, string>)[meta.paneIdField as string]
-                    : meta.defaultPaneId
+                const paneId = this.paneIdOverrides.get(meta.name) ?? meta.defaultPaneId
                 const current = this.pluginHost.getSharedState<BaseIndicatorState & { visibleMin?: number; visibleMax?: number }>(
                     resolveStateKey(meta.stateKey, paneId),
                 )
@@ -691,9 +653,7 @@ export class IndicatorScheduler {
                 meta.displayName,
             )
 
-            const paneId = meta.paneIdField
-                ? (this.configSnapshot as unknown as Record<string, string>)[meta.paneIdField as string]
-                : meta.defaultPaneId
+            const paneId = this.paneIdOverrides.get(meta.name) ?? meta.defaultPaneId
 
             meta.applyResult(this.pluginHost, state as BaseIndicatorState, paneId)
             if (meta.category === 'main') {
@@ -709,8 +669,7 @@ export class IndicatorScheduler {
         const activeIds = this.getActiveSubPaneIds?.() ?? []
         const mask: Record<string, boolean> = {}
         for (const meta of this.registry.getAll()) {
-            if (!meta.paneIdField) continue
-            const paneId = (this.configSnapshot as unknown as Record<string, string>)[meta.paneIdField as string] ?? meta.defaultPaneId
+            const paneId = this.paneIdOverrides.get(meta.name) ?? meta.defaultPaneId
             mask[meta.name] = activeIds.includes(paneId) || !!(meta.allowMainPane && paneId === 'main')
         }
         return mask
@@ -723,8 +682,7 @@ export class IndicatorScheduler {
 
         const cfg: Record<string, unknown> = { ...this.configSnapshot }
         for (const meta of this.registry.getAll()) {
-            if (!meta.paneIdField) continue
-            const paneId = cfg[meta.paneIdField] as string
+            const paneId = this.paneIdOverrides.get(meta.name) ?? meta.defaultPaneId
             if (!activeIds.includes(paneId) && paneId !== 'main') {
                 const subCfg = { ...(cfg[meta.name] as Record<string, unknown>) }
                 for (const k of Object.keys(subCfg)) {
@@ -1043,8 +1001,8 @@ export class IndicatorScheduler {
         }
         const rt = meta.runtime
         // Update paneId if provided
-        if (rt.paneIdKey && paneId !== undefined) {
-            ;(this.configSnapshot as any)[rt.paneIdKey] = paneId
+        if (paneId !== undefined) {
+            this.paneIdOverrides.set(indicatorId, paneId)
         }
         // Merge config
         ;(this.configSnapshot as any)[rt.configKey] = {

--- a/packages/core/src/engine/indicators/stateComposer.ts
+++ b/packages/core/src/engine/indicators/stateComposer.ts
@@ -70,6 +70,7 @@ import type { ZonesRenderState } from './zonesState'
 import type { VolumeProfileRenderState } from './volumeProfileState'
 import type { IndicatorSeriesBundle } from './workerProtocol'
 import type { IndicatorMetadata } from './indicatorMetadata'
+import { getRegisteredIndicatorDefinitions } from './indicatorDefinitionRegistry'
 
 /**
  * 可见范围
@@ -166,56 +167,13 @@ type MainRenderStateIndicatorId = keyof MainRenderStates
 
 type ComposedRenderStates = VisibleSubIndicatorStates & MainRenderStates
 
-const MAIN_RENDER_STATE_INDICATOR_IDS: readonly MainRenderStateIndicatorId[] = ['ma', 'boll', 'expma', 'ene']
-const METADATA_VISIBLE_STATE_INDICATOR_IDS = [
-    'cci',
-    'wma',
-    'dema',
-    'tema',
-    'hma',
-    'kama',
-    'roc',
-    'chaikinVol',
-    'obv',
-    'pvt',
-    'vwap',
-    'rsi',
-    'stoch',
-    'fastk',
-    'mfi',
-    'wmsr',
-    'cmf',
-    'atr',
-    'hv',
-    'kst',
-    'mom',
-    'parkinson',
-    'trix',
-    'vma',
-    'macd',
-    'sar',
-    'supertrend',
-    'keltner',
-    'donchian',
-    'ichimoku',
-    'pivot',
-    'fib',
-    'structure',
-    'zones',
-    'volumeProfile',
-] as const satisfies readonly (keyof VisibleSubIndicatorStates)[]
-
-type _MissingVisibleStateId = Exclude<
-    keyof VisibleSubIndicatorStates,
-    typeof METADATA_VISIBLE_STATE_INDICATOR_IDS[number]
->
-type _ExtraVisibleStateId = Exclude<
-    typeof METADATA_VISIBLE_STATE_INDICATOR_IDS[number],
-    keyof VisibleSubIndicatorStates
->
-type AssertNever<T extends never> = T
-type _AssertNoMissingId = AssertNever<_MissingVisibleStateId>
-type _AssertNoExtraId = AssertNever<_ExtraVisibleStateId>
+function getVisibleStateIndicatorIds(): (keyof VisibleSubIndicatorStates)[] {
+    return getRegisteredIndicatorDefinitions()
+        .filter((d): d is IndicatorMetadata & { visibleState: NonNullable<IndicatorMetadata['visibleState']> } =>
+            !!d.visibleState?.compose
+        )
+        .map(d => d.name as keyof VisibleSubIndicatorStates)
+}
 
 /**
  * 仅计算副图指标的 visible-only states
@@ -230,7 +188,7 @@ export function composeVisibleSubIndicatorStates(
 ): VisibleSubIndicatorStates {
     const states: Partial<VisibleSubIndicatorStates> = {}
 
-    for (const indicatorId of METADATA_VISIBLE_STATE_INDICATOR_IDS) {
+    for (const indicatorId of getVisibleStateIndicatorIds()) {
         states[indicatorId] = composeRequiredMetadataVisibleState(
             indicatorId, bundle, visibleRange, timestamp, activeMask, getIndicatorMetadata,
         ) as never
@@ -290,15 +248,13 @@ function composeMainRenderStates(
 ): MainRenderStates {
     const states: Partial<Record<MainRenderStateIndicatorId, unknown>> = {}
 
-    for (const indicatorId of MAIN_RENDER_STATE_INDICATOR_IDS) {
-        const definition = getIndicatorMetadata(indicatorId)
-        if (!definition) continue
-
-        const composeRenderState = definition.mainPane?.composeRenderState
-        if (!composeRenderState) {
-            throw new Error(`[StateComposer] Missing mainPane.composeRenderState for ${indicatorId}`)
-        }
-        states[indicatorId] = composeRenderState(bundle, visibleRange, timestamp)
+    for (const def of getRegisteredIndicatorDefinitions()) {
+        if (!def.mainPane?.composeRenderState) continue
+        const indicatorId = def.name as MainRenderStateIndicatorId
+        const meta = getIndicatorMetadata(indicatorId)
+        const compose = meta?.mainPane?.composeRenderState ?? def.mainPane.composeRenderState
+        if (!compose) continue
+        states[indicatorId] = compose(bundle, visibleRange, timestamp)
     }
 
     return states as MainRenderStates

--- a/packages/core/src/engine/indicators/workerProtocol.ts
+++ b/packages/core/src/engine/indicators/workerProtocol.ts
@@ -404,42 +404,6 @@ export interface IndicatorConfigSnapshot {
     structure: StructureSchedulerConfig
     zones: ZonesSchedulerConfig
     volumeProfile: VolumeProfileSchedulerConfig
-    // pane IDs for sub-indicators
-    rsiPaneId: string
-    cciPaneId: string
-    stochPaneId: string
-    momPaneId: string
-    wmsrPaneId: string
-    kstPaneId: string
-    fastkPaneId: string
-    macdPaneId: string
-    atrPaneId: string
-    wmaPaneId: string
-    demaPaneId: string
-    temaPaneId: string
-    hmaPaneId: string
-    kamaPaneId: string
-    sarPaneId: string
-    supertrendPaneId: string
-    keltnerPaneId: string
-    donchianPaneId: string
-    ichimokuPaneId: string
-    rocPaneId: string
-    trixPaneId: string
-    hvPaneId: string
-    parkinsonPaneId: string
-    chaikinVolPaneId: string
-    vmaPaneId: string
-    obvPaneId: string
-    pvtPaneId: string
-    vwapPaneId: string
-    cmfPaneId: string
-    mfiPaneId: string
-    pivotPaneId: string
-    fibPaneId: string
-    structurePaneId: string
-    zonesPaneId: string
-    volumeProfilePaneId: string
 }
 
 // ============================================================================

--- a/packages/core/src/engine/indicators/workerProtocol.ts
+++ b/packages/core/src/engine/indicators/workerProtocol.ts
@@ -277,9 +277,22 @@ export interface VolumeProfileSchedulerConfig {
 // Worker 请求类型
 // ============================================================================
 
+export interface SerializedRuntimeDescriptor {
+    configKey: string
+    paneIdKey?: string
+    defaultConfig: unknown
+    computeKey: string
+}
+
 export interface InitRequest {
     type: 'init'
     protocolVersion: number
+    descriptors?: SerializedRuntimeDescriptor[]
+}
+
+export interface AddDescriptorRequest {
+    type: 'addDescriptor'
+    descriptor: SerializedRuntimeDescriptor
 }
 
 export interface SetDataRequest {
@@ -308,6 +321,7 @@ export interface DisposeRequest {
 
 export type IndicatorWorkerRequest =
     | InitRequest
+    | AddDescriptorRequest
     | SetDataRequest
     | SetConfigRequest
     | ComputeSeriesRequest

--- a/packages/core/src/engine/renderers/Indicator/atr.ts
+++ b/packages/core/src/engine/renderers/Indicator/atr.ts
@@ -235,7 +235,6 @@ export function getATRTitleInfo(
     category: 'oscillator',
     stateKey: createATRStateKey,
     defaultPaneId: 'sub_ATR',
-    paneIdField: 'atrPaneId',
     scaleRendererFactory: createAtrScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
     (scheduler as IndicatorScheduler).updateIndicatorConfig('atr', params, paneId)
@@ -246,7 +245,6 @@ export function getATRTitleInfo(
     },
     runtime: {
         configKey: 'atr',
-        paneIdKey: 'atrPaneId',
         defaultConfig: { period: 14, showATR: true },
         computeKey: 'calcATRData',
         compute: (data, c) => calcATRData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/atr.ts
+++ b/packages/core/src/engine/renderers/Indicator/atr.ts
@@ -238,7 +238,7 @@ export function getATRTitleInfo(
     paneIdField: 'atrPaneId',
     scaleRendererFactory: createAtrScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateATRConfig(params as Partial<ATRSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('atr', params, paneId)
   },
     visibleState: { compose: createNonNegativeSparseVisibleStateComposer('atr', EMPTY_ATR_STATE) },
     applyResult: (host, state, paneId) => {

--- a/packages/core/src/engine/renderers/Indicator/atr.ts
+++ b/packages/core/src/engine/renderers/Indicator/atr.ts
@@ -9,6 +9,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, ATRSchedulerConfig } from '../../indicators/scheduler'
 import { createAtrScaleRendererPlugin } from './scale/atr_scale'
+import { calcATRData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -242,6 +243,13 @@ export function getATRTitleInfo(
     visibleState: { compose: createNonNegativeSparseVisibleStateComposer('atr', EMPTY_ATR_STATE) },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createATRStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'atr',
+        paneIdKey: 'atrPaneId',
+        defaultConfig: { period: 14, showATR: true },
+        computeKey: 'calcATRData',
+        compute: (data, c) => calcATRData(data, c.period),
     },
 })
 class ATRIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/boll.ts
+++ b/packages/core/src/engine/renderers/Indicator/boll.ts
@@ -8,6 +8,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorPriceRangeComputer, IndicatorRenderStateComposer } from '../../indicators/indicatorMetadata'
 import type { BOLLSchedulerConfig, IndicatorScheduler } from '../../indicators/scheduler'
+import { calcBOLLData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -183,6 +184,7 @@ const composeBOLLRenderState: IndicatorRenderStateComposer = (bundle, range, tim
     applyResult: (host, state, _paneId) => {
         host.setSharedState(BOLL_STATE_KEY, state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'boll', defaultConfig:{period:20,multiplier:2,showUpper:true,showMiddle:true,showLower:true,showBand:true}, computeKey:'calcBOLLData', compute:(data,c)=>calcBOLLData(data,c.period,c.multiplier) },
 })
 class BOLLDefinition {
     static rendererFactory = createBOLLRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/boll.ts
+++ b/packages/core/src/engine/renderers/Indicator/boll.ts
@@ -170,7 +170,7 @@ const composeBOLLRenderState: IndicatorRenderStateComposer = (bundle, range, tim
         composeRenderState: composeBOLLRenderState,
     },
     updateConfig: (scheduler, params) => {
-        (scheduler as IndicatorScheduler).updateBOLLConfig(params as Partial<BOLLSchedulerConfig>)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('boll', params)
     },
     semantic: {
         apply: (chart, indicator) => {

--- a/packages/core/src/engine/renderers/Indicator/cci.ts
+++ b/packages/core/src/engine/renderers/Indicator/cci.ts
@@ -273,7 +273,7 @@ export function getCCITitleInfo(
     scaleRendererFactory: createCciScaleRendererPlugin,
     visibleState: { compose: createCCIVisibleStateComposer('cci', EMPTY_CCI_STATE) },
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateCCIConfig(params as Partial<CCISchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('cci', params, paneId)
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createCCIStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/cci.ts
+++ b/packages/core/src/engine/renderers/Indicator/cci.ts
@@ -269,7 +269,6 @@ export function getCCITitleInfo(
     category: 'oscillator',
     stateKey: createCCIStateKey,
     defaultPaneId: 'sub_CCI',
-    paneIdField: 'cciPaneId',
     scaleRendererFactory: createCciScaleRendererPlugin,
     visibleState: { compose: createCCIVisibleStateComposer('cci', EMPTY_CCI_STATE) },
     updateConfig: (scheduler, params, paneId) => {
@@ -280,7 +279,6 @@ export function getCCITitleInfo(
     },
     runtime: {
         configKey: 'cci',
-        paneIdKey: 'cciPaneId',
         defaultConfig: { period: 14, showCCI: true },
         computeKey: 'calcCCIData',
         compute: (data, c) => calcCCIData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/cci.ts
+++ b/packages/core/src/engine/renderers/Indicator/cci.ts
@@ -8,6 +8,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, CCISchedulerConfig } from '../../indicators/scheduler'
 import { createCciScaleRendererPlugin } from './scale/cci_scale'
+import { calcCCIData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -276,6 +277,13 @@ export function getCCITitleInfo(
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createCCIStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'cci',
+        paneIdKey: 'cciPaneId',
+        defaultConfig: { period: 14, showCCI: true },
+        computeKey: 'calcCCIData',
+        compute: (data, c) => calcCCIData(data, c.period),
     },
 })
 class CCIIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/chaikinVol.ts
+++ b/packages/core/src/engine/renderers/Indicator/chaikinVol.ts
@@ -130,7 +130,6 @@ export function createChaikinVolRendererPlugin(options: { paneId?: string } = {}
     category: 'oscillator',
     stateKey: createChaikinVolStateKey,
     defaultPaneId: 'sub_ChaikinVol',
-    paneIdField: 'chaikinVolPaneId',
     visibleState: { compose: createSparseVisibleStateComposer('chaikinVol', EMPTY_CHAIKIN_VOL_STATE) },
     scale: { indicatorKey: 'chaikinVol', label: 'ChaikinVol', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
@@ -141,7 +140,6 @@ export function createChaikinVolRendererPlugin(options: { paneId?: string } = {}
     },
     runtime: {
         configKey: 'chaikinVol',
-        paneIdKey: 'chaikinVolPaneId',
         defaultConfig: { emaPeriod: 10, rocPeriod: 10, showChaikinVol: true },
         computeKey: 'calcChaikinVolData',
         compute: (data, c) => calcChaikinVolData(data, c.emaPeriod, c.rocPeriod),

--- a/packages/core/src/engine/renderers/Indicator/chaikinVol.ts
+++ b/packages/core/src/engine/renderers/Indicator/chaikinVol.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, ChaikinVolSchedulerConfig } from '../../indicators/scheduler'
+import { calcChaikinVolData } from '../../indicators/calculators'
 
 const CHAIKIN_VOL_COLOR = '#f59e0b'
 
@@ -137,6 +138,13 @@ export function createChaikinVolRendererPlugin(options: { paneId?: string } = {}
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createChaikinVolStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'chaikinVol',
+        paneIdKey: 'chaikinVolPaneId',
+        defaultConfig: { emaPeriod: 10, rocPeriod: 10, showChaikinVol: true },
+        computeKey: 'calcChaikinVolData',
+        compute: (data, c) => calcChaikinVolData(data, c.emaPeriod, c.rocPeriod),
     },
 })
 class ChaikinVolIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/chaikinVol.ts
+++ b/packages/core/src/engine/renderers/Indicator/chaikinVol.ts
@@ -134,7 +134,7 @@ export function createChaikinVolRendererPlugin(options: { paneId?: string } = {}
     visibleState: { compose: createSparseVisibleStateComposer('chaikinVol', EMPTY_CHAIKIN_VOL_STATE) },
     scale: { indicatorKey: 'chaikinVol', label: 'ChaikinVol', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateChaikinVolConfig(params as Partial<ChaikinVolSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('chaikinVol', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createChaikinVolStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/cmf.ts
+++ b/packages/core/src/engine/renderers/Indicator/cmf.ts
@@ -133,7 +133,7 @@ export function createCMFRendererPlugin(options: { paneId?: string } = {}): Rend
     visibleState: { compose: createFixedRangeSparseVisibleStateComposer('cmf', EMPTY_CMF_STATE) },
     scale: { indicatorKey: 'cmf', label: 'CMF', decimals: 4 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateCMFConfig(params as Partial<CMFSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('cmf', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createCMFStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/cmf.ts
+++ b/packages/core/src/engine/renderers/Indicator/cmf.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { createFixedRangeSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, CMFSchedulerConfig } from '../../indicators/scheduler'
+import { calcCMFData } from '../../indicators/calculators'
 
 const CMF_COLOR = '#06b6d4'
 
@@ -136,6 +137,13 @@ export function createCMFRendererPlugin(options: { paneId?: string } = {}): Rend
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createCMFStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'cmf',
+        paneIdKey: 'cmfPaneId',
+        defaultConfig: { period: 20, showCMF: true },
+        computeKey: 'calcCMFData',
+        compute: (data, c) => calcCMFData(data, c.period),
     },
 })
 class CMFIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/cmf.ts
+++ b/packages/core/src/engine/renderers/Indicator/cmf.ts
@@ -129,7 +129,6 @@ export function createCMFRendererPlugin(options: { paneId?: string } = {}): Rend
     category: 'volume',
     stateKey: createCMFStateKey,
     defaultPaneId: 'sub_CMF',
-    paneIdField: 'cmfPaneId',
     visibleState: { compose: createFixedRangeSparseVisibleStateComposer('cmf', EMPTY_CMF_STATE) },
     scale: { indicatorKey: 'cmf', label: 'CMF', decimals: 4 },
     updateConfig: (scheduler, params, paneId) => {
@@ -140,7 +139,6 @@ export function createCMFRendererPlugin(options: { paneId?: string } = {}): Rend
     },
     runtime: {
         configKey: 'cmf',
-        paneIdKey: 'cmfPaneId',
         defaultConfig: { period: 20, showCMF: true },
         computeKey: 'calcCMFData',
         compute: (data, c) => calcCMFData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/dema.ts
+++ b/packages/core/src/engine/renderers/Indicator/dema.ts
@@ -127,7 +127,6 @@ export function createDEMARendererPlugin(options: DEMARendererOptions = {}): Ren
     category: 'main',
     stateKey: createDEMAStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'demaPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'dema_main', toActiveConfig: (params, active) => ({ ...params, showDEMA: active }) },
     visibleState: { compose: createSparseVisibleStateComposer('dema', EMPTY_DEMA_STATE) },
@@ -138,7 +137,7 @@ export function createDEMARendererPlugin(options: DEMARendererOptions = {}): Ren
     applyResult: (host, state, paneId) => {
         host.setSharedState(createDEMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'dema', paneIdKey:'demaPaneId', defaultConfig:{period:14,showDEMA:true}, computeKey:'calcDEMAData', compute:(data,c)=>calcDEMAData(data,c.period) },
+    runtime: { configKey:'dema', defaultConfig:{period:14,showDEMA:true}, computeKey:'calcDEMAData', compute:(data,c)=>calcDEMAData(data,c.period) },
 })
 class DEMADefinition {
     static rendererFactory = createDEMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/dema.ts
+++ b/packages/core/src/engine/renderers/Indicator/dema.ts
@@ -133,7 +133,7 @@ export function createDEMARendererPlugin(options: DEMARendererOptions = {}): Ren
     visibleState: { compose: createSparseVisibleStateComposer('dema', EMPTY_DEMA_STATE) },
     scale: { indicatorKey: 'dema', label: 'DEMA', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateDEMAConfig(params as Partial<DEMASchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('dema', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createDEMAStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/dema.ts
+++ b/packages/core/src/engine/renderers/Indicator/dema.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, DEMASchedulerConfig } from '../../indicators/scheduler'
+import { calcDEMAData } from '../../indicators/calculators'
 
 const DEMA_COLOR = '#6366f1'
 
@@ -137,6 +138,7 @@ export function createDEMARendererPlugin(options: DEMARendererOptions = {}): Ren
     applyResult: (host, state, paneId) => {
         host.setSharedState(createDEMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'dema', paneIdKey:'demaPaneId', defaultConfig:{period:14,showDEMA:true}, computeKey:'calcDEMAData', compute:(data,c)=>calcDEMAData(data,c.period) },
 })
 class DEMADefinition {
     static rendererFactory = createDEMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/donchian.ts
+++ b/packages/core/src/engine/renderers/Indicator/donchian.ts
@@ -135,7 +135,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     scale: { indicatorKey: 'donchian', label: 'Donchian', decimals: 2 },
     visibleState: { compose: createBandVisibleStateComposer('donchian', EMPTY_DONCHIAN_STATE, 'lower', 'upper') },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateDonchianConfig(params as Partial<DonchianSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('donchian', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createDonchianStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/donchian.ts
+++ b/packages/core/src/engine/renderers/Indicator/donchian.ts
@@ -129,7 +129,6 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     category: 'main',
     stateKey: createDonchianStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'donchianPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'donchian_main', toActiveConfig: (params, active) => ({ ...params, showUpper: active, showMiddle: active, showLower: active }) },
     scale: { indicatorKey: 'donchian', label: 'Donchian', decimals: 2 },
@@ -140,7 +139,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createDonchianStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'donchian', paneIdKey:'donchianPaneId', defaultConfig:{period:20,showUpper:true,showMiddle:true,showLower:true}, computeKey:'calcDonchianData', compute:(data,c)=>calcDonchianData(data,c.period) },
+    runtime: { configKey:'donchian', defaultConfig:{period:20,showUpper:true,showMiddle:true,showLower:true}, computeKey:'calcDonchianData', compute:(data,c)=>calcDonchianData(data,c.period) },
 })
 class DonchianDefinition {
     static rendererFactory = createDonchianRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/donchian.ts
+++ b/packages/core/src/engine/renderers/Indicator/donchian.ts
@@ -5,6 +5,7 @@ import { createDonchianStateKey, EMPTY_DONCHIAN_STATE } from '../../indicators/d
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, DonchianSchedulerConfig } from '../../indicators/scheduler'
+import { calcDonchianData } from '../../indicators/calculators'
 import { createBandVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
 const DONCHIAN_UPPER_COLOR = '#0891b2'
@@ -139,6 +140,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createDonchianStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'donchian', paneIdKey:'donchianPaneId', defaultConfig:{period:20,showUpper:true,showMiddle:true,showLower:true}, computeKey:'calcDonchianData', compute:(data,c)=>calcDonchianData(data,c.period) },
 })
 class DonchianDefinition {
     static rendererFactory = createDonchianRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/ene.ts
+++ b/packages/core/src/engine/renderers/Indicator/ene.ts
@@ -8,6 +8,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorPriceRangeComputer, IndicatorRenderStateComposer } from '../../indicators/indicatorMetadata'
 import type { ENESchedulerConfig, IndicatorScheduler } from '../../indicators/scheduler'
+import { calcENEData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -315,6 +316,7 @@ export function createENERendererPlugin(): RendererPluginWithHost {
     applyResult: (host, state, _paneId) => {
         host.setSharedState(ENE_STATE_KEY, state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'ene', defaultConfig:{period:10,deviation:11}, computeKey:'calcENEData', compute:(data,c)=>calcENEData(data,c.period,c.deviation) },
 })
 class ENEDefinition {
     static rendererFactory = createENERendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/ene.ts
+++ b/packages/core/src/engine/renderers/Indicator/ene.ts
@@ -302,7 +302,7 @@ export function createENERendererPlugin(): RendererPluginWithHost {
         composeRenderState: composeENERenderState,
     },
     updateConfig: (scheduler, params) => {
-        (scheduler as IndicatorScheduler).updateENEConfig(params as Partial<ENESchedulerConfig>)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('ene', params)
     },
     semantic: {
         apply: (chart, indicator) => {

--- a/packages/core/src/engine/renderers/Indicator/expma.ts
+++ b/packages/core/src/engine/renderers/Indicator/expma.ts
@@ -228,7 +228,7 @@ export function createEXPMARendererPlugin(): RendererPluginWithHost {
         composeRenderState: composeEXPMARenderState,
     },
     updateConfig: (scheduler, params) => {
-        (scheduler as IndicatorScheduler).updateEXPMAConfig(params as Partial<EXPMASchedulerConfig>)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('expma', params)
     },
     semantic: {
         apply: (chart, indicator) => {

--- a/packages/core/src/engine/renderers/Indicator/expma.ts
+++ b/packages/core/src/engine/renderers/Indicator/expma.ts
@@ -8,6 +8,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorPriceRangeComputer, IndicatorRenderStateComposer } from '../../indicators/indicatorMetadata'
 import type { EXPMASchedulerConfig, IndicatorScheduler } from '../../indicators/scheduler'
+import { calcEXPMAData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -241,6 +242,7 @@ export function createEXPMARendererPlugin(): RendererPluginWithHost {
     applyResult: (host, state, _paneId) => {
         host.setSharedState(EXPMA_STATE_KEY, state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'expma', defaultConfig:{fastPeriod:12,slowPeriod:50}, computeKey:'calcEXPMAData', compute:(data,c)=>calcEXPMAData(data,c.fastPeriod,c.slowPeriod) },
 })
 class EXPMADefinition {
     static rendererFactory = createEXPMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/fastk.ts
+++ b/packages/core/src/engine/renderers/Indicator/fastk.ts
@@ -310,7 +310,6 @@ export function getFASTKTitleInfo(
     category: 'oscillator',
     stateKey: createFASTKStateKey,
     defaultPaneId: 'sub_FASTK',
-    paneIdField: 'fastkPaneId',
     visibleState: { compose: createFixedRangeSparseVisibleStateComposer('fastk', EMPTY_FASTK_STATE) },
     scaleRendererFactory: createFastkScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
@@ -321,7 +320,6 @@ export function getFASTKTitleInfo(
     },
     runtime: {
         configKey: 'fastk',
-        paneIdKey: 'fastkPaneId',
         defaultConfig: { period: 9, showFASTK: true },
         computeKey: 'calcFASTKData',
         compute: (data, c) => calcFASTKData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/fastk.ts
+++ b/packages/core/src/engine/renderers/Indicator/fastk.ts
@@ -9,6 +9,7 @@ import { createFixedRangeSparseVisibleStateComposer } from '../../indicators/vis
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, FASTKSchedulerConfig } from '../../indicators/scheduler'
 import { createFastkScaleRendererPlugin } from './scale/fastk_scale'
+import { calcFASTKData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -317,6 +318,13 @@ export function getFASTKTitleInfo(
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createFASTKStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'fastk',
+        paneIdKey: 'fastkPaneId',
+        defaultConfig: { period: 9, showFASTK: true },
+        computeKey: 'calcFASTKData',
+        compute: (data, c) => calcFASTKData(data, c.period),
     },
 })
 class FASTKIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/fastk.ts
+++ b/packages/core/src/engine/renderers/Indicator/fastk.ts
@@ -314,7 +314,7 @@ export function getFASTKTitleInfo(
     visibleState: { compose: createFixedRangeSparseVisibleStateComposer('fastk', EMPTY_FASTK_STATE) },
     scaleRendererFactory: createFastkScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateFASTKConfig(params as Partial<FASTKSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('fastk', params, paneId)
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createFASTKStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/fib.ts
+++ b/packages/core/src/engine/renderers/Indicator/fib.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, FibSchedulerConfig } from '../../indicators/scheduler'
 import { createExactRangePointVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { calcFibData } from '../../indicators/calculators'
 
 const FIB_COLORS = {
     high: '#94a3b8',
@@ -142,6 +143,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createFibStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'fib', paneIdKey:'fibPaneId', defaultConfig:{period:50,showLevels:true}, computeKey:'calcFibData', compute:(data,c)=>calcFibData(data,c.period) },
 })
 class FibDefinition {
     static rendererFactory = createFibRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/fib.ts
+++ b/packages/core/src/engine/renderers/Indicator/fib.ts
@@ -132,7 +132,6 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     category: 'main',
     stateKey: createFibStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'fibPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'fib_main', toActiveConfig: (params, active) => ({ ...params, showLevels: active }) },
     scale: { indicatorKey: 'fib', label: 'Fib', decimals: 4 },
@@ -143,7 +142,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createFibStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'fib', paneIdKey:'fibPaneId', defaultConfig:{period:50,showLevels:true}, computeKey:'calcFibData', compute:(data,c)=>calcFibData(data,c.period) },
+    runtime: { configKey:'fib', defaultConfig:{period:50,showLevels:true}, computeKey:'calcFibData', compute:(data,c)=>calcFibData(data,c.period) },
 })
 class FibDefinition {
     static rendererFactory = createFibRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/fib.ts
+++ b/packages/core/src/engine/renderers/Indicator/fib.ts
@@ -138,7 +138,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     scale: { indicatorKey: 'fib', label: 'Fib', decimals: 4 },
     visibleState: { compose: createExactRangePointVisibleStateComposer('fib', EMPTY_FIB_STATE, ['low', 'high']) },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateFibConfig(params as Partial<FibSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('fib', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createFibStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/hma.ts
+++ b/packages/core/src/engine/renderers/Indicator/hma.ts
@@ -133,7 +133,7 @@ export function createHMARendererPlugin(options: HMARendererOptions = {}): Rende
     visibleState: { compose: createSparseVisibleStateComposer('hma', EMPTY_HMA_STATE) },
     scale: { indicatorKey: 'hma', label: 'HMA', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateHMAConfig(params as Partial<HMASchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('hma', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createHMAStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/hma.ts
+++ b/packages/core/src/engine/renderers/Indicator/hma.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, HMASchedulerConfig } from '../../indicators/scheduler'
+import { calcHMAData } from '../../indicators/calculators'
 
 const HMA_COLOR = '#f43f5e'
 
@@ -137,6 +138,7 @@ export function createHMARendererPlugin(options: HMARendererOptions = {}): Rende
     applyResult: (host, state, paneId) => {
         host.setSharedState(createHMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'hma', paneIdKey:'hmaPaneId', defaultConfig:{period:14,showHMA:true}, computeKey:'calcHMAData', compute:(data,c)=>calcHMAData(data,c.period) },
 })
 class HMADefinition {
     static rendererFactory = createHMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/hma.ts
+++ b/packages/core/src/engine/renderers/Indicator/hma.ts
@@ -127,7 +127,6 @@ export function createHMARendererPlugin(options: HMARendererOptions = {}): Rende
     category: 'main',
     stateKey: createHMAStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'hmaPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'hma_main', toActiveConfig: (params, active) => ({ ...params, showHMA: active }) },
     visibleState: { compose: createSparseVisibleStateComposer('hma', EMPTY_HMA_STATE) },
@@ -138,7 +137,7 @@ export function createHMARendererPlugin(options: HMARendererOptions = {}): Rende
     applyResult: (host, state, paneId) => {
         host.setSharedState(createHMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'hma', paneIdKey:'hmaPaneId', defaultConfig:{period:14,showHMA:true}, computeKey:'calcHMAData', compute:(data,c)=>calcHMAData(data,c.period) },
+    runtime: { configKey:'hma', defaultConfig:{period:14,showHMA:true}, computeKey:'calcHMAData', compute:(data,c)=>calcHMAData(data,c.period) },
 })
 class HMADefinition {
     static rendererFactory = createHMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/hv.ts
+++ b/packages/core/src/engine/renderers/Indicator/hv.ts
@@ -7,6 +7,7 @@ import { createNonNegativeSparseVisibleStateComposer } from '../../indicators/vi
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, HVSchedulerConfig } from '../../indicators/scheduler'
+import { calcHVData } from '../../indicators/calculators'
 
 const HV_COLOR = '#7c3aed'
 
@@ -125,6 +126,7 @@ export function createHVRendererPlugin(options: { paneId?: string } = {}): Rende
     applyResult: (host, state, paneId) => {
         host.setSharedState(createHVStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'hv', paneIdKey:'hvPaneId', defaultConfig:{period:20,annualizationFactor:252,showHV:true}, computeKey:'calcHVData', compute:(data,c)=>calcHVData(data,c.period,c.annualizationFactor) },
 })
 class HVIndicatorDefinition {
     static rendererFactory = createHVRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/hv.ts
+++ b/packages/core/src/engine/renderers/Indicator/hv.ts
@@ -120,7 +120,7 @@ export function createHVRendererPlugin(options: { paneId?: string } = {}): Rende
     paneIdField: 'hvPaneId',
     scale: { indicatorKey: 'hv', label: 'HV', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateHVConfig(params as Partial<HVSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('hv', params, paneId)
   },
     visibleState: { compose: createNonNegativeSparseVisibleStateComposer('hv', EMPTY_HV_STATE) },
     applyResult: (host, state, paneId) => {

--- a/packages/core/src/engine/renderers/Indicator/hv.ts
+++ b/packages/core/src/engine/renderers/Indicator/hv.ts
@@ -117,7 +117,6 @@ export function createHVRendererPlugin(options: { paneId?: string } = {}): Rende
     category: 'oscillator',
     stateKey: createHVStateKey,
     defaultPaneId: 'sub_HV',
-    paneIdField: 'hvPaneId',
     scale: { indicatorKey: 'hv', label: 'HV', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
     (scheduler as IndicatorScheduler).updateIndicatorConfig('hv', params, paneId)
@@ -126,7 +125,7 @@ export function createHVRendererPlugin(options: { paneId?: string } = {}): Rende
     applyResult: (host, state, paneId) => {
         host.setSharedState(createHVStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'hv', paneIdKey:'hvPaneId', defaultConfig:{period:20,annualizationFactor:252,showHV:true}, computeKey:'calcHVData', compute:(data,c)=>calcHVData(data,c.period,c.annualizationFactor) },
+    runtime: { configKey:'hv', defaultConfig:{period:20,annualizationFactor:252,showHV:true}, computeKey:'calcHVData', compute:(data,c)=>calcHVData(data,c.period,c.annualizationFactor) },
 })
 class HVIndicatorDefinition {
     static rendererFactory = createHVRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/ichimoku.ts
+++ b/packages/core/src/engine/renderers/Indicator/ichimoku.ts
@@ -5,6 +5,7 @@ import { createIchimokuStateKey, EMPTY_ICHIMOKU_STATE } from '../../indicators/i
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, IchimokuSchedulerConfig } from '../../indicators/scheduler'
+import { calcIchimokuData } from '../../indicators/calculators'
 import { createValuePointVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
 const TENKAN_COLOR = '#dc2626'
@@ -183,6 +184,7 @@ function fillCloud(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createIchimokuStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'ichimoku', paneIdKey:'ichimokuPaneId', defaultConfig:{tenkanPeriod:9,kijunPeriod:26,spanBPeriod:52,displacement:26,showTenkan:true,showKijun:true,showSpanA:true,showSpanB:true,showCloud:true,showChikou:true}, computeKey:'calcIchimokuData', compute:(data,c)=>calcIchimokuData(data,c.tenkanPeriod,c.kijunPeriod,c.spanBPeriod,c.displacement) },
 })
 class IchimokuDefinition {
     static rendererFactory = createIchimokuRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/ichimoku.ts
+++ b/packages/core/src/engine/renderers/Indicator/ichimoku.ts
@@ -173,7 +173,6 @@ function fillCloud(
     category: 'main',
     stateKey: createIchimokuStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'ichimokuPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'ichimoku_main', toActiveConfig: (params, active) => ({ ...params, showTenkan: active, showKijun: active, showSpanA: active, showSpanB: active, showChikou: active, showCloud: active }) },
     scale: { indicatorKey: 'ichimoku', label: 'Ichimoku', decimals: 2 },
@@ -184,7 +183,7 @@ function fillCloud(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createIchimokuStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'ichimoku', paneIdKey:'ichimokuPaneId', defaultConfig:{tenkanPeriod:9,kijunPeriod:26,spanBPeriod:52,displacement:26,showTenkan:true,showKijun:true,showSpanA:true,showSpanB:true,showCloud:true,showChikou:true}, computeKey:'calcIchimokuData', compute:(data,c)=>calcIchimokuData(data,c.tenkanPeriod,c.kijunPeriod,c.spanBPeriod,c.displacement) },
+    runtime: { configKey:'ichimoku', defaultConfig:{tenkanPeriod:9,kijunPeriod:26,spanBPeriod:52,displacement:26,showTenkan:true,showKijun:true,showSpanA:true,showSpanB:true,showCloud:true,showChikou:true}, computeKey:'calcIchimokuData', compute:(data,c)=>calcIchimokuData(data,c.tenkanPeriod,c.kijunPeriod,c.spanBPeriod,c.displacement) },
 })
 class IchimokuDefinition {
     static rendererFactory = createIchimokuRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/ichimoku.ts
+++ b/packages/core/src/engine/renderers/Indicator/ichimoku.ts
@@ -179,7 +179,7 @@ function fillCloud(
     scale: { indicatorKey: 'ichimoku', label: 'Ichimoku', decimals: 2 },
     visibleState: { compose: createValuePointVisibleStateComposer('ichimoku', EMPTY_ICHIMOKU_STATE, ['tenkan', 'kijun', 'spanA', 'spanB', 'chikou']) },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateIchimokuConfig(params as Partial<IchimokuSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('ichimoku', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createIchimokuStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/kama.ts
+++ b/packages/core/src/engine/renderers/Indicator/kama.ts
@@ -127,7 +127,6 @@ export function createKAMARendererPlugin(options: KAMARendererOptions = {}): Ren
     category: 'main',
     stateKey: createKAMAStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'kamaPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'kama_main', toActiveConfig: (params, active) => ({ ...params, showKAMA: active }) },
     visibleState: { compose: createSparseVisibleStateComposer('kama', EMPTY_KAMA_STATE) },
@@ -138,7 +137,7 @@ export function createKAMARendererPlugin(options: KAMARendererOptions = {}): Ren
     applyResult: (host, state, paneId) => {
         host.setSharedState(createKAMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'kama', paneIdKey:'kamaPaneId', defaultConfig:{period:10,fastPeriod:2,slowPeriod:30,showKAMA:true}, computeKey:'calcKAMAData', compute:(data,c)=>calcKAMAData(data,c.period,c.fastPeriod,c.slowPeriod) },
+    runtime: { configKey:'kama', defaultConfig:{period:10,fastPeriod:2,slowPeriod:30,showKAMA:true}, computeKey:'calcKAMAData', compute:(data,c)=>calcKAMAData(data,c.period,c.fastPeriod,c.slowPeriod) },
 })
 class KAMADefinition {
     static rendererFactory = createKAMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/kama.ts
+++ b/packages/core/src/engine/renderers/Indicator/kama.ts
@@ -133,7 +133,7 @@ export function createKAMARendererPlugin(options: KAMARendererOptions = {}): Ren
     visibleState: { compose: createSparseVisibleStateComposer('kama', EMPTY_KAMA_STATE) },
     scale: { indicatorKey: 'kama', label: 'KAMA', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateKAMAConfig(params as Partial<KAMASchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('kama', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createKAMAStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/kama.ts
+++ b/packages/core/src/engine/renderers/Indicator/kama.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, KAMASchedulerConfig } from '../../indicators/scheduler'
+import { calcKAMAData } from '../../indicators/calculators'
 
 const KAMA_COLOR = '#0ea5e9'
 
@@ -137,6 +138,7 @@ export function createKAMARendererPlugin(options: KAMARendererOptions = {}): Ren
     applyResult: (host, state, paneId) => {
         host.setSharedState(createKAMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'kama', paneIdKey:'kamaPaneId', defaultConfig:{period:10,fastPeriod:2,slowPeriod:30,showKAMA:true}, computeKey:'calcKAMAData', compute:(data,c)=>calcKAMAData(data,c.period,c.fastPeriod,c.slowPeriod) },
 })
 class KAMADefinition {
     static rendererFactory = createKAMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/keltner.ts
+++ b/packages/core/src/engine/renderers/Indicator/keltner.ts
@@ -135,7 +135,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     scale: { indicatorKey: 'keltner', label: 'Keltner', decimals: 2 },
     visibleState: { compose: createBandVisibleStateComposer('keltner', EMPTY_KELTNER_STATE, 'lower', 'upper') },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateKeltnerConfig(params as Partial<KeltnerSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('keltner', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createKeltnerStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/keltner.ts
+++ b/packages/core/src/engine/renderers/Indicator/keltner.ts
@@ -129,7 +129,6 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     category: 'main',
     stateKey: createKeltnerStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'keltnerPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'keltner_main', toActiveConfig: (params, active) => ({ ...params, showUpper: active, showMiddle: active, showLower: active }) },
     scale: { indicatorKey: 'keltner', label: 'Keltner', decimals: 2 },
@@ -140,7 +139,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createKeltnerStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'keltner', paneIdKey:'keltnerPaneId', defaultConfig:{emaPeriod:20,atrPeriod:10,multiplier:2,showUpper:true,showMiddle:true,showLower:true}, computeKey:'calcKeltnerData', compute:(data,c)=>calcKeltnerData(data,c.emaPeriod,c.atrPeriod,c.multiplier) },
+    runtime: { configKey:'keltner', defaultConfig:{emaPeriod:20,atrPeriod:10,multiplier:2,showUpper:true,showMiddle:true,showLower:true}, computeKey:'calcKeltnerData', compute:(data,c)=>calcKeltnerData(data,c.emaPeriod,c.atrPeriod,c.multiplier) },
 })
 class KeltnerDefinition {
     static rendererFactory = createKeltnerRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/keltner.ts
+++ b/packages/core/src/engine/renderers/Indicator/keltner.ts
@@ -5,6 +5,7 @@ import { createKeltnerStateKey, EMPTY_KELTNER_STATE } from '../../indicators/kel
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, KeltnerSchedulerConfig } from '../../indicators/scheduler'
+import { calcKeltnerData } from '../../indicators/calculators'
 import { createBandVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
 const KELTNER_UPPER_COLOR = '#7c3aed'
@@ -139,6 +140,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createKeltnerStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'keltner', paneIdKey:'keltnerPaneId', defaultConfig:{emaPeriod:20,atrPeriod:10,multiplier:2,showUpper:true,showMiddle:true,showLower:true}, computeKey:'calcKeltnerData', compute:(data,c)=>calcKeltnerData(data,c.emaPeriod,c.atrPeriod,c.multiplier) },
 })
 class KeltnerDefinition {
     static rendererFactory = createKeltnerRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/kst.ts
+++ b/packages/core/src/engine/renderers/Indicator/kst.ts
@@ -297,7 +297,6 @@ export function getKSTTitleInfo(
     category: 'oscillator',
     stateKey: createKSTStateKey,
     defaultPaneId: 'sub_KST',
-    paneIdField: 'kstPaneId',
     scaleRendererFactory: createKstScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
     (scheduler as IndicatorScheduler).updateIndicatorConfig('kst', params, paneId)
@@ -306,7 +305,7 @@ export function getKSTTitleInfo(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createKSTStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'kst', paneIdKey:'kstPaneId', defaultConfig:{roc1:10,roc2:15,roc3:20,roc4:30,signalPeriod:9,showKST:true,showSignal:true}, computeKey:'calcKSTData', compute:(data,c)=>calcKSTData(data,c.roc1,c.roc2,c.roc3,c.roc4,c.signalPeriod) },
+    runtime: { configKey:'kst', defaultConfig:{roc1:10,roc2:15,roc3:20,roc4:30,signalPeriod:9,showKST:true,showSignal:true}, computeKey:'calcKSTData', compute:(data,c)=>calcKSTData(data,c.roc1,c.roc2,c.roc3,c.roc4,c.signalPeriod) },
 })
 class KSTIndicatorDefinition {
     static rendererFactory = createKSTRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/kst.ts
+++ b/packages/core/src/engine/renderers/Indicator/kst.ts
@@ -300,7 +300,7 @@ export function getKSTTitleInfo(
     paneIdField: 'kstPaneId',
     scaleRendererFactory: createKstScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateKSTConfig(params as Partial<KSTSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('kst', params, paneId)
   },
     visibleState: { compose: createPaddedPointVisibleStateComposer('kst', EMPTY_KST_STATE, ['kst', 'signal'] as const) },
     applyResult: (host, state, paneId) => {

--- a/packages/core/src/engine/renderers/Indicator/kst.ts
+++ b/packages/core/src/engine/renderers/Indicator/kst.ts
@@ -9,6 +9,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, KSTSchedulerConfig } from '../../indicators/scheduler'
 import { createKstScaleRendererPlugin } from './scale/kst_scale'
+import { calcKSTData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -305,6 +306,7 @@ export function getKSTTitleInfo(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createKSTStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'kst', paneIdKey:'kstPaneId', defaultConfig:{roc1:10,roc2:15,roc3:20,roc4:30,signalPeriod:9,showKST:true,showSignal:true}, computeKey:'calcKSTData', compute:(data,c)=>calcKSTData(data,c.roc1,c.roc2,c.roc3,c.roc4,c.signalPeriod) },
 })
 class KSTIndicatorDefinition {
     static rendererFactory = createKSTRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/ma.ts
+++ b/packages/core/src/engine/renderers/Indicator/ma.ts
@@ -112,7 +112,7 @@ function getMAStateKey(host: PluginHost | null): string | null {
         composeRenderState: composeMARenderState,
     },
     updateConfig: (scheduler, params) => {
-        (scheduler as IndicatorScheduler).updateMAConfig(params as MAFlags)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('ma', params)
     },
     semantic: {
         apply: (chart, indicator) => {

--- a/packages/core/src/engine/renderers/Indicator/ma.ts
+++ b/packages/core/src/engine/renderers/Indicator/ma.ts
@@ -5,7 +5,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorPriceRangeComputer, IndicatorRenderStateComposer } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler } from '../../indicators/scheduler'
-import type { MAFlags } from '../../indicators/calculators'
+import { calcMAData, type MAFlags } from '../../indicators/calculators'
 import { alignToPhysicalPixelCenter } from '../../draw/pixelAlign'
 import { resolveThemeColors } from '../../../tokens'
 
@@ -128,6 +128,7 @@ function getMAStateKey(host: PluginHost | null): string | null {
     applyResult: (host, state, _paneId) => {
         host.setSharedState(MA_STATE_KEY, state as any, 'ma_scheduler')
     },
+    runtime: { configKey:'ma', defaultConfig:{ma5:true,ma10:true,ma20:true,ma30:true,ma60:true}, computeKey:'calcMAData', compute:(data,c)=>{const p=[5,10,20,30,60];const r:Record<number,(number|undefined)[]>={};for(const o of p){if((c as any)['ma'+o])r[o]=calcMAData(data,o)}return r} },
 })
 class MADefinition {
     static rendererFactory = createMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/macd.ts
+++ b/packages/core/src/engine/renderers/Indicator/macd.ts
@@ -475,7 +475,7 @@ export function getMACDTitleInfo(
   scaleRendererFactory: createMacdScaleRendererPlugin,
   visibleState: { compose: createMACDVisibleStateComposer('macd', EMPTY_MACD_STATE) },
   updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateMACDConfig(params as Partial<MACDSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('macd', params, paneId)
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createMACDStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/macd.ts
+++ b/packages/core/src/engine/renderers/Indicator/macd.ts
@@ -471,7 +471,6 @@ export function getMACDTitleInfo(
   category: 'oscillator',
   stateKey: createMACDStateKey,
   defaultPaneId: 'sub_MACD',
-  paneIdField: 'macdPaneId',
   scaleRendererFactory: createMacdScaleRendererPlugin,
   visibleState: { compose: createMACDVisibleStateComposer('macd', EMPTY_MACD_STATE) },
   updateConfig: (scheduler, params, paneId) => {
@@ -480,7 +479,7 @@ export function getMACDTitleInfo(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createMACDStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'macd', paneIdKey:'macdPaneId', defaultConfig:{fastPeriod:12,slowPeriod:26,signalPeriod:9,showDIF:true,showDEA:true,showBAR:true}, computeKey:'calcMACDData', compute:(data,c)=>calcMACDData(data,c.fastPeriod,c.slowPeriod,c.signalPeriod) },
+    runtime: { configKey:'macd', defaultConfig:{fastPeriod:12,slowPeriod:26,signalPeriod:9,showDIF:true,showDEA:true,showBAR:true}, computeKey:'calcMACDData', compute:(data,c)=>calcMACDData(data,c.fastPeriod,c.slowPeriod,c.signalPeriod) },
 })
 class MACDIndicatorDefinition {
   static rendererFactory = createMACDRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/macd.ts
+++ b/packages/core/src/engine/renderers/Indicator/macd.ts
@@ -477,9 +477,10 @@ export function getMACDTitleInfo(
   updateConfig: (scheduler, params, paneId) => {
     (scheduler as IndicatorScheduler).updateMACDConfig(params as Partial<MACDSchedulerConfig>, paneId)
   },
-  applyResult: (host, state, paneId) => {
-    host.setSharedState(createMACDStateKey(paneId), state as any, 'indicator_scheduler')
-  },
+    applyResult: (host, state, paneId) => {
+        host.setSharedState(createMACDStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: { configKey:'macd', paneIdKey:'macdPaneId', defaultConfig:{fastPeriod:12,slowPeriod:26,signalPeriod:9,showDIF:true,showDEA:true,showBAR:true}, computeKey:'calcMACDData', compute:(data,c)=>calcMACDData(data,c.fastPeriod,c.slowPeriod,c.signalPeriod) },
 })
 class MACDIndicatorDefinition {
   static rendererFactory = createMACDRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/mfi.ts
+++ b/packages/core/src/engine/renderers/Indicator/mfi.ts
@@ -134,7 +134,6 @@ export function createMFIRendererPlugin(options: { paneId?: string } = {}): Rend
     category: 'volume',
     stateKey: createMFIStateKey,
     defaultPaneId: 'sub_MFI',
-    paneIdField: 'mfiPaneId',
     visibleState: { compose: createFixedRangeSparseVisibleStateComposer('mfi', EMPTY_MFI_STATE) },
     scale: { indicatorKey: 'mfi', label: 'MFI', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
@@ -145,7 +144,6 @@ export function createMFIRendererPlugin(options: { paneId?: string } = {}): Rend
     },
     runtime: {
         configKey: 'mfi',
-        paneIdKey: 'mfiPaneId',
         defaultConfig: { period: 14, showMFI: true },
         computeKey: 'calcMFIData',
         compute: (data, c) => calcMFIData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/mfi.ts
+++ b/packages/core/src/engine/renderers/Indicator/mfi.ts
@@ -138,7 +138,7 @@ export function createMFIRendererPlugin(options: { paneId?: string } = {}): Rend
     visibleState: { compose: createFixedRangeSparseVisibleStateComposer('mfi', EMPTY_MFI_STATE) },
     scale: { indicatorKey: 'mfi', label: 'MFI', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateMFIConfig(params as Partial<MFISchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('mfi', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createMFIStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/mfi.ts
+++ b/packages/core/src/engine/renderers/Indicator/mfi.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { createFixedRangeSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, MFISchedulerConfig } from '../../indicators/scheduler'
+import { calcMFIData } from '../../indicators/calculators'
 
 const MFI_COLOR = '#fb923c'
 
@@ -141,6 +142,13 @@ export function createMFIRendererPlugin(options: { paneId?: string } = {}): Rend
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createMFIStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'mfi',
+        paneIdKey: 'mfiPaneId',
+        defaultConfig: { period: 14, showMFI: true },
+        computeKey: 'calcMFIData',
+        compute: (data, c) => calcMFIData(data, c.period),
     },
 })
 class MFIIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/mom.ts
+++ b/packages/core/src/engine/renderers/Indicator/mom.ts
@@ -10,6 +10,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, MOMSchedulerConfig } from '../../indicators/scheduler'
 import { createMomScaleRendererPlugin } from './scale/mom_scale'
+import { calcMOMData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -313,6 +314,13 @@ export function getMOMTitleInfo(
     visibleState: { compose: createPaddedSparseVisibleStateComposer('mom', EMPTY_MOM_STATE) },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createMOMStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'mom',
+        paneIdKey: 'momPaneId',
+        defaultConfig: { period: 10, showMOM: true },
+        computeKey: 'calcMOMData',
+        compute: (data, c) => calcMOMData(data, c.period),
     },
 })
 class MOMIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/mom.ts
+++ b/packages/core/src/engine/renderers/Indicator/mom.ts
@@ -309,7 +309,7 @@ export function getMOMTitleInfo(
     paneIdField: 'momPaneId',
     scaleRendererFactory: createMomScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateMOMConfig(params as Partial<MOMSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('mom', params, paneId)
   },
     visibleState: { compose: createPaddedSparseVisibleStateComposer('mom', EMPTY_MOM_STATE) },
     applyResult: (host, state, paneId) => {

--- a/packages/core/src/engine/renderers/Indicator/mom.ts
+++ b/packages/core/src/engine/renderers/Indicator/mom.ts
@@ -306,7 +306,6 @@ export function getMOMTitleInfo(
     category: 'oscillator',
     stateKey: createMOMStateKey,
     defaultPaneId: 'sub_MOM',
-    paneIdField: 'momPaneId',
     scaleRendererFactory: createMomScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
     (scheduler as IndicatorScheduler).updateIndicatorConfig('mom', params, paneId)
@@ -317,7 +316,6 @@ export function getMOMTitleInfo(
     },
     runtime: {
         configKey: 'mom',
-        paneIdKey: 'momPaneId',
         defaultConfig: { period: 10, showMOM: true },
         computeKey: 'calcMOMData',
         compute: (data, c) => calcMOMData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/obv.ts
+++ b/packages/core/src/engine/renderers/Indicator/obv.ts
@@ -115,7 +115,6 @@ export function createOBVRendererPlugin(options: { paneId?: string } = {}): Rend
     category: 'volume',
     stateKey: createOBVStateKey,
     defaultPaneId: 'sub_OBV',
-    paneIdField: 'obvPaneId',
     visibleState: { compose: createSparseVisibleStateComposer('obv', EMPTY_OBV_STATE) },
     scale: { indicatorKey: 'obv', label: 'OBV', decimals: 0 },
     updateConfig: (scheduler, params, paneId) => {
@@ -126,7 +125,6 @@ export function createOBVRendererPlugin(options: { paneId?: string } = {}): Rend
     },
     runtime: {
         configKey: 'obv',
-        paneIdKey: 'obvPaneId',
         defaultConfig: { showOBV: true },
         computeKey: 'calcOBVData',
         compute: (data, c) => calcOBVData(data),

--- a/packages/core/src/engine/renderers/Indicator/obv.ts
+++ b/packages/core/src/engine/renderers/Indicator/obv.ts
@@ -119,7 +119,7 @@ export function createOBVRendererPlugin(options: { paneId?: string } = {}): Rend
     visibleState: { compose: createSparseVisibleStateComposer('obv', EMPTY_OBV_STATE) },
     scale: { indicatorKey: 'obv', label: 'OBV', decimals: 0 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateOBVConfig(params as Partial<OBVSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('obv', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createOBVStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/obv.ts
+++ b/packages/core/src/engine/renderers/Indicator/obv.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, OBVSchedulerConfig } from '../../indicators/scheduler'
+import { calcOBVData } from '../../indicators/calculators'
 
 const OBV_COLOR = '#16a34a'
 
@@ -122,6 +123,13 @@ export function createOBVRendererPlugin(options: { paneId?: string } = {}): Rend
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createOBVStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'obv',
+        paneIdKey: 'obvPaneId',
+        defaultConfig: { showOBV: true },
+        computeKey: 'calcOBVData',
+        compute: (data, c) => calcOBVData(data),
     },
 })
 class OBVIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/parkinson.ts
+++ b/packages/core/src/engine/renderers/Indicator/parkinson.ts
@@ -7,6 +7,7 @@ import { createNonNegativeSparseVisibleStateComposer } from '../../indicators/vi
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, ParkinsonSchedulerConfig } from '../../indicators/scheduler'
+import { calcParkinsonData } from '../../indicators/calculators'
 
 const PARKINSON_COLOR = '#0891b2'
 
@@ -125,6 +126,7 @@ export function createParkinsonRendererPlugin(options: { paneId?: string } = {})
     applyResult: (host, state, paneId) => {
         host.setSharedState(createParkinsonStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'parkinson', paneIdKey:'parkinsonPaneId', defaultConfig:{period:20,annualizationFactor:252,showParkinson:true}, computeKey:'calcParkinsonData', compute:(data,c)=>calcParkinsonData(data,c.period,c.annualizationFactor) },
 })
 class ParkinsonIndicatorDefinition {
     static rendererFactory = createParkinsonRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/parkinson.ts
+++ b/packages/core/src/engine/renderers/Indicator/parkinson.ts
@@ -120,7 +120,7 @@ export function createParkinsonRendererPlugin(options: { paneId?: string } = {})
     paneIdField: 'parkinsonPaneId',
     scale: { indicatorKey: 'parkinson', label: 'Parkinson', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateParkinsonConfig(params as Partial<ParkinsonSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('parkinson', params, paneId)
     },
     visibleState: { compose: createNonNegativeSparseVisibleStateComposer('parkinson', EMPTY_PARKINSON_STATE) },
     applyResult: (host, state, paneId) => {

--- a/packages/core/src/engine/renderers/Indicator/parkinson.ts
+++ b/packages/core/src/engine/renderers/Indicator/parkinson.ts
@@ -117,7 +117,6 @@ export function createParkinsonRendererPlugin(options: { paneId?: string } = {})
     category: 'oscillator',
     stateKey: createParkinsonStateKey,
     defaultPaneId: 'sub_Parkinson',
-    paneIdField: 'parkinsonPaneId',
     scale: { indicatorKey: 'parkinson', label: 'Parkinson', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
         (scheduler as IndicatorScheduler).updateIndicatorConfig('parkinson', params, paneId)
@@ -126,7 +125,7 @@ export function createParkinsonRendererPlugin(options: { paneId?: string } = {})
     applyResult: (host, state, paneId) => {
         host.setSharedState(createParkinsonStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'parkinson', paneIdKey:'parkinsonPaneId', defaultConfig:{period:20,annualizationFactor:252,showParkinson:true}, computeKey:'calcParkinsonData', compute:(data,c)=>calcParkinsonData(data,c.period,c.annualizationFactor) },
+    runtime: { configKey:'parkinson', defaultConfig:{period:20,annualizationFactor:252,showParkinson:true}, computeKey:'calcParkinsonData', compute:(data,c)=>calcParkinsonData(data,c.period,c.annualizationFactor) },
 })
 class ParkinsonIndicatorDefinition {
     static rendererFactory = createParkinsonRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/pivot.ts
+++ b/packages/core/src/engine/renderers/Indicator/pivot.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, PivotSchedulerConfig } from '../../indicators/scheduler'
 import { createExactRangePointVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { calcPivotData } from '../../indicators/calculators'
 
 const PP_COLOR = '#94a3b8'
 const R_COLOR = '#dc2626'
@@ -132,6 +133,7 @@ function drawStep(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createPivotStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'pivot', paneIdKey:'pivotPaneId', defaultConfig:{showPP:true,showR1:true,showR2:true,showR3:true,showS1:true,showS2:true,showS3:true}, computeKey:'calcPivotData', compute:(data,c)=>calcPivotData(data) },
 })
 class PivotDefinition {
     static rendererFactory = createPivotRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/pivot.ts
+++ b/packages/core/src/engine/renderers/Indicator/pivot.ts
@@ -128,7 +128,7 @@ function drawStep(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     scale: { indicatorKey: 'pivot', label: 'Pivot', decimals: 2 },
     visibleState: { compose: createExactRangePointVisibleStateComposer('pivot', EMPTY_PIVOT_STATE, ['pp', 'r1', 'r2', 'r3', 's1', 's2', 's3']) },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updatePivotConfig(params as Partial<PivotSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('pivot', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createPivotStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/pivot.ts
+++ b/packages/core/src/engine/renderers/Indicator/pivot.ts
@@ -122,7 +122,6 @@ function drawStep(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     category: 'main',
     stateKey: createPivotStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'pivotPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'pivot_main', toActiveConfig: (params, active) => ({ ...params, showPP: active, showR1: active, showR2: active, showR3: active, showS1: active, showS2: active, showS3: active }) },
     scale: { indicatorKey: 'pivot', label: 'Pivot', decimals: 2 },
@@ -133,7 +132,7 @@ function drawStep(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createPivotStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'pivot', paneIdKey:'pivotPaneId', defaultConfig:{showPP:true,showR1:true,showR2:true,showR3:true,showS1:true,showS2:true,showS3:true}, computeKey:'calcPivotData', compute:(data,c)=>calcPivotData(data) },
+    runtime: { configKey:'pivot', defaultConfig:{showPP:true,showR1:true,showR2:true,showR3:true,showS1:true,showS2:true,showS3:true}, computeKey:'calcPivotData', compute:(data,c)=>calcPivotData(data) },
 })
 class PivotDefinition {
     static rendererFactory = createPivotRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/pvt.ts
+++ b/packages/core/src/engine/renderers/Indicator/pvt.ts
@@ -115,7 +115,6 @@ export function createPVTRendererPlugin(options: { paneId?: string } = {}): Rend
     category: 'volume',
     stateKey: createPVTStateKey,
     defaultPaneId: 'sub_PVT',
-    paneIdField: 'pvtPaneId',
     visibleState: { compose: createSparseVisibleStateComposer('pvt', EMPTY_PVT_STATE) },
     scale: { indicatorKey: 'pvt', label: 'PVT', decimals: 0 },
     updateConfig: (scheduler, params, paneId) => {
@@ -126,7 +125,6 @@ export function createPVTRendererPlugin(options: { paneId?: string } = {}): Rend
     },
     runtime: {
         configKey: 'pvt',
-        paneIdKey: 'pvtPaneId',
         defaultConfig: { showPVT: true },
         computeKey: 'calcPVTData',
         compute: (data, c) => calcPVTData(data),

--- a/packages/core/src/engine/renderers/Indicator/pvt.ts
+++ b/packages/core/src/engine/renderers/Indicator/pvt.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, PVTSchedulerConfig } from '../../indicators/scheduler'
+import { calcPVTData } from '../../indicators/calculators'
 
 const PVT_COLOR = '#a855f7'
 
@@ -122,6 +123,13 @@ export function createPVTRendererPlugin(options: { paneId?: string } = {}): Rend
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createPVTStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'pvt',
+        paneIdKey: 'pvtPaneId',
+        defaultConfig: { showPVT: true },
+        computeKey: 'calcPVTData',
+        compute: (data, c) => calcPVTData(data),
     },
 })
 class PVTIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/pvt.ts
+++ b/packages/core/src/engine/renderers/Indicator/pvt.ts
@@ -119,7 +119,7 @@ export function createPVTRendererPlugin(options: { paneId?: string } = {}): Rend
     visibleState: { compose: createSparseVisibleStateComposer('pvt', EMPTY_PVT_STATE) },
     scale: { indicatorKey: 'pvt', label: 'PVT', decimals: 0 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updatePVTConfig(params as Partial<PVTSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('pvt', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createPVTStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/roc.ts
+++ b/packages/core/src/engine/renderers/Indicator/roc.ts
@@ -135,7 +135,6 @@ export function createROCRendererPlugin(options: ROCRendererOptions = {}): Rende
     category: 'oscillator',
     stateKey: createROCStateKey,
     defaultPaneId: 'sub_ROC',
-    paneIdField: 'rocPaneId',
     visibleState: { compose: createSparseVisibleStateComposer('roc', EMPTY_ROC_STATE) },
     scale: { indicatorKey: 'roc', label: 'ROC', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
@@ -146,7 +145,6 @@ export function createROCRendererPlugin(options: ROCRendererOptions = {}): Rende
     },
     runtime: {
         configKey: 'roc',
-        paneIdKey: 'rocPaneId',
         defaultConfig: { period: 12, showROC: true },
         computeKey: 'calcROCData',
         compute: (data, c) => calcROCData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/roc.ts
+++ b/packages/core/src/engine/renderers/Indicator/roc.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, ROCSchedulerConfig } from '../../indicators/scheduler'
+import { calcROCData } from '../../indicators/calculators'
 
 const ROC_COLOR = '#0ea5e9'
 
@@ -142,6 +143,13 @@ export function createROCRendererPlugin(options: ROCRendererOptions = {}): Rende
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createROCStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'roc',
+        paneIdKey: 'rocPaneId',
+        defaultConfig: { period: 12, showROC: true },
+        computeKey: 'calcROCData',
+        compute: (data, c) => calcROCData(data, c.period),
     },
 })
 class ROCIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/roc.ts
+++ b/packages/core/src/engine/renderers/Indicator/roc.ts
@@ -139,7 +139,7 @@ export function createROCRendererPlugin(options: ROCRendererOptions = {}): Rende
     visibleState: { compose: createSparseVisibleStateComposer('roc', EMPTY_ROC_STATE) },
     scale: { indicatorKey: 'roc', label: 'ROC', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateROCConfig(params as Partial<ROCSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('roc', params, paneId)
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createROCStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/rsi.ts
+++ b/packages/core/src/engine/renderers/Indicator/rsi.ts
@@ -9,6 +9,7 @@ import { createFixedRangeRecordVisibleStateComposer } from '../../indicators/vis
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, RSISchedulerConfig } from '../../indicators/scheduler'
 import { createRsiScaleRendererPlugin } from './scale/rsi_scale'
+import { calcRSIData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -398,6 +399,7 @@ export function getRSITitleInfo(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createRSIStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'rsi', paneIdKey:'rsiPaneId', defaultConfig:{period1:6,period2:12,period3:24,showRSI1:true,showRSI2:true,showRSI3:true}, computeKey:'calcRSIData', compute:(data,c)=>{const p=[c.period1,c.period2,c.period3];const s=[c.showRSI1,c.showRSI2,c.showRSI3];const r:Record<number,(number|undefined)[]>={};for(let i=0;i<3;i++){if(s[i])r[p[i]]=calcRSIData(data,p[i])}return r} },
 })
 class RSIIndicatorDefinition {
     static rendererFactory = createRSIRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/rsi.ts
+++ b/packages/core/src/engine/renderers/Indicator/rsi.ts
@@ -390,7 +390,6 @@ export function getRSITitleInfo(
     category: 'oscillator',
     stateKey: createRSIStateKey,
     defaultPaneId: 'sub_RSI',
-    paneIdField: 'rsiPaneId',
     visibleState: { compose: createFixedRangeRecordVisibleStateComposer('rsi', EMPTY_RSI_STATE) },
     scaleRendererFactory: createRsiScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
@@ -399,7 +398,7 @@ export function getRSITitleInfo(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createRSIStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'rsi', paneIdKey:'rsiPaneId', defaultConfig:{period1:6,period2:12,period3:24,showRSI1:true,showRSI2:true,showRSI3:true}, computeKey:'calcRSIData', compute:(data,c)=>{const p=[c.period1,c.period2,c.period3];const s=[c.showRSI1,c.showRSI2,c.showRSI3];const r:Record<number,(number|undefined)[]>={};for(let i=0;i<3;i++){if(s[i])r[p[i]]=calcRSIData(data,p[i])}return r} },
+    runtime: { configKey:'rsi', defaultConfig:{period1:6,period2:12,period3:24,showRSI1:true,showRSI2:true,showRSI3:true}, computeKey:'calcRSIData', compute:(data,c)=>{const p=[c.period1,c.period2,c.period3];const s=[c.showRSI1,c.showRSI2,c.showRSI3];const r:Record<number,(number|undefined)[]>={};for(let i=0;i<3;i++){if(s[i])r[p[i]]=calcRSIData(data,p[i])}return r} },
 })
 class RSIIndicatorDefinition {
     static rendererFactory = createRSIRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/rsi.ts
+++ b/packages/core/src/engine/renderers/Indicator/rsi.ts
@@ -394,7 +394,7 @@ export function getRSITitleInfo(
     visibleState: { compose: createFixedRangeRecordVisibleStateComposer('rsi', EMPTY_RSI_STATE) },
     scaleRendererFactory: createRsiScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateRSIConfig(params as Partial<RSISchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('rsi', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createRSIStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/sar.ts
+++ b/packages/core/src/engine/renderers/Indicator/sar.ts
@@ -110,7 +110,7 @@ export function createSARRendererPlugin(options: SARRendererOptions = {}): Rende
     scale: { indicatorKey: 'sar', label: 'SAR', decimals: 4 },
     visibleState: { compose: createValuePointVisibleStateComposer('sar', EMPTY_SAR_STATE, ['value']) },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateSARConfig(params as Partial<SARSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('sar', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSARStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/sar.ts
+++ b/packages/core/src/engine/renderers/Indicator/sar.ts
@@ -104,7 +104,6 @@ export function createSARRendererPlugin(options: SARRendererOptions = {}): Rende
     category: 'main',
     stateKey: createSARStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'sarPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'sar_main', toActiveConfig: (params, active) => ({ ...params, showSAR: active }) },
     scale: { indicatorKey: 'sar', label: 'SAR', decimals: 4 },
@@ -115,7 +114,7 @@ export function createSARRendererPlugin(options: SARRendererOptions = {}): Rende
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSARStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'sar', paneIdKey:'sarPaneId', defaultConfig:{step:0.02,maxStep:0.2,showSAR:true}, computeKey:'calcSARData', compute:(data,c)=>calcSARData(data,c.step,c.maxStep) },
+    runtime: { configKey:'sar', defaultConfig:{step:0.02,maxStep:0.2,showSAR:true}, computeKey:'calcSARData', compute:(data,c)=>calcSARData(data,c.step,c.maxStep) },
 })
 class SARDefinition {
     static rendererFactory = createSARRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/sar.ts
+++ b/packages/core/src/engine/renderers/Indicator/sar.ts
@@ -5,6 +5,7 @@ import { createSARStateKey, EMPTY_SAR_STATE } from '../../indicators/sarState'
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, SARSchedulerConfig } from '../../indicators/scheduler'
+import { calcSARData } from '../../indicators/calculators'
 import { createValuePointVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
 const SAR_UP_COLOR = '#22c55e'
@@ -114,6 +115,7 @@ export function createSARRendererPlugin(options: SARRendererOptions = {}): Rende
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSARStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'sar', paneIdKey:'sarPaneId', defaultConfig:{step:0.02,maxStep:0.2,showSAR:true}, computeKey:'calcSARData', compute:(data,c)=>calcSARData(data,c.step,c.maxStep) },
 })
 class SARDefinition {
     static rendererFactory = createSARRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/stoch.ts
+++ b/packages/core/src/engine/renderers/Indicator/stoch.ts
@@ -9,6 +9,7 @@ import { createFixedRangePointVisibleStateComposer } from '../../indicators/visi
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, STOCHSchedulerConfig } from '../../indicators/scheduler'
 import { createStochScaleRendererPlugin } from './scale/stoch_scale'
+import { calcSTOCHData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -361,6 +362,7 @@ export function getSTOCHTitleInfo(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSTOCHStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'stoch', paneIdKey:'stochPaneId', defaultConfig:{n:9,m:3,showK:true,showD:true}, computeKey:'calcSTOCHData', compute:(data,c)=>calcSTOCHData(data,c.n,c.m) },
 })
 class STOCHIndicatorDefinition {
     static rendererFactory = createSTOCHRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/stoch.ts
+++ b/packages/core/src/engine/renderers/Indicator/stoch.ts
@@ -357,7 +357,7 @@ export function getSTOCHTitleInfo(
     visibleState: { compose: createFixedRangePointVisibleStateComposer('stoch', EMPTY_STOCH_STATE, ['k', 'd'] as const) },
     scaleRendererFactory: createStochScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateSTOCHConfig(params as Partial<STOCHSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('stoch', params, paneId)
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSTOCHStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/stoch.ts
+++ b/packages/core/src/engine/renderers/Indicator/stoch.ts
@@ -353,7 +353,6 @@ export function getSTOCHTitleInfo(
     category: 'oscillator',
     stateKey: createSTOCHStateKey,
     defaultPaneId: 'sub_STOCH',
-    paneIdField: 'stochPaneId',
     visibleState: { compose: createFixedRangePointVisibleStateComposer('stoch', EMPTY_STOCH_STATE, ['k', 'd'] as const) },
     scaleRendererFactory: createStochScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
@@ -362,7 +361,7 @@ export function getSTOCHTitleInfo(
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSTOCHStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'stoch', paneIdKey:'stochPaneId', defaultConfig:{n:9,m:3,showK:true,showD:true}, computeKey:'calcSTOCHData', compute:(data,c)=>calcSTOCHData(data,c.n,c.m) },
+    runtime: { configKey:'stoch', defaultConfig:{n:9,m:3,showK:true,showD:true}, computeKey:'calcSTOCHData', compute:(data,c)=>calcSTOCHData(data,c.n,c.m) },
 })
 class STOCHIndicatorDefinition {
     static rendererFactory = createSTOCHRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/structure.ts
+++ b/packages/core/src/engine/renderers/Indicator/structure.ts
@@ -117,7 +117,6 @@ export function createStructureRendererPlugin(options: { paneId?: string } = {})
     category: 'sub',
     stateKey: createStructureStateKey,
     defaultPaneId: 'sub_Structure',
-    paneIdField: 'structurePaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'structure_main', toActiveConfig: (params, active) => ({ ...params, showSwingLabels: active, showBOS: active, showCHOCH: active }) },
     scale: { indicatorKey: 'structure', label: 'Structure', decimals: 2 },
@@ -128,7 +127,7 @@ export function createStructureRendererPlugin(options: { paneId?: string } = {})
     applyResult: (host, state, paneId) => {
         host.setSharedState(createStructureStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'structure', paneIdKey:'structurePaneId', defaultConfig:{leftWindow:5,rightWindow:2,breakoutSource:'close',showSwingLabels:true,showBOS:true,showCHOCH:true,showProvisional:true}, computeKey:'calcStructureData', compute:(data,c)=>calcStructureData(data,c.leftWindow,c.rightWindow,c.breakoutSource) },
+    runtime: { configKey:'structure', defaultConfig:{leftWindow:5,rightWindow:2,breakoutSource:'close',showSwingLabels:true,showBOS:true,showCHOCH:true,showProvisional:true}, computeKey:'calcStructureData', compute:(data,c)=>calcStructureData(data,c.leftWindow,c.rightWindow,c.breakoutSource) },
 })
 class StructureIndicatorDefinition {
     static rendererFactory = createStructureRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/structure.ts
+++ b/packages/core/src/engine/renderers/Indicator/structure.ts
@@ -123,7 +123,7 @@ export function createStructureRendererPlugin(options: { paneId?: string } = {})
     scale: { indicatorKey: 'structure', label: 'Structure', decimals: 2 },
     visibleState: { compose: createFixedUnitVisibleStateComposer('structure', EMPTY_STRUCTURE_STATE) },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateStructureConfig(params as Partial<StructureSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('structure', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createStructureStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/structure.ts
+++ b/packages/core/src/engine/renderers/Indicator/structure.ts
@@ -7,6 +7,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { createFixedUnitVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, StructureSchedulerConfig } from '../../indicators/scheduler'
+import { calcStructureData } from '../../indicators/calculators'
 
 const LABEL_FONT = '11px sans-serif'
 
@@ -127,6 +128,7 @@ export function createStructureRendererPlugin(options: { paneId?: string } = {})
     applyResult: (host, state, paneId) => {
         host.setSharedState(createStructureStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'structure', paneIdKey:'structurePaneId', defaultConfig:{leftWindow:5,rightWindow:2,breakoutSource:'close',showSwingLabels:true,showBOS:true,showCHOCH:true,showProvisional:true}, computeKey:'calcStructureData', compute:(data,c)=>calcStructureData(data,c.leftWindow,c.rightWindow,c.breakoutSource) },
 })
 class StructureIndicatorDefinition {
     static rendererFactory = createStructureRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/supertrend.ts
+++ b/packages/core/src/engine/renderers/Indicator/supertrend.ts
@@ -112,7 +112,7 @@ export function createSuperTrendRendererPlugin(options: SuperTrendRendererOption
     scale: { indicatorKey: 'supertrend', label: 'SuperTrend', decimals: 2 },
     visibleState: { compose: createValuePointVisibleStateComposer('supertrend', EMPTY_SUPERTREND_STATE, ['value']) },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateSuperTrendConfig(params as Partial<SuperTrendSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('supertrend', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSuperTrendStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/supertrend.ts
+++ b/packages/core/src/engine/renderers/Indicator/supertrend.ts
@@ -106,7 +106,6 @@ export function createSuperTrendRendererPlugin(options: SuperTrendRendererOption
     category: 'oscillator',
     stateKey: createSuperTrendStateKey,
     defaultPaneId: 'sub_SuperTrend',
-    paneIdField: 'supertrendPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'supertrend_main', toActiveConfig: (params, active) => ({ ...params, showSuperTrend: active }) },
     scale: { indicatorKey: 'supertrend', label: 'SuperTrend', decimals: 2 },
@@ -117,7 +116,7 @@ export function createSuperTrendRendererPlugin(options: SuperTrendRendererOption
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSuperTrendStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'supertrend', paneIdKey:'supertrendPaneId', defaultConfig:{atrPeriod:10,multiplier:3,showSuperTrend:true}, computeKey:'calcSuperTrendData', compute:(data,c)=>calcSuperTrendData(data,c.atrPeriod,c.multiplier) },
+    runtime: { configKey:'supertrend', defaultConfig:{atrPeriod:10,multiplier:3,showSuperTrend:true}, computeKey:'calcSuperTrendData', compute:(data,c)=>calcSuperTrendData(data,c.atrPeriod,c.multiplier) },
 })
 class SuperTrendIndicatorDefinition {
     static rendererFactory = createSuperTrendRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/supertrend.ts
+++ b/packages/core/src/engine/renderers/Indicator/supertrend.ts
@@ -5,6 +5,7 @@ import { createSuperTrendStateKey, EMPTY_SUPERTREND_STATE } from '../../indicato
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, SuperTrendSchedulerConfig } from '../../indicators/scheduler'
+import { calcSuperTrendData } from '../../indicators/calculators'
 import { createValuePointVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
 const ST_UP_COLOR = '#22c55e'
@@ -116,6 +117,7 @@ export function createSuperTrendRendererPlugin(options: SuperTrendRendererOption
     applyResult: (host, state, paneId) => {
         host.setSharedState(createSuperTrendStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'supertrend', paneIdKey:'supertrendPaneId', defaultConfig:{atrPeriod:10,multiplier:3,showSuperTrend:true}, computeKey:'calcSuperTrendData', compute:(data,c)=>calcSuperTrendData(data,c.atrPeriod,c.multiplier) },
 })
 class SuperTrendIndicatorDefinition {
     static rendererFactory = createSuperTrendRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/tema.ts
+++ b/packages/core/src/engine/renderers/Indicator/tema.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, TEMASchedulerConfig } from '../../indicators/scheduler'
+import { calcTEMAData } from '../../indicators/calculators'
 
 const TEMA_COLOR = '#d946ef'
 
@@ -137,6 +138,7 @@ export function createTEMARendererPlugin(options: TEMARendererOptions = {}): Ren
     applyResult: (host, state, paneId) => {
         host.setSharedState(createTEMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'tema', paneIdKey:'temaPaneId', defaultConfig:{period:14,showTEMA:true}, computeKey:'calcTEMAData', compute:(data,c)=>calcTEMAData(data,c.period) },
 })
 class TEMADefinition {
     static rendererFactory = createTEMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/tema.ts
+++ b/packages/core/src/engine/renderers/Indicator/tema.ts
@@ -133,7 +133,7 @@ export function createTEMARendererPlugin(options: TEMARendererOptions = {}): Ren
     visibleState: { compose: createSparseVisibleStateComposer('tema', EMPTY_TEMA_STATE) },
     scale: { indicatorKey: 'tema', label: 'TEMA', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateTEMAConfig(params as Partial<TEMASchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('tema', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createTEMAStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/tema.ts
+++ b/packages/core/src/engine/renderers/Indicator/tema.ts
@@ -127,7 +127,6 @@ export function createTEMARendererPlugin(options: TEMARendererOptions = {}): Ren
     category: 'main',
     stateKey: createTEMAStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'temaPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'tema_main', toActiveConfig: (params, active) => ({ ...params, showTEMA: active }) },
     visibleState: { compose: createSparseVisibleStateComposer('tema', EMPTY_TEMA_STATE) },
@@ -138,7 +137,7 @@ export function createTEMARendererPlugin(options: TEMARendererOptions = {}): Ren
     applyResult: (host, state, paneId) => {
         host.setSharedState(createTEMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'tema', paneIdKey:'temaPaneId', defaultConfig:{period:14,showTEMA:true}, computeKey:'calcTEMAData', compute:(data,c)=>calcTEMAData(data,c.period) },
+    runtime: { configKey:'tema', defaultConfig:{period:14,showTEMA:true}, computeKey:'calcTEMAData', compute:(data,c)=>calcTEMAData(data,c.period) },
 })
 class TEMADefinition {
     static rendererFactory = createTEMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/trix.ts
+++ b/packages/core/src/engine/renderers/Indicator/trix.ts
@@ -154,7 +154,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     paneIdField: 'trixPaneId',
     scale: { indicatorKey: 'trix', label: 'TRIX', decimals: 6 },
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateTRIXConfig(params as Partial<TRIXSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('trix', params, paneId)
   },
     visibleState: { compose: createDualSparseVisibleStateComposer('trix', EMPTY_TRIX_STATE) },
     applyResult: (host, state, paneId) => {

--- a/packages/core/src/engine/renderers/Indicator/trix.ts
+++ b/packages/core/src/engine/renderers/Indicator/trix.ts
@@ -151,7 +151,6 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     category: 'oscillator',
     stateKey: createTRIXStateKey,
     defaultPaneId: 'sub_TRIX',
-    paneIdField: 'trixPaneId',
     scale: { indicatorKey: 'trix', label: 'TRIX', decimals: 6 },
     updateConfig: (scheduler, params, paneId) => {
     (scheduler as IndicatorScheduler).updateIndicatorConfig('trix', params, paneId)
@@ -160,7 +159,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createTRIXStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'trix', paneIdKey:'trixPaneId', defaultConfig:{period:15,signalPeriod:9,showTRIX:true,showSignal:true}, computeKey:'calcTRIXData', compute:(data,c)=>calcTRIXData(data,c.period,c.signalPeriod) },
+    runtime: { configKey:'trix', defaultConfig:{period:15,signalPeriod:9,showTRIX:true,showSignal:true}, computeKey:'calcTRIXData', compute:(data,c)=>calcTRIXData(data,c.period,c.signalPeriod) },
 })
 class TRIXIndicatorDefinition {
     static rendererFactory = createTRIXRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/trix.ts
+++ b/packages/core/src/engine/renderers/Indicator/trix.ts
@@ -7,6 +7,7 @@ import { createDualSparseVisibleStateComposer } from '../../indicators/visibleSt
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, TRIXSchedulerConfig } from '../../indicators/scheduler'
+import { calcTRIXData } from '../../indicators/calculators'
 
 const TRIX_COLOR = '#e11d48'
 const SIGNAL_COLOR = '#f59e0b'
@@ -159,6 +160,7 @@ function drawLine(ctx: CanvasRenderingContext2D, pts: Point[], color: string): v
     applyResult: (host, state, paneId) => {
         host.setSharedState(createTRIXStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'trix', paneIdKey:'trixPaneId', defaultConfig:{period:15,signalPeriod:9,showTRIX:true,showSignal:true}, computeKey:'calcTRIXData', compute:(data,c)=>calcTRIXData(data,c.period,c.signalPeriod) },
 })
 class TRIXIndicatorDefinition {
     static rendererFactory = createTRIXRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/vma.ts
+++ b/packages/core/src/engine/renderers/Indicator/vma.ts
@@ -7,6 +7,7 @@ import { createNonNegativeSparseVisibleStateComposer } from '../../indicators/vi
 import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, VMASchedulerConfig } from '../../indicators/scheduler'
+import { calcVMAData } from '../../indicators/calculators'
 
 const VMA_COLOR = '#0ea5e9'
 
@@ -124,6 +125,13 @@ export function createVMARendererPlugin(options: { paneId?: string } = {}): Rend
     visibleState: { compose: createNonNegativeSparseVisibleStateComposer('vma', EMPTY_VMA_STATE) },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createVMAStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'vma',
+        paneIdKey: 'vmaPaneId',
+        defaultConfig: { period: 5, showVMA: true },
+        computeKey: 'calcVMAData',
+        compute: (data, c) => calcVMAData(data, c.period),
     },
 })
 class VMAIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/vma.ts
+++ b/packages/core/src/engine/renderers/Indicator/vma.ts
@@ -120,7 +120,7 @@ export function createVMARendererPlugin(options: { paneId?: string } = {}): Rend
     paneIdField: 'vmaPaneId',
     scale: { indicatorKey: 'vma', label: 'VMA', decimals: 0 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateVMAConfig(params as Partial<VMASchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('vma', params, paneId)
     },
     visibleState: { compose: createNonNegativeSparseVisibleStateComposer('vma', EMPTY_VMA_STATE) },
     applyResult: (host, state, paneId) => {

--- a/packages/core/src/engine/renderers/Indicator/vma.ts
+++ b/packages/core/src/engine/renderers/Indicator/vma.ts
@@ -117,7 +117,6 @@ export function createVMARendererPlugin(options: { paneId?: string } = {}): Rend
     category: 'volume',
     stateKey: createVMAStateKey,
     defaultPaneId: 'sub_VMA',
-    paneIdField: 'vmaPaneId',
     scale: { indicatorKey: 'vma', label: 'VMA', decimals: 0 },
     updateConfig: (scheduler, params, paneId) => {
         (scheduler as IndicatorScheduler).updateIndicatorConfig('vma', params, paneId)
@@ -128,7 +127,6 @@ export function createVMARendererPlugin(options: { paneId?: string } = {}): Rend
     },
     runtime: {
         configKey: 'vma',
-        paneIdKey: 'vmaPaneId',
         defaultConfig: { period: 5, showVMA: true },
         computeKey: 'calcVMAData',
         compute: (data, c) => calcVMAData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/volumeProfile.ts
+++ b/packages/core/src/engine/renderers/Indicator/volumeProfile.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { createVolumeProfileVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, VolumeProfileSchedulerConfig } from '../../indicators/scheduler'
+import { calcVolumeProfileData } from '../../indicators/calculators'
 
 const BAR_FILL = 'rgba(99, 102, 241, 0.35)'
 const POC_COLOR = '#f59e0b'
@@ -125,6 +126,7 @@ export function createVolumeProfileRendererPlugin(options: { paneId?: string } =
     applyResult: (host, state, paneId) => {
         host.setSharedState(createVolumeProfileStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'volumeProfile', paneIdKey:'volumeProfilePaneId', defaultConfig:{bins:24,lookback:100,valueAreaPercent:70,showPOC:true,showValueArea:true}, computeKey:'calcVolumeProfileData', compute:(data,c)=>calcVolumeProfileData(data,c.bins,c.lookback,c.valueAreaPercent) },
 })
 class VolumeProfileIndicatorDefinition {
     static rendererFactory = createVolumeProfileRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/volumeProfile.ts
+++ b/packages/core/src/engine/renderers/Indicator/volumeProfile.ts
@@ -121,7 +121,7 @@ export function createVolumeProfileRendererPlugin(options: { paneId?: string } =
     scale: { indicatorKey: 'volumeProfile', label: 'VP', decimals: 0 },
     visibleState: { compose: createVolumeProfileVisibleStateComposer('volumeProfile', EMPTY_VOLUME_PROFILE_STATE) },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateVolumeProfileConfig(params as Partial<VolumeProfileSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('volumeProfile', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createVolumeProfileStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/volumeProfile.ts
+++ b/packages/core/src/engine/renderers/Indicator/volumeProfile.ts
@@ -117,7 +117,6 @@ export function createVolumeProfileRendererPlugin(options: { paneId?: string } =
     category: 'volume',
     stateKey: createVolumeProfileStateKey,
     defaultPaneId: 'sub_VolumeProfile',
-    paneIdField: 'volumeProfilePaneId',
     scale: { indicatorKey: 'volumeProfile', label: 'VP', decimals: 0 },
     visibleState: { compose: createVolumeProfileVisibleStateComposer('volumeProfile', EMPTY_VOLUME_PROFILE_STATE) },
     updateConfig: (scheduler, params, paneId) => {
@@ -126,7 +125,7 @@ export function createVolumeProfileRendererPlugin(options: { paneId?: string } =
     applyResult: (host, state, paneId) => {
         host.setSharedState(createVolumeProfileStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'volumeProfile', paneIdKey:'volumeProfilePaneId', defaultConfig:{bins:24,lookback:100,valueAreaPercent:70,showPOC:true,showValueArea:true}, computeKey:'calcVolumeProfileData', compute:(data,c)=>calcVolumeProfileData(data,c.bins,c.lookback,c.valueAreaPercent) },
+    runtime: { configKey:'volumeProfile', defaultConfig:{bins:24,lookback:100,valueAreaPercent:70,showPOC:true,showValueArea:true}, computeKey:'calcVolumeProfileData', compute:(data,c)=>calcVolumeProfileData(data,c.bins,c.lookback,c.valueAreaPercent) },
 })
 class VolumeProfileIndicatorDefinition {
     static rendererFactory = createVolumeProfileRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/vwap.ts
+++ b/packages/core/src/engine/renderers/Indicator/vwap.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, VWAPSchedulerConfig } from '../../indicators/scheduler'
+import { calcVWAPData } from '../../indicators/calculators'
 
 const VWAP_COLOR = '#ec4899'
 
@@ -122,6 +123,13 @@ export function createVWAPRendererPlugin(options: { paneId?: string } = {}): Ren
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createVWAPStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'vwap',
+        paneIdKey: 'vwapPaneId',
+        defaultConfig: { sessionResetGapMs: 0, showVWAP: true },
+        computeKey: 'calcVWAPData',
+        compute: (data, c) => calcVWAPData(data, c.sessionResetGapMs),
     },
 })
 class VWAPIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/vwap.ts
+++ b/packages/core/src/engine/renderers/Indicator/vwap.ts
@@ -119,7 +119,7 @@ export function createVWAPRendererPlugin(options: { paneId?: string } = {}): Ren
     visibleState: { compose: createSparseVisibleStateComposer('vwap', EMPTY_VWAP_STATE) },
     scale: { indicatorKey: 'vwap', label: 'VWAP', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateVWAPConfig(params as Partial<VWAPSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('vwap', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createVWAPStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/vwap.ts
+++ b/packages/core/src/engine/renderers/Indicator/vwap.ts
@@ -115,7 +115,6 @@ export function createVWAPRendererPlugin(options: { paneId?: string } = {}): Ren
     category: 'volume',
     stateKey: createVWAPStateKey,
     defaultPaneId: 'sub_VWAP',
-    paneIdField: 'vwapPaneId',
     visibleState: { compose: createSparseVisibleStateComposer('vwap', EMPTY_VWAP_STATE) },
     scale: { indicatorKey: 'vwap', label: 'VWAP', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
@@ -126,7 +125,6 @@ export function createVWAPRendererPlugin(options: { paneId?: string } = {}): Ren
     },
     runtime: {
         configKey: 'vwap',
-        paneIdKey: 'vwapPaneId',
         defaultConfig: { sessionResetGapMs: 0, showVWAP: true },
         computeKey: 'calcVWAPData',
         compute: (data, c) => calcVWAPData(data, c.sessionResetGapMs),

--- a/packages/core/src/engine/renderers/Indicator/wma.ts
+++ b/packages/core/src/engine/renderers/Indicator/wma.ts
@@ -133,7 +133,7 @@ export function createWMARendererPlugin(options: WMARendererOptions = {}): Rende
     visibleState: { compose: createSparseVisibleStateComposer('wma', EMPTY_WMA_STATE) },
     scale: { indicatorKey: 'wma', label: 'WMA', decimals: 2 },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateWMAConfig(params as Partial<WMASchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('wma', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createWMAStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/wma.ts
+++ b/packages/core/src/engine/renderers/Indicator/wma.ts
@@ -6,6 +6,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import type { IndicatorScheduler, WMASchedulerConfig } from '../../indicators/scheduler'
+import { calcWMAData } from '../../indicators/calculators'
 
 const WMA_COLOR = '#10b981'
 
@@ -137,6 +138,7 @@ export function createWMARendererPlugin(options: WMARendererOptions = {}): Rende
     applyResult: (host, state, paneId) => {
         host.setSharedState(createWMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'wma', paneIdKey:'wmaPaneId', defaultConfig:{period:10,showWMA:true}, computeKey:'calcWMAData', compute:(data,c)=>calcWMAData(data,c.period) },
 })
 class WMADefinition {
     static rendererFactory = createWMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/wma.ts
+++ b/packages/core/src/engine/renderers/Indicator/wma.ts
@@ -127,7 +127,6 @@ export function createWMARendererPlugin(options: WMARendererOptions = {}): Rende
     category: 'main',
     stateKey: createWMAStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'wmaPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'wma_main', toActiveConfig: (params, active) => ({ ...params, showWMA: active }) },
     visibleState: { compose: createSparseVisibleStateComposer('wma', EMPTY_WMA_STATE) },
@@ -138,7 +137,7 @@ export function createWMARendererPlugin(options: WMARendererOptions = {}): Rende
     applyResult: (host, state, paneId) => {
         host.setSharedState(createWMAStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'wma', paneIdKey:'wmaPaneId', defaultConfig:{period:10,showWMA:true}, computeKey:'calcWMAData', compute:(data,c)=>calcWMAData(data,c.period) },
+    runtime: { configKey:'wma', defaultConfig:{period:10,showWMA:true}, computeKey:'calcWMAData', compute:(data,c)=>calcWMAData(data,c.period) },
 })
 class WMADefinition {
     static rendererFactory = createWMARendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/wmsr.ts
+++ b/packages/core/src/engine/renderers/Indicator/wmsr.ts
@@ -326,7 +326,7 @@ export function getWMSRTitleInfo(
     visibleState: { compose: createFixedRangeSparseVisibleStateComposer('wmsr', EMPTY_WMSR_STATE) },
     scaleRendererFactory: createWmsrScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
-    (scheduler as IndicatorScheduler).updateWMSRConfig(params as Partial<WMSRSchedulerConfig>, paneId)
+    (scheduler as IndicatorScheduler).updateIndicatorConfig('wmsr', params, paneId)
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createWMSRStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/wmsr.ts
+++ b/packages/core/src/engine/renderers/Indicator/wmsr.ts
@@ -322,7 +322,6 @@ export function getWMSRTitleInfo(
     category: 'oscillator',
     stateKey: createWMSRStateKey,
     defaultPaneId: 'sub_WMSR',
-    paneIdField: 'wmsrPaneId',
     visibleState: { compose: createFixedRangeSparseVisibleStateComposer('wmsr', EMPTY_WMSR_STATE) },
     scaleRendererFactory: createWmsrScaleRendererPlugin,
     updateConfig: (scheduler, params, paneId) => {
@@ -333,7 +332,6 @@ export function getWMSRTitleInfo(
     },
     runtime: {
         configKey: 'wmsr',
-        paneIdKey: 'wmsrPaneId',
         defaultConfig: { period: 14, showWMSR: true },
         computeKey: 'calcWMSRData',
         compute: (data, c) => calcWMSRData(data, c.period),

--- a/packages/core/src/engine/renderers/Indicator/wmsr.ts
+++ b/packages/core/src/engine/renderers/Indicator/wmsr.ts
@@ -9,6 +9,7 @@ import { createFixedRangeSparseVisibleStateComposer } from '../../indicators/vis
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, WMSRSchedulerConfig } from '../../indicators/scheduler'
 import { createWmsrScaleRendererPlugin } from './scale/wmsr_scale'
+import { calcWMSRData } from '../../indicators/calculators'
 
 type LinePoint = { x: number; y: number }
 
@@ -329,6 +330,13 @@ export function getWMSRTitleInfo(
   },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createWMSRStateKey(paneId), state as any, 'indicator_scheduler')
+    },
+    runtime: {
+        configKey: 'wmsr',
+        paneIdKey: 'wmsrPaneId',
+        defaultConfig: { period: 14, showWMSR: true },
+        computeKey: 'calcWMSRData',
+        compute: (data, c) => calcWMSRData(data, c.period),
     },
 })
 class WMSRIndicatorDefinition {

--- a/packages/core/src/engine/renderers/Indicator/zones.ts
+++ b/packages/core/src/engine/renderers/Indicator/zones.ts
@@ -96,7 +96,6 @@ export function createZonesRendererPlugin(options: { paneId?: string } = {}): Re
     category: 'main',
     stateKey: createZonesStateKey,
     defaultPaneId: 'main',
-    paneIdField: 'zonesPaneId',
     allowMainPane: true,
     mainPane: { rendererName: 'zones_main', toActiveConfig: (params, active) => ({ ...params, showFVG: active, showOB: active, showFilledZones: active }) },
     scale: { indicatorKey: 'zones', label: 'Zones', decimals: 2 },
@@ -107,7 +106,7 @@ export function createZonesRendererPlugin(options: { paneId?: string } = {}): Re
     applyResult: (host, state, paneId) => {
         host.setSharedState(createZonesStateKey(paneId), state as any, 'indicator_scheduler')
     },
-    runtime: { configKey:'zones', paneIdKey:'zonesPaneId', defaultConfig:{showFVG:true,showOB:true,showFilledZones:true,obLookback:20}, computeKey:'calcZonesData', compute:(data,c)=>calcZonesData(data,c.obLookback,5,2,'close') },
+    runtime: { configKey:'zones', defaultConfig:{showFVG:true,showOB:true,showFilledZones:true,obLookback:20}, computeKey:'calcZonesData', compute:(data,c)=>calcZonesData(data,c.obLookback,5,2,'close') },
 })
 class ZonesDefinition {
     static rendererFactory = createZonesRendererPlugin

--- a/packages/core/src/engine/renderers/Indicator/zones.ts
+++ b/packages/core/src/engine/renderers/Indicator/zones.ts
@@ -102,7 +102,7 @@ export function createZonesRendererPlugin(options: { paneId?: string } = {}): Re
     scale: { indicatorKey: 'zones', label: 'Zones', decimals: 2 },
     visibleState: { compose: createFixedUnitVisibleStateComposer('zones', EMPTY_ZONES_STATE) },
     updateConfig: (scheduler, params, paneId) => {
-        (scheduler as IndicatorScheduler).updateZonesConfig(params as Partial<ZonesSchedulerConfig>, paneId)
+        (scheduler as IndicatorScheduler).updateIndicatorConfig('zones', params, paneId)
     },
     applyResult: (host, state, paneId) => {
         host.setSharedState(createZonesStateKey(paneId), state as any, 'indicator_scheduler')

--- a/packages/core/src/engine/renderers/Indicator/zones.ts
+++ b/packages/core/src/engine/renderers/Indicator/zones.ts
@@ -7,6 +7,7 @@ import { Indicator } from '../../indicators/indicatorDefinitionRegistry'
 import { createFixedUnitVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import { resolveStateKey } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler, ZonesSchedulerConfig } from '../../indicators/scheduler'
+import { calcZonesData } from '../../indicators/calculators'
 
 function getZonesStateKey(host: PluginHost | null, paneId: string): string | null {
     const scheduler = host?.getService<IndicatorScheduler>('indicatorScheduler')
@@ -106,6 +107,7 @@ export function createZonesRendererPlugin(options: { paneId?: string } = {}): Re
     applyResult: (host, state, paneId) => {
         host.setSharedState(createZonesStateKey(paneId), state as any, 'indicator_scheduler')
     },
+    runtime: { configKey:'zones', paneIdKey:'zonesPaneId', defaultConfig:{showFVG:true,showOB:true,showFilledZones:true,obLookback:20}, computeKey:'calcZonesData', compute:(data,c)=>calcZonesData(data,c.obLookback,5,2,'close') },
 })
 class ZonesDefinition {
     static rendererFactory = createZonesRendererPlugin

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.7.12-alpha.1"
+export const VERSION = "0.7.12"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@363045841yyt/klinechart",
-  "version": "0.7.12-alpha.1",
+  "version": "0.7.12",
   "description": "Vue 3 bindings for @363045841yyt/klinechart-core. Idiomatic composables, SFC components.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Refactor the indicator pipeline from hardcoded config/expansion pattern to fully descriptor-driven architecture.

## Changes

### P0-P2 — Descriptor infrastructure
- Add `IndicatorRuntimeDescriptor` type with `configKey`, `defaultConfig`, `computeKey`, `compute`
- Add `runtime` field to all 39 `@Indicator` decorators
- Rewrite `indicatorRuntime.ts` (1548→213 lines) with Map-based storage and `CALCULATOR_MAP` bridge
- Add `addDescriptor` message handler for Worker descriptor reconstruction
- Fix race: Worker flushes descriptors before `triggerRecompute`

### P3 — Unify updateConfig callbacks
- Migrate 39 renderer callbacks from `updateXxxConfig(params, paneId)` to `updateIndicatorConfig('xxx', params, paneId)`

### P4 — Dynamic state composition
- Derive `METADATA_VISIBLE_STATE_INDICATOR_IDS` and compose loops from `getRegisteredIndicatorDefinitions()`
- Remove 35-entry and 4-entry hardcoded lists in `stateComposer.ts`

### P5-A — PaneId storage refactor
- Move 35 `XxxPaneId` fields from `configSnapshot` to dedicated `paneIdOverrides` Map
- Remove dead `paneIdField` / `paneIdKey` from all renderers
- Fix `buildActiveSubIndicatorMask` guard (removed stale `paneIdField` check)

## Related
Refs #49

## Breaking Changes
None. All 39 `updateXxxConfig` thin delegates retained (dead code) for backward compatibility.