### PR TITLE
feat(core+vue): add comparison overlay symbol line renderer

### DIFF
--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -2409,14 +2409,15 @@ export class Chart {
             const key = spec.symbol
             let buffer = this._comparisonBuffers.get(key)
             if (!buffer) {
-                buffer = new DataBuffer()
-                buffer.setFetcher(this._dataFetcher)
-                this._comparisonBuffers.set(key, buffer)
-                const unsubscribe = buffer.data.subscribe(() => {
-                    this._comparisonData.set(key, [...buffer.data.peek()])
+                const newBuffer = new DataBuffer()
+                newBuffer.setFetcher(this._dataFetcher)
+                this._comparisonBuffers.set(key, newBuffer)
+                const unsubscribe = newBuffer.data.subscribe(() => {
+                    this._comparisonData.set(key, [...newBuffer.data.peek()])
                     this.scheduleDraw()
                 })
                 this._comparisonBufferUnsubs.set(key, unsubscribe)
+                buffer = newBuffer
             } else {
                 buffer.setFetcher(this._dataFetcher)
             }

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -39,6 +39,7 @@ import { DrawingStore } from './drawing'
 import { createDrawingRendererPlugin, createDrawingLabelOverlayPlugin } from './drawing/plugin'
 import { createGridLinesRendererPlugin } from './renderers/gridLines'
 import { createCandleRenderer } from './renderers/candle'
+import { createComparisonLineRenderer } from './renderers/comparisonLine'
 import { createLastPriceLineRendererPlugin, createLastPriceLabelRegistrarPlugin } from './renderers/lastPrice'
 import { createCustomMarkersRenderer } from './renderers/customMarkers'
 import { createExtremaMarkersRendererPlugin } from './renderers/extremaMarkers'
@@ -163,6 +164,10 @@ export class Chart {
     private _dataFetcher: DataFetcher | null = null
     private _dataBuffer: DataBuffer = new DataBuffer()
     private _dataBufferUnsub: (() => void) | null = null
+    private _comparisonSpecs: SymbolSpec[] = []
+    private _comparisonData: Map<string, KLineData[]> = new Map()
+    private _comparisonBuffers: Map<string, DataBuffer> = new Map()
+    private _comparisonBufferUnsubs: Map<string, () => void> = new Map()
 
     private raf: number | null = null
     private pendingUpdateLevel: UpdateLevel = UpdateLevel.All
@@ -564,6 +569,7 @@ export class Chart {
 
         this.useRenderer(createGridLinesRendererPlugin())
         this.useRenderer(createCandleRenderer())
+        this.useRenderer(createComparisonLineRenderer())
         this.useRenderer(createLastPriceLineRendererPlugin())
         this.useRenderer(createLastPriceLabelRegistrarPlugin())
         this.useRenderer(createCustomMarkersRenderer())
@@ -900,7 +906,9 @@ export class Chart {
 
             if (!useCachedFrame) {
                 const indicatorRange = pane.role === 'price' ? mainIndicatorRange : null
-                pane.updateRange(this._internalData, range, indicatorRange)
+                const comparisonRange = pane.id === 'main' ? this.getComparisonEquivalentPriceRange(range) : null
+                const mergedRange = this.mergeNumericRanges(indicatorRange, comparisonRange)
+                pane.updateRange(this._internalData, range, mergedRange)
                 if (pane.id === 'main' && this.settings.disableMainPaneVerticalScroll) {
                     pane.yAxis.resetTransform()
                 }
@@ -936,6 +944,8 @@ export class Chart {
                 overlayCtx: overlayCtx ?? undefined,
                 pane: wrapPaneInfo(pane),
                 data: this._internalData,
+                comparisonData: this._comparisonData,
+                comparisonSymbols: this._comparisonSpecs,
                 range,
                 scrollLeft: vp.scrollLeft,
                 kWidth: this.opt.kWidth,
@@ -1786,6 +1796,7 @@ export class Chart {
             this._dataBufferUnsub = null
         }
         this._dataBuffer.dispose()
+        this.clearComparisonBuffers()
 
         // 清理尺寸观察器
         this.resizeObserver?.disconnect()
@@ -2292,6 +2303,9 @@ export class Chart {
     setDataFetcher(fetcher: DataFetcher | null): void {
         this._dataFetcher = fetcher
         this._dataBuffer.setFetcher(fetcher)
+        for (const buffer of this._comparisonBuffers.values()) {
+            buffer.setFetcher(fetcher)
+        }
     }
 
     get dataBuffer(): DataBuffer {
@@ -2319,13 +2333,117 @@ export class Chart {
         }
     }
 
+    private getComparisonEquivalentPriceRange(range: VisibleRange): { min: number; max: number } | null {
+        if (this._comparisonSpecs.length === 0 || this._comparisonData.size === 0) return null
+        const baseIndex = Math.max(0, range.start)
+        const mainBase = this._internalData[baseIndex]?.close
+        const baseTimestamp = this._internalData[baseIndex]?.timestamp
+        if (!Number.isFinite(mainBase) || mainBase <= 0 || baseTimestamp === undefined) return null
+
+        let min = Number.POSITIVE_INFINITY
+        let max = Number.NEGATIVE_INFINITY
+
+        for (const spec of this._comparisonSpecs) {
+            const data = this._comparisonData.get(spec.symbol)
+            if (!data?.length) continue
+
+            const baseline = this.findComparisonBaseline(data, baseTimestamp)
+            if (!baseline || !Number.isFinite(baseline.close) || baseline.close <= 0) continue
+
+            const byTimestamp = new Map<number, KLineData>()
+            for (const item of data) byTimestamp.set(item.timestamp, item)
+
+            for (let i = range.start; i < range.end && i < this._internalData.length; i++) {
+                const mainItem = this._internalData[i]
+                if (!mainItem) continue
+                const item = byTimestamp.get(mainItem.timestamp)
+                if (!item || !Number.isFinite(item.close)) continue
+
+                const pct = (item.close - baseline.close) / baseline.close
+                const equivalentPrice = mainBase * (1 + pct)
+                if (!Number.isFinite(equivalentPrice)) continue
+                min = Math.min(min, equivalentPrice)
+                max = Math.max(max, equivalentPrice)
+            }
+        }
+
+        if (!Number.isFinite(min) || !Number.isFinite(max)) return null
+        return { min, max }
+    }
+
+    private findComparisonBaseline(data: ReadonlyArray<KLineData>, timestamp: number): KLineData | null {
+        for (const item of data) {
+            if (item.timestamp >= timestamp) return item
+        }
+        return null
+    }
+
+    private mergeNumericRanges(
+        left: { min: number; max: number } | null | undefined,
+        right: { min: number; max: number } | null | undefined,
+    ): { min: number; max: number } | null {
+        if (!left) return right ?? null
+        if (!right) return left
+        return {
+            min: Math.min(left.min, right.min),
+            max: Math.max(left.max, right.max),
+        }
+    }
+
+    private syncComparisonBuffers(specs: ReadonlyArray<SymbolSpec>): void {
+        this._comparisonSpecs = [...specs]
+        const nextKeys = new Set(specs.map((spec) => spec.symbol))
+
+        for (const [key, buffer] of this._comparisonBuffers) {
+            if (nextKeys.has(key)) continue
+            this._comparisonBufferUnsubs.get(key)?.()
+            this._comparisonBufferUnsubs.delete(key)
+            buffer.dispose()
+            this._comparisonBuffers.delete(key)
+            this._comparisonData.delete(key)
+        }
+
+        if (!this._dataFetcher) return
+
+        for (const spec of specs) {
+            const key = spec.symbol
+            let buffer = this._comparisonBuffers.get(key)
+            if (!buffer) {
+                buffer = new DataBuffer()
+                buffer.setFetcher(this._dataFetcher)
+                this._comparisonBuffers.set(key, buffer)
+                const unsubscribe = buffer.data.subscribe(() => {
+                    this._comparisonData.set(key, [...buffer.data.peek()])
+                    this.scheduleDraw()
+                })
+                this._comparisonBufferUnsubs.set(key, unsubscribe)
+            } else {
+                buffer.setFetcher(this._dataFetcher)
+            }
+            buffer.setSymbol(spec)
+        }
+    }
+
+    private clearComparisonBuffers(): void {
+        for (const unsubscribe of this._comparisonBufferUnsubs.values()) unsubscribe()
+        this._comparisonBufferUnsubs.clear()
+        for (const buffer of this._comparisonBuffers.values()) buffer.dispose()
+        this._comparisonBuffers.clear()
+        this._comparisonData.clear()
+        this._comparisonSpecs = []
+    }
+
     /**
      * 设置当前符号并触发数据加载
      */
     setSymbols(specs: ReadonlyArray<SymbolSpec>): void {
         this._symbolsSignal.set(specs)
-        if (specs.length === 0) return
+        if (specs.length === 0) {
+            this.clearComparisonBuffers()
+            return
+        }
         const spec = specs[0]!
+        this.syncComparisonBuffers(specs.slice(1))
         if (!this._dataFetcher) return
 
         this._dataBuffer.setFetcher(this._dataFetcher)

--- a/packages/core/src/engine/renderers/comparisonLine.ts
+++ b/packages/core/src/engine/renderers/comparisonLine.ts
@@ -1,0 +1,89 @@
+import type { RendererPlugin, RenderContext } from '../../plugin'
+import { RENDERER_PRIORITY } from '../../plugin'
+import type { KLineData } from '../../types/price'
+
+const COMPARISON_COLORS = ['#f59e0b', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16', '#f97316']
+
+export function createComparisonLineRenderer(): RendererPlugin {
+    return {
+        name: 'comparisonLine',
+        version: '1.0.0',
+        description: '比较商品百分比折线渲染器',
+        debugName: '比较折线',
+        paneId: 'main',
+        priority: RENDERER_PRIORITY.MAIN + 2,
+
+        draw(context: RenderContext) {
+            const mainData = context.data as KLineData[]
+            const comparisonData = context.comparisonData
+            const comparisonSymbols = context.comparisonSymbols ?? []
+            if (!mainData.length || !comparisonData?.size || comparisonSymbols.length === 0) return
+            if (context.pane.id !== 'main') return
+
+            const baseIndex = Math.max(0, context.range.start)
+            const mainBase = mainData[baseIndex]?.close
+            const baseTimestamp = mainData[baseIndex]?.timestamp
+            if (!Number.isFinite(mainBase) || mainBase <= 0 || baseTimestamp === undefined) return
+
+            const ctx = context.ctx
+            ctx.save()
+            ctx.translate(-context.scrollLeft, 0)
+            ctx.lineWidth = Math.max(1, 1.5 / context.dpr)
+
+            for (let symbolIndex = 0; symbolIndex < comparisonSymbols.length; symbolIndex++) {
+                const spec = comparisonSymbols[symbolIndex]
+                const data = comparisonData.get(spec.symbol)
+                if (!data?.length) continue
+
+                const baseline = findBaseline(data, baseTimestamp)
+                if (!baseline || baseline.close <= 0) continue
+
+                const byTimestamp = new Map<number, KLineData>()
+                for (const item of data) byTimestamp.set(item.timestamp, item)
+
+                ctx.beginPath()
+                ctx.strokeStyle = COMPARISON_COLORS[symbolIndex % COMPARISON_COLORS.length]!
+                let hasPath = false
+                let previousHadPoint = false
+
+                for (let i = context.range.start; i < context.range.end && i < mainData.length; i++) {
+                    const mainItem = mainData[i]
+                    if (!mainItem) {
+                        previousHadPoint = false
+                        continue
+                    }
+                    const item = byTimestamp.get(mainItem.timestamp)
+                    const x = context.kLineCenters[i - context.range.start]
+                    if (!item || x === undefined || !Number.isFinite(item.close)) {
+                        previousHadPoint = false
+                        continue
+                    }
+
+                    const pct = ((item.close - baseline.close) / baseline.close) * 100
+                    const equivalentPrice = mainBase * (1 + pct / 100)
+                    const y = context.pane.yAxis.priceToY(equivalentPrice)
+                    if (!Number.isFinite(y)) {
+                        previousHadPoint = false
+                        continue
+                    }
+
+                    if (previousHadPoint) ctx.lineTo(x, y)
+                    else ctx.moveTo(x, y)
+                    previousHadPoint = true
+                    hasPath = true
+                }
+
+                if (hasPath) ctx.stroke()
+            }
+
+            ctx.restore()
+        },
+    }
+}
+
+function findBaseline(data: ReadonlyArray<KLineData>, timestamp: number): KLineData | null {
+    for (const item of data) {
+        if (item.timestamp >= timestamp) return item
+    }
+    return null
+}

--- a/packages/core/src/plugin/types.ts
+++ b/packages/core/src/plugin/types.ts
@@ -273,6 +273,8 @@ export interface RenderContext {
   ctx: CanvasRenderingContext2D
   pane: PaneInfo
   data: unknown[]
+  comparisonData?: ReadonlyMap<string, ReadonlyArray<KLineData>>
+  comparisonSymbols?: ReadonlyArray<import('../controllers/types').SymbolSpec>
   range: { start: number; end: number }
   scrollLeft: number
   kWidth: number

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -1,0 +1,583 @@
+<template>
+  <div ref="rootRef" class="compare-chip-wrap">
+    <button
+      type="button"
+      class="compare-chip"
+      :class="{ 'is-open': showPopup }"
+      title="比较商品"
+      :aria-expanded="showPopup"
+      aria-haspopup="dialog"
+      @click="togglePopup"
+    >
+      <span class="compare-chip__icon" aria-hidden="true">+</span>
+      <span class="compare-chip__text">比较商品</span>
+      <span v-if="selected.length > 0" class="compare-chip__badge">{{ selected.length }}</span>
+    </button>
+    <Transition name="symbol-popover">
+      <div v-if="showPopup" class="compare-popover" role="dialog" aria-label="比较商品">
+        <div class="compare-search">
+          <span class="compare-search__icon" aria-hidden="true">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <circle cx="6.5" cy="6.5" r="5" stroke="currentColor" stroke-width="1.6" />
+              <line
+                x1="10.5"
+                y1="10.5"
+                x2="14.5"
+                y2="14.5"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+              />
+            </svg>
+          </span>
+          <input
+            ref="searchInputRef"
+            v-model="searchQuery"
+            class="compare-search__input"
+            type="text"
+            placeholder="搜索代码或名称…"
+            autocomplete="off"
+            spellcheck="false"
+            aria-label="搜索比较商品"
+          />
+          <button
+            v-if="searchQuery"
+            type="button"
+            class="compare-search__clear"
+            aria-label="清空搜索"
+            @click="clearSearch"
+          >
+            <svg class="delete-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 6h18" />
+              <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+              <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+            </svg>
+          </button>
+        </div>
+
+        <div v-if="selected.length > 0" class="compare-selected">
+          <div class="compare-selected__header">
+            <span class="compare-selected__title">已添加商品</span>
+          </div>
+          <div class="compare-selected__list">
+            <div
+              v-for="item in selectedItems"
+              :key="item.code"
+              class="compare-selected__item"
+            >
+              <span class="compare-selected__code">{{ item.code }}</span>
+              <span class="compare-selected__desc">{{ item.description }}</span>
+              <button
+                type="button"
+                class="compare-selected__remove"
+                :aria-label="'移除 ' + item.code"
+                @click="removeSymbol(item.code)"
+              >
+                <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M18 6L6 18" />
+                  <path d="M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="compare-list" role="listbox" aria-label="商品列表">
+          <div v-if="filteredSymbols.length === 0" class="compare-list__empty">
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 32 32"
+              fill="none"
+              style="margin-bottom: 8px; opacity: 0.35"
+            >
+              <circle cx="13" cy="13" r="10" stroke="currentColor" stroke-width="2" />
+              <line
+                x1="21"
+                y1="21"
+                x2="29"
+                y2="29"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+              />
+            </svg>
+            <span>未找到相关商品</span>
+          </div>
+          <button
+            v-for="item in filteredSymbols"
+            :key="item.code"
+            type="button"
+            class="compare-list__item"
+            :class="{ 'is-selected': isSelected(item.code) }"
+            role="option"
+            :aria-selected="isSelected(item.code)"
+            @click="toggleSymbol(item)"
+          >
+            <span class="compare-list__left">
+              <span class="compare-list__code">{{ item.code }}</span>
+              <span class="compare-list__desc">{{ item.description }}</span>
+            </span>
+            <span class="compare-list__right">
+              <span class="compare-list__exchange">{{ item.exchange }}</span>
+              <span v-if="isSelected(item.code)" class="compare-list__check" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import type { SymbolItem } from './SymbolSelector.vue'
+
+const props = withDefaults(defineProps<{
+  symbols: SymbolItem[]
+  selected?: string[]
+}>(), {
+  selected: () => [],
+})
+
+const emit = defineEmits<{
+  (e: 'add', code: string): void
+  (e: 'remove', code: string): void
+}>()
+
+const showPopup = ref(false)
+const searchQuery = ref('')
+const searchInputRef = ref<HTMLInputElement | null>(null)
+const rootRef = ref<HTMLElement | null>(null)
+
+const selectedSet = computed(() => new Set(props.selected ?? []))
+
+const selectedItems = computed<SymbolItem[]>(() => {
+  const set = selectedSet.value
+  return props.symbols.filter((s) => set.has(s.code))
+})
+
+const filteredSymbols = computed<SymbolItem[]>(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return props.symbols
+  return props.symbols.filter(
+    (s) =>
+      s.code.toLowerCase().includes(q) ||
+      s.description.toLowerCase().includes(q) ||
+      s.exchange.toLowerCase().includes(q),
+  )
+})
+
+function isSelected(code: string): boolean {
+  return selectedSet.value.has(code)
+}
+
+function toggleSymbol(item: SymbolItem) {
+  if (isSelected(item.code)) {
+    emit('remove', item.code)
+  } else {
+    emit('add', item.code)
+  }
+}
+
+function removeSymbol(code: string) {
+  emit('remove', code)
+}
+
+function togglePopup() {
+  showPopup.value = !showPopup.value
+  if (showPopup.value) {
+    nextTick(() => searchInputRef.value?.focus())
+  }
+}
+
+function clearSearch() {
+  searchQuery.value = ''
+  searchInputRef.value?.focus()
+}
+
+function onDocumentClick(e: MouseEvent) {
+  if (rootRef.value && !rootRef.value.contains(e.target as Node)) {
+    showPopup.value = false
+    searchQuery.value = ''
+  }
+}
+
+onMounted(() => document.addEventListener('mousedown', onDocumentClick))
+onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick))
+</script>
+
+<style scoped>
+.compare-chip-wrap {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.compare-chip {
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  padding: 0 10px;
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 4px;
+  background: var(--klc-color-background);
+  color: var(--klc-color-foreground);
+  font: inherit;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.compare-chip:hover,
+.compare-chip.is-open {
+  border-color: var(--klc-color-axis-text);
+  background: var(--klc-color-grid-minor);
+}
+
+.compare-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--klc-color-foreground);
+  color: var(--klc-color-background);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.compare-chip__text {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.compare-chip__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--klc-color-axis-text);
+  color: var(--klc-color-background);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.compare-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 20;
+  width: min(360px, calc(100vw - 24px));
+  padding: 14px;
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 3px;
+  background: var(--klc-color-tag-bg-white);
+  color: var(--klc-color-foreground);
+
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.compare-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  height: 32px;
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 8px;
+  background: var(--klc-color-background);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.compare-search:focus-within {
+  border-color: var(--klc-color-axis-text);
+}
+
+.compare-search__icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  color: var(--klc-color-axis-text);
+}
+
+.compare-search__input {
+  flex: 1 1 0;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--klc-color-foreground);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.compare-search__input::placeholder {
+  color: var(--klc-color-axis-text);
+  opacity: 0.7;
+}
+
+.compare-search__clear {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--klc-color-axis-text);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.compare-search__clear:hover {
+  border-color: var(--klc-color-axis-line);
+  background: var(--klc-color-grid-minor);
+  color: var(--klc-color-foreground);
+}
+
+.compare-search__clear .delete-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.compare-selected {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--klc-color-border-chart);
+}
+
+.compare-selected__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.compare-selected__title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--klc-color-axis-text);
+}
+
+.compare-selected__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.compare-selected__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 6px;
+  background: var(--klc-color-grid-minor);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.compare-selected__code {
+  font-weight: 600;
+  color: var(--klc-color-foreground);
+}
+
+.compare-selected__desc {
+  color: var(--klc-color-axis-text);
+  font-size: 11px;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-selected__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--klc-color-axis-text);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+  flex-shrink: 0;
+}
+
+.compare-selected__remove:hover {
+  background: color-mix(in srgb, var(--klc-color-alert-active) 16%, transparent);
+  color: var(--klc-color-alert-active);
+}
+
+.compare-list {
+  max-height: 220px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  margin: 0 -4px;
+}
+
+.compare-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.compare-list::-webkit-scrollbar-thumb {
+  background: var(--klc-color-border-button);
+  border-radius: 999px;
+}
+
+.compare-list__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 0;
+  color: var(--klc-color-axis-text);
+  font-size: 13px;
+  text-align: center;
+  gap: 2px;
+}
+
+.compare-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 9px 10px;
+  margin: 0 4px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--klc-color-foreground);
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease;
+  flex-shrink: 0;
+}
+
+.compare-list__item:hover {
+  background: var(--klc-color-grid-minor);
+}
+
+.compare-list__left {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  flex: 1 1 0;
+}
+
+.compare-list__code {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  color: var(--klc-color-foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-list__desc {
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.2;
+  color: var(--klc-color-axis-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-list__right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.compare-list__exchange {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: var(--klc-color-grid-major);
+  color: var(--klc-color-axis-text);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.compare-list__check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--klc-color-alert-active);
+  flex-shrink: 0;
+}
+
+.symbol-popover-enter-active,
+.symbol-popover-leave-active {
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.symbol-popover-enter-from,
+.symbol-popover-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+@media (max-width: 768px), (max-height: 640px) {
+  .compare-chip {
+    height: 26px;
+    padding: 0 8px;
+  }
+
+  .compare-popover {
+    width: min(330px, calc(100vw - 16px));
+    padding: 12px;
+    gap: 8px;
+  }
+
+  .compare-list {
+    max-height: 180px;
+  }
+}
+</style>

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -145,7 +145,7 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{
-  (e: 'add', code: string): void
+  (e: 'add', item: SymbolItem): void
   (e: 'remove', code: string): void
 }>()
 
@@ -180,7 +180,7 @@ function toggleSymbol(item: SymbolItem) {
   if (isSelected(item.code)) {
     emit('remove', item.code)
   } else {
-    emit('add', item.code)
+    emit('add', item)
   }
 }
 

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -5,7 +5,9 @@
       :k-line-level="kLineLevel"
       :symbol-loading="symbolLoading"
       :symbol-error="symbolError"
-      @add-overlay-symbol="$emit('addOverlaySymbol')"
+      :overlay-symbols="overlaySymbols"
+      @add-overlay-symbol="onAddOverlaySymbol"
+      @remove-overlay-symbol="onRemoveOverlaySymbol"
       @k-line-level-change="onKLineLevelChange"
       @toggle-indicator="onToggleIndicator"
       @symbol-change="onSymbolChange"
@@ -203,7 +205,6 @@ const emit = defineEmits<{
   (e: 'zoomLevelChange', level: number, kWidth: number): void
   (e: 'toggleFullscreen'): void
   (e: 'themeChange', theme: 'light' | 'dark'): void
-  (e: 'addOverlaySymbol'): void
   (e: 'kLineLevelChange', level: string): void
 }>()
 
@@ -211,6 +212,7 @@ const kLineLevel = ref(props.semanticConfig.data.period)
 const currentSymbol = ref('选择商品')
 const symbolLoading = ref(false)
 const symbolError = ref(false)
+const overlaySymbols = ref<string[]>([])
 
 function onKLineLevelChange(level: string) {
   kLineLevel.value = level as typeof kLineLevel.value
@@ -231,6 +233,15 @@ function onSymbolChange(item: SymbolItem) {
       adjust: props.semanticConfig.data.adjust,
     },
   ])
+}
+
+function onAddOverlaySymbol(code: string) {
+  if (overlaySymbols.value.includes(code)) return
+  overlaySymbols.value = [...overlaySymbols.value, code]
+}
+
+function onRemoveOverlaySymbol(code: string) {
+  overlaySymbols.value = overlaySymbols.value.filter((c) => c !== code)
 }
 
 const containerRef = ref<HTMLDivElement | null>(null)

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -142,6 +142,7 @@ import {
   type InteractionSnapshot,
   type DrawingToolId,
   type KLineData,
+  type SymbolSpec,
   zoomLevelToKWidth,
   kGapFromKWidth,
   getPhysicalKLineConfig,
@@ -210,38 +211,65 @@ const emit = defineEmits<{
 
 const kLineLevel = ref(props.semanticConfig.data.period)
 const currentSymbol = ref('选择商品')
+const currentSymbolItem = ref<SymbolItem | null>(null)
 const symbolLoading = ref(false)
 const symbolError = ref(false)
 const overlaySymbols = ref<string[]>([])
+const overlaySymbolItems = ref<SymbolItem[]>([])
 
 function onKLineLevelChange(level: string) {
   kLineLevel.value = level as typeof kLineLevel.value
   emit('kLineLevelChange', level)
+  syncSymbolsToController()
 }
 
 function onSymbolChange(item: SymbolItem) {
   symbolError.value = false
   currentSymbol.value = item.code
-  controller.value?.setSymbols([
-    {
-      symbol: item.code,
-      exchange: item.exchange,
-      period: kLineLevel.value,
-      source: item.source,
-      startDate: props.semanticConfig.data.startDate,
-      endDate: props.semanticConfig.data.endDate,
-      adjust: props.semanticConfig.data.adjust,
-    },
-  ])
+  currentSymbolItem.value = item
+  syncSymbolsToController()
 }
 
-function onAddOverlaySymbol(code: string) {
-  if (overlaySymbols.value.includes(code)) return
-  overlaySymbols.value = [...overlaySymbols.value, code]
+function onAddOverlaySymbol(item: SymbolItem) {
+  if (currentSymbolItem.value?.code === item.code) return
+  if (overlaySymbols.value.includes(item.code)) return
+  overlaySymbolItems.value = [...overlaySymbolItems.value, item]
+  overlaySymbols.value = overlaySymbolItems.value.map((symbol) => symbol.code)
+  forcePercentAxis()
+  syncSymbolsToController()
 }
 
 function onRemoveOverlaySymbol(code: string) {
-  overlaySymbols.value = overlaySymbols.value.filter((c) => c !== code)
+  overlaySymbolItems.value = overlaySymbolItems.value.filter((item) => item.code !== code)
+  overlaySymbols.value = overlaySymbolItems.value.map((symbol) => symbol.code)
+  syncSymbolsToController()
+}
+
+function toSymbolSpec(item: SymbolItem): SymbolSpec {
+  return {
+    symbol: item.code,
+    exchange: item.exchange,
+    period: kLineLevel.value,
+    source: item.source,
+    startDate: props.semanticConfig.data.startDate,
+    endDate: props.semanticConfig.data.endDate,
+    adjust: props.semanticConfig.data.adjust,
+  }
+}
+
+function syncSymbolsToController() {
+  if (!currentSymbolItem.value) return
+  controller.value?.setSymbols([
+    toSymbolSpec(currentSymbolItem.value),
+    ...overlaySymbolItems.value.map(toSymbolSpec),
+  ])
+}
+
+function forcePercentAxis() {
+  if (chartSettings.value.axisType === 'percent') return
+  const nextSettings = { ...chartSettings.value, axisType: 'percent' as const }
+  chartSettings.value = nextSettings
+  controller.value?.updateSettingsFacade(nextSettings)
 }
 
 const containerRef = ref<HTMLDivElement | null>(null)

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -50,7 +50,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'addOverlaySymbol', code: string): void
+  (e: 'addOverlaySymbol', item: SymbolItem): void
   (e: 'removeOverlaySymbol', code: string): void
   (e: 'kLineLevelChange', level: KLineLevel): void
   (e: 'toggleIndicator'): void

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -8,16 +8,12 @@
       :error="symbolError"
       @change="onSymbolSelectorChange"
     />
-    <button
-      type="button"
-      class="overlay-symbol-button"
-      title="添加比较商品"
-      aria-label="添加比较商品"
-      @click="emit('addOverlaySymbol')"
-    >
-      <span class="overlay-symbol-button__icon" aria-hidden="true">+</span>
-      <span class="overlay-symbol-button__text">添加比较商品</span>
-    </button>
+    <CompareSymbolSelector
+      :symbols="symbolPool"
+      :selected="overlaySymbols"
+      @add="emit('addOverlaySymbol', $event)"
+      @remove="emit('removeOverlaySymbol', $event)"
+    />
     <KLineLevelDropdown
       :model-value="kLineLevel"
       @update:model-value="emit('kLineLevelChange', $event)"
@@ -39,6 +35,7 @@
 import { computed } from 'vue'
 import KLineLevelDropdown, { type KLineLevel } from './KLineLevelDropdown.vue'
 import SymbolSelector from './SymbolSelector.vue'
+import CompareSymbolSelector from './CompareSymbolSelector.vue'
 import type { SymbolItem } from './SymbolSelector.vue'
 
 export type { SymbolItem }
@@ -49,10 +46,12 @@ const props = defineProps<{
   symbols?: SymbolItem[]
   symbolLoading?: boolean
   symbolError?: boolean
+  overlaySymbols?: string[]
 }>()
 
 const emit = defineEmits<{
-  (e: 'addOverlaySymbol'): void
+  (e: 'addOverlaySymbol', code: string): void
+  (e: 'removeOverlaySymbol', code: string): void
   (e: 'kLineLevelChange', level: KLineLevel): void
   (e: 'toggleIndicator'): void
   (e: 'symbolChange', symbol: SymbolItem): void
@@ -108,52 +107,6 @@ function onSymbolSelectorChange(item: SymbolItem) {
   user-select: none;
 }
 
-.overlay-symbol-button {
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  gap: 6px;
-  padding: 0 10px;
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 4px;
-  background: var(--klc-color-background);
-  color: var(--klc-color-foreground);
-  font: inherit;
-  cursor: pointer;
-  transition:
-    background 0.15s ease,
-    border-color 0.15s ease,
-    color 0.15s ease;
-}
-
-.overlay-symbol-button:hover {
-  border-color: var(--klc-color-axis-text);
-  background: var(--klc-color-grid-minor);
-}
-
-.overlay-symbol-button__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--klc-color-foreground);
-  color: var(--klc-color-background);
-  font-size: 13px;
-  font-weight: 700;
-  line-height: 1;
-}
-
-.overlay-symbol-button__text {
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1;
-  white-space: nowrap;
-}
-
 .indicator-button {
   height: 28px;
   display: inline-flex;
@@ -202,7 +155,6 @@ function onSymbolSelectorChange(item: SymbolItem) {
 }
 
 @media (max-width: 768px), (max-height: 640px) {
-  .overlay-symbol-button__text,
   .indicator-button__text {
     display: none;
   }


### PR DESCRIPTION

## Summary

Add percentage-change comparison line support for overlay symbols on the price chart. Users can now select additional symbols to overlay as percentage-change polylines, with the Y-axis automatically switching to percent mode.

## Changes

### Core Engine
- **Multi-symbol data loading**: `Chart.setSymbols()` now handles `specs[0]` as primary and `specs[1..]` as comparison symbols, each with independent `DataBuffer` instances
- **Percentage range merge**: `getComparisonEquivalentPriceRange()` converts comparison symbol percentage ranges back to equivalent primary price ranges and merges them into the main pane`s `updateRange()`
- **RenderContext extended**: Added `comparisonData` and `comparisonSymbols` fields for renderer access
- **New comparisonLine renderer**: Registered after candle renderer at `MAIN + 2` priority; draws percentage-change polylines aligned to primary symbol timestamps; missing timestamps break line segments

### Vue Bindings
- `CompareSymbolSelector`: Emits full `SymbolItem` object instead of just code string
- `KLineChart`: Maintains `currentSymbolItem` + `overlaySymbolItems` state; `syncSymbolsToController()` builds full `SymbolSpec[]` array
- **Force percent axis**: When first comparison symbol is added, `chartSettings.axisType` is set to `'percent'` (not reverted on removal)

## Behavior Details
- Comparison baseline uses the first visible K-line`s close for both primary and comparison symbols
- Missing comparison timestamps: uses nearest timestamp `>= baseline` as baseline; gaps in data break the line (no bridging)
- Color pool: `#f59e0b, #8b5cf6, #06b6d4, #ec4899, #84cc16, #f97316`

## Verification
- Core: 929 tests passing (48 test files)
- Vue package build: passing
