### PR TITLE
feat: comparison product incremental loading, batch fetches, and legend fixes

### DIFF
--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -500,6 +500,16 @@ export function createChartController(opts: ChartMountOptions): ChartController 
         chart.setSymbols(next)
     }
 
+    function addComparisonSymbol(spec: SymbolSpec): void {
+        if (disposed) return
+        chart.addComparisonSymbol(spec)
+    }
+
+    function removeComparisonSymbol(symbol: string): void {
+        if (disposed) return
+        chart.removeComparisonSymbol(symbol)
+    }
+
     function setDataFetcher(fetcher: DataFetcher | null): void {
         if (disposed) return
         chart.setDataFetcher(fetcher)
@@ -784,6 +794,8 @@ export function createChartController(opts: ChartMountOptions): ChartController 
         interactionState,
         catalog: DEFAULT_INDICATOR_CATALOG,
         setSymbols,
+        addComparisonSymbol,
+        removeComparisonSymbol,
         setDataFetcher,
         setData,
         appendData,

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -371,6 +371,7 @@ export function createChartController(opts: ChartMountOptions): ChartController 
     >({})
     const interactionState: Signal<InteractionSnapshot> = createSignal(INITIAL_INTERACTION)
     const comparisonColors: Signal<ReadonlyMap<string, string>> = createSignal<ReadonlyMap<string, string>>(new Map())
+    const comparisonLoading: Signal<boolean> = createSignal(false)
 
     // -------------------------------------------------------------------
     // Apply initial render state + seed data
@@ -481,6 +482,13 @@ export function createChartController(opts: ChartMountOptions): ChartController 
     unsubs.push(
         chart.comparisonColors.subscribe(() =>
             comparisonColors.set(new Map(chart.comparisonColors.peek())),
+        ),
+    )
+
+    // comparisonLoading
+    unsubs.push(
+        chart.comparisonLoading.subscribe(() =>
+            comparisonLoading.set(chart.comparisonLoading.peek()),
         ),
     )
 
@@ -801,6 +809,7 @@ export function createChartController(opts: ChartMountOptions): ChartController 
         paneLayout,
         interactionState,
         comparisonColors,
+        comparisonLoading,
         catalog: DEFAULT_INDICATOR_CATALOG,
         setSymbols,
         addComparisonSymbol,

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -370,6 +370,7 @@ export function createChartController(opts: ChartMountOptions): ChartController 
         Readonly<Record<string, number>>
     >({})
     const interactionState: Signal<InteractionSnapshot> = createSignal(INITIAL_INTERACTION)
+    const comparisonColors: Signal<ReadonlyMap<string, string>> = createSignal<ReadonlyMap<string, string>>(new Map())
 
     // -------------------------------------------------------------------
     // Apply initial render state + seed data
@@ -473,6 +474,13 @@ export function createChartController(opts: ChartMountOptions): ChartController 
     unsubs.push(
         chart.interactionState.subscribe(() =>
             interactionState.set(mapInteractionSnapshot(chart.interactionState.peek())),
+        ),
+    )
+
+    // comparisonColors
+    unsubs.push(
+        chart.comparisonColors.subscribe(() =>
+            comparisonColors.set(new Map(chart.comparisonColors.peek())),
         ),
     )
 
@@ -792,6 +800,7 @@ export function createChartController(opts: ChartMountOptions): ChartController 
         paneRatios,
         paneLayout,
         interactionState,
+        comparisonColors,
         catalog: DEFAULT_INDICATOR_CATALOG,
         setSymbols,
         addComparisonSymbol,

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -71,6 +71,7 @@ export interface KLineData {
     changePercent?: number
     changeAmount?: number
     turnoverRate?: number
+    date?: string
 }
 
 export type { PaneSpec }
@@ -248,6 +249,8 @@ export interface ChartController extends DrawingChartAdapter {
 
     // ---- Data ----
     setSymbols(next: ReadonlyArray<SymbolSpec>): void
+    addComparisonSymbol(spec: SymbolSpec): void
+    removeComparisonSymbol(symbol: string): void
     setDataFetcher(fetcher: DataFetcher | null): void
     setData(next: ReadonlyArray<KLineData>): void
     appendData(next: ReadonlyArray<KLineData>): void

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -243,6 +243,7 @@ export interface ChartController extends DrawingChartAdapter {
     readonly paneRatios: Signal<Readonly<Record<string, number>>>
     readonly paneLayout: Signal<ReadonlyArray<PaneSpec>>
     readonly interactionState: Signal<InteractionSnapshot>
+    readonly comparisonColors: Signal<ReadonlyMap<string, string>>
 
     // indicator catalog (static — adapters use for picker UI)
     readonly catalog: ReadonlyArray<IndicatorDefinition>

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -244,6 +244,7 @@ export interface ChartController extends DrawingChartAdapter {
     readonly paneLayout: Signal<ReadonlyArray<PaneSpec>>
     readonly interactionState: Signal<InteractionSnapshot>
     readonly comparisonColors: Signal<ReadonlyMap<string, string>>
+    readonly comparisonLoading: Signal<boolean>
 
     // indicator catalog (static — adapters use for picker UI)
     readonly catalog: ReadonlyArray<IndicatorDefinition>

--- a/packages/core/src/data-fetchers/baostock.ts
+++ b/packages/core/src/data-fetchers/baostock.ts
@@ -18,6 +18,7 @@ const periodMap: Record<string, string> = { daily: 'd', weekly: 'w', monthly: 'm
     console.log(json)
     return (json.data ?? json).map((item: Record<string, unknown>) => ({
       timestamp: new Date(item.date as string).getTime(),
+      date: item.date as string,
       open: Number(item.open),
       high: Number(item.high),
       low: Number(item.low),

--- a/packages/core/src/data-fetchers/baostock.ts
+++ b/packages/core/src/data-fetchers/baostock.ts
@@ -11,8 +11,7 @@ const periodMap: Record<string, string> = { daily: 'd', weekly: 'w', monthly: 'm
     const res = await fetch(url)
     console.log(res)
     if (!res.ok) {
-      console.warn(`[baostock] fetch failed: ${res.status} ${res.statusText}`)
-      return []
+      throw new Error(`[baostock] fetch failed: ${res.status} ${res.statusText}`)
     }
     const json = await res.json()
     console.log(json)
@@ -30,6 +29,6 @@ const periodMap: Record<string, string> = { daily: 'd', weekly: 'w', monthly: 'm
     })) as KLineData[]
   } catch (err) {
     console.warn('[baostock] network error:', err)
-    return []
+    throw err
   }
 }

--- a/packages/core/src/data-fetchers/dataBuffer.ts
+++ b/packages/core/src/data-fetchers/dataBuffer.ts
@@ -72,13 +72,17 @@ export class DataBuffer {
         this._fetcher = fetcher
     }
 
-    setSymbol(spec: SymbolSpec): void {
+    setSymbol(spec: SymbolSpec, initialStartTs?: number): void {
         this._currentSpec = spec
         this._data = []
         this._loadedWindow = null
         this._attemptedBoundaries.clear()
         this._dataSignal.set([])
-        this.loadInitial()
+        if (initialStartTs !== undefined) {
+            this.loadInitialRange(initialStartTs, Date.now())
+        } else {
+            this.loadInitial()
+        }
     }
 
     ensureRange(requestStartTs: number, _requestEndTs: number): void {
@@ -106,6 +110,11 @@ export class DataBuffer {
         const endDate = now
 
         this.fetchRange(startDate, endDate)
+    }
+
+    private loadInitialRange(startTs: number, endTs: number): void {
+        if (!this._fetcher || !this._currentSpec || this._disposed) return
+        this.fetchRange(startTs, endTs)
     }
 
     private fetchRange(startTs: number, endTs: number): void {

--- a/packages/core/src/data-fetchers/dataBuffer.ts
+++ b/packages/core/src/data-fetchers/dataBuffer.ts
@@ -60,6 +60,10 @@ export class DataBuffer {
         return this._loadingSignal
     }
 
+    get currentSpec(): SymbolSpec | null {
+        return this._currentSpec
+    }
+
     get loadedWindow(): DataWindow | null {
         return this._loadedWindow
     }

--- a/packages/core/src/data-fetchers/dataBuffer.ts
+++ b/packages/core/src/data-fetchers/dataBuffer.ts
@@ -9,6 +9,7 @@ export interface DataWindow {
 const MS_PER_DAY = 86_400_000
 const INITIAL_LOAD_DAYS = 365
 const INCREMENTAL_LOAD_DAYS = 90
+const FETCH_MAX_RETRIES = 2
 
 function formatDate(ts: number): string {
     const d = new Date(ts)
@@ -117,13 +118,13 @@ export class DataBuffer {
         this.fetchRange(startTs, endTs)
     }
 
-    private fetchRange(startTs: number, endTs: number): void {
+    private fetchRange(startTs: number, endTs: number, retryCount = 0): void {
         if (!this._fetcher || !this._currentSpec || this._disposed) return
 
         if (this._pendingFetch) {
             this._pendingFetch = this._pendingFetch.then(() => {
                 if (this._disposed) return
-                this.fetchRange(startTs, endTs)
+                return this.fetchRange(startTs, endTs, retryCount)
             })
             return
         }
@@ -133,15 +134,15 @@ export class DataBuffer {
 
         this._loadingSignal.set(true)
 
-        this._pendingFetch = fetcher(spec.source ?? 'baostock', {
-            symbol: spec.symbol,
-            startDate: formatDate(startTs),
-            endDate: formatDate(endTs),
-            period: spec.period ?? 'daily',
-            adjust: spec.adjust ?? 'none',
-            exchange: spec.exchange,
-        })
-            .then((incoming) => {
+        const doFetch = (): Promise<void> =>
+            fetcher(spec.source ?? 'baostock', {
+                symbol: spec.symbol,
+                startDate: formatDate(startTs),
+                endDate: formatDate(endTs),
+                period: spec.period ?? 'daily',
+                adjust: spec.adjust ?? 'none',
+                exchange: spec.exchange,
+            }).then((incoming) => {
                 if (this._disposed) return
 
                 const oldLength = this._data.length
@@ -174,16 +175,34 @@ export class DataBuffer {
                     }
                 }
             })
-            .catch((err) => {
+
+        const attempt = (count: number): Promise<void> => {
+            return doFetch().catch((err) => {
                 if (this._disposed) return
-                console.error('[DataBuffer] fetch failed:', err)
-            })
-            .finally(() => {
-                this._pendingFetch = null
-                if (!this._disposed) {
-                    this._loadingSignal.set(false)
+
+                if (count < FETCH_MAX_RETRIES) {
+                    const delay = Math.pow(2, count) * 1000
+                    console.warn(
+                        `[DataBuffer] fetch failed, retry ${count + 1}/${FETCH_MAX_RETRIES} in ${delay}ms:`,
+                        err,
+                    )
+                    return new Promise<void>((resolve) => setTimeout(resolve, delay)).then(() => {
+                        if (this._disposed) return
+                        return attempt(count + 1)
+                    })
                 }
+
+                console.error(`[DataBuffer] fetch failed after ${FETCH_MAX_RETRIES + 1} attempts:`, err)
+                this._attemptedBoundaries.delete(endTs)
             })
+        }
+
+        this._pendingFetch = attempt(retryCount).finally(() => {
+            this._pendingFetch = null
+            if (!this._disposed) {
+                this._loadingSignal.set(false)
+            }
+        })
     }
 
     dispose(): void {

--- a/packages/core/src/data-fetchers/dataBuffer.ts
+++ b/packages/core/src/data-fetchers/dataBuffer.ts
@@ -40,6 +40,7 @@ export class DataBuffer {
     private _dataSignal: Signal<ReadonlyArray<KLineData>>
     private _loadingSignal: Signal<boolean>
     private _fetcher: DataFetcher | null = null
+    private _requestFetch: ((spec: SymbolSpec, startTs: number, endTs: number) => Promise<ReadonlyArray<KLineData>>) | null = null
     private _currentSpec: SymbolSpec | null = null
     private _loadedWindow: DataWindow | null = null
     private _pendingFetch: Promise<void> | null = null
@@ -73,6 +74,10 @@ export class DataBuffer {
         this._fetcher = fetcher
     }
 
+    setRequestFetch(fn: ((spec: SymbolSpec, startTs: number, endTs: number) => Promise<ReadonlyArray<KLineData>>) | null): void {
+        this._requestFetch = fn
+    }
+
     setSymbol(spec: SymbolSpec, initialStartTs?: number): void {
         this._currentSpec = spec
         this._data = []
@@ -87,7 +92,7 @@ export class DataBuffer {
     }
 
     ensureRange(requestStartTs: number, _requestEndTs: number): void {
-        if (this._disposed || !this._fetcher || !this._currentSpec) return
+        if (this._disposed || (!this._requestFetch && !this._fetcher) || !this._currentSpec) return
         if (!this._loadedWindow) return
 
         if (requestStartTs >= this._loadedWindow.earliestTs) return
@@ -104,7 +109,7 @@ export class DataBuffer {
     }
 
     private loadInitial(): void {
-        if (!this._fetcher || !this._currentSpec || this._disposed) return
+        if ((!this._requestFetch && !this._fetcher) || !this._currentSpec || this._disposed) return
 
         const now = Date.now()
         const startDate = now - INITIAL_LOAD_DAYS * MS_PER_DAY
@@ -114,12 +119,12 @@ export class DataBuffer {
     }
 
     private loadInitialRange(startTs: number, endTs: number): void {
-        if (!this._fetcher || !this._currentSpec || this._disposed) return
+        if ((!this._requestFetch && !this._fetcher) || !this._currentSpec || this._disposed) return
         this.fetchRange(startTs, endTs)
     }
 
     private fetchRange(startTs: number, endTs: number, retryCount = 0): void {
-        if (!this._fetcher || !this._currentSpec || this._disposed) return
+        if ((!this._requestFetch && !this._fetcher) || !this._currentSpec || this._disposed) return
 
         if (this._pendingFetch) {
             this._pendingFetch = this._pendingFetch.then(() => {
@@ -134,15 +139,18 @@ export class DataBuffer {
 
         this._loadingSignal.set(true)
 
-        const doFetch = (): Promise<void> =>
-            fetcher(spec.source ?? 'baostock', {
-                symbol: spec.symbol,
-                startDate: formatDate(startTs),
-                endDate: formatDate(endTs),
-                period: spec.period ?? 'daily',
-                adjust: spec.adjust ?? 'none',
-                exchange: spec.exchange,
-            }).then((incoming) => {
+        const doFetch = (): Promise<void> => {
+            const fetchPromise = this._requestFetch
+                ? this._requestFetch(spec, startTs, endTs)
+                : (fetcher as NonNullable<DataFetcher>)(spec.source ?? 'baostock', {
+                    symbol: spec.symbol,
+                    startDate: formatDate(startTs),
+                    endDate: formatDate(endTs),
+                    period: spec.period ?? 'daily',
+                    adjust: spec.adjust ?? 'none',
+                    exchange: spec.exchange,
+                })
+            return fetchPromise.then((incoming) => {
                 if (this._disposed) return
 
                 const oldLength = this._data.length
@@ -175,6 +183,7 @@ export class DataBuffer {
                     }
                 }
             })
+        }
 
         const attempt = (count: number): Promise<void> => {
             return doFetch().catch((err) => {

--- a/packages/core/src/data-fetchers/tradingview.ts
+++ b/packages/core/src/data-fetchers/tradingview.ts
@@ -35,6 +35,7 @@ export const tradingviewDataFetcher: DataFetcher = async (source, config) => {
 
     return (json.data ?? []).map((item: Record<string, unknown>) => ({
       timestamp: item.ts_open as number,
+      date: item.date as string,
       open: item.open as number,
       high: item.high as number,
       low: item.low as number,

--- a/packages/core/src/data-fetchers/tradingview.ts
+++ b/packages/core/src/data-fetchers/tradingview.ts
@@ -21,13 +21,11 @@ export const tradingviewDataFetcher: DataFetcher = async (source, config) => {
   try {
     const res = await fetch(url)
     if (!res.ok) {
-      console.warn(`[tradingview] fetch failed: ${res.status} ${res.statusText}`)
-      return []
+      throw new Error(`[tradingview] fetch failed: ${res.status} ${res.statusText}`)
     }
     const json = await res.json()
     if (!json.success) {
-      console.warn(`[tradingview] API error: ${json.error_msg}`)
-      return []
+      throw new Error(`[tradingview] API error: ${json.error_msg}`)
     }
     if (json.warning) {
       console.warn(`[tradingview] ${json.warning}`)
@@ -45,6 +43,6 @@ export const tradingviewDataFetcher: DataFetcher = async (source, config) => {
     })) as KLineData[]
   } catch (err) {
     console.warn('[tradingview] network error:', err)
-    return []
+    throw err
   }
 }

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -736,6 +736,11 @@ export class Chart {
         return this.dataManager.symbols
     }
 
+    /** 比较商品颜色信号 */
+    get comparisonColors(): Signal<ReadonlyMap<string, string>> {
+        return this.dataManager.comparisonColors
+    }
+
     /** 主题信号 */
     get theme(): Signal<'light' | 'dark'> {
         return this._themeSignal

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -801,6 +801,14 @@ export class Chart {
         this.dataManager.setSymbols(specs)
     }
 
+    addComparisonSymbol(spec: SymbolSpec): void {
+        this.dataManager.addComparisonSymbol(spec)
+    }
+
+    removeComparisonSymbol(symbol: string): void {
+        this.dataManager.removeComparisonSymbol(symbol)
+    }
+
     // ---------- Theme ----------
 
     /**

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -319,11 +319,13 @@ export class Chart {
         this.interaction.updateSettings(settings)
 
         // 同步刻度类型设置到所有 pane（百分比仅用于主图）
-        const axisType = (settings.axisType as ScaleType) ?? 'linear'
-        for (const renderer of this.paneRenderers) {
-            const pane = renderer.getPane()
-            const scaleType = axisType === 'percent' && pane.role !== 'price' ? 'linear' : axisType
-            pane.yAxis.setScaleType(scaleType)
+        if ('axisType' in settings) {
+            const axisType = (settings.axisType as ScaleType) ?? 'linear'
+            for (const renderer of this.paneRenderers) {
+                const pane = renderer.getPane()
+                const scaleType = axisType === 'percent' && pane.role !== 'price' ? 'linear' : axisType
+                pane.yAxis.setScaleType(scaleType)
+            }
         }
 
         this.scheduleDraw()

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -741,6 +741,11 @@ export class Chart {
         return this.dataManager.comparisonColors
     }
 
+    /** 比较商品加载信号 */
+    get comparisonLoading(): Signal<boolean> {
+        return this.dataManager.comparisonLoading
+    }
+
     /** 主题信号 */
     get theme(): Signal<'light' | 'dark'> {
         return this._themeSignal

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -251,18 +251,24 @@ export class ChartDataManager {
     if (!window) return
     const range = this.computeRawVisibleRange() ?? this.lastRawVisibleRange
 
+    const MS_PER_DAY = 86_400_000
+    let firstVisibleTs: number | undefined
+
     if (range.start < 0 && this._dataFetcher) {
-      const MS_PER_DAY = 86_400_000
       const earlierThanEarliest = window.earliestTs - 90 * MS_PER_DAY
       this._dataBuffer.ensureRange(earlierThanEarliest, window.earliestTs)
-      return
+      firstVisibleTs = this._internalData[0]?.timestamp
+    } else if (range.start < this._internalData.length) {
+      firstVisibleTs = this._internalData[Math.max(0, range.start)]?.timestamp
+      if (firstVisibleTs !== undefined && firstVisibleTs < window.earliestTs) {
+        this._dataBuffer.ensureRange(firstVisibleTs, window.earliestTs)
+      }
     }
 
-    if (range.start >= this._internalData.length) return
-    const firstVisibleTs = this._internalData[Math.max(0, range.start)]?.timestamp
     if (firstVisibleTs === undefined) return
-    if (firstVisibleTs < window.earliestTs) {
-      this._dataBuffer.ensureRange(firstVisibleTs, window.earliestTs)
+
+    for (const buffer of this._comparisonBuffers.values()) {
+      buffer.ensureRange(firstVisibleTs, window.earliestTs)
     }
   }
 

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -466,9 +466,10 @@ export class ChartDataManager {
   getComparisonEquivalentPriceRange(range: VisibleRange): { min: number; max: number } | null {
     if (this._comparisonSpecs.length === 0 || this._comparisonData.size === 0) return null
     const baseIndex = Math.max(0, range.start)
-    const mainBase = this._internalData[baseIndex]?.close
-    const baseTimestamp = this._internalData[baseIndex]?.timestamp
-    if (!Number.isFinite(mainBase) || mainBase <= 0 || baseTimestamp === undefined) return null
+    const baseItem = this._internalData[baseIndex]
+    if (!baseItem || !Number.isFinite(baseItem.close) || baseItem.close <= 0) return null
+    const mainBase = baseItem.close
+    const baseDate = baseItem.date ?? ''
 
     let min = Number.POSITIVE_INFINITY
     let max = Number.NEGATIVE_INFINITY
@@ -477,16 +478,22 @@ export class ChartDataManager {
       const data = this._comparisonData.get(spec.symbol)
       if (!data?.length) continue
 
-      const baseline = this.findComparisonBaseline(data, baseTimestamp)
+      const baseline = baseDate
+        ? findComparisonBaselineByDate(data, baseDate)
+        : findComparisonBaselineByTimestamp(data, baseItem.timestamp)
       if (!baseline || !Number.isFinite(baseline.close) || baseline.close <= 0) continue
 
-      const byTimestamp = new Map<number, KLineData>()
-      for (const item of data) byTimestamp.set(item.timestamp, item)
+      const byDate = new Map<string, KLineData>()
+      for (const item of data) {
+        if (item.date) byDate.set(item.date, item)
+        else byDate.set(String(item.timestamp), item)
+      }
 
       for (let i = Math.max(0, range.start); i < range.end && i < this._internalData.length; i++) {
         const mainItem = this._internalData[i]
         if (!mainItem) continue
-        const item = byTimestamp.get(mainItem.timestamp)
+        const key = mainItem.date ?? String(mainItem.timestamp)
+        const item = byDate.get(key)
         if (!item || !Number.isFinite(item.close)) continue
 
         const pct = (item.close - baseline.close) / baseline.close
@@ -499,13 +506,6 @@ export class ChartDataManager {
 
     if (!Number.isFinite(min) || !Number.isFinite(max)) return null
     return { min, max }
-  }
-
-  private findComparisonBaseline(data: ReadonlyArray<KLineData>, timestamp: number): KLineData | null {
-    for (const item of data) {
-      if (item.timestamp >= timestamp) return item
-    }
-    return null
   }
 
   getLogicalSlotCount(): number {
@@ -547,4 +547,18 @@ export class ChartDataManager {
     this._dataBuffer.dispose()
     this.clearComparisonBuffers()
   }
+}
+
+function findComparisonBaselineByDate(data: ReadonlyArray<KLineData>, date: string): KLineData | null {
+  for (const item of data) {
+    if (item.date && item.date >= date) return item
+  }
+  return null
+}
+
+function findComparisonBaselineByTimestamp(data: ReadonlyArray<KLineData>, timestamp: number): KLineData | null {
+  for (const item of data) {
+    if (item.timestamp >= timestamp) return item
+  }
+  return null
 }

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -7,6 +7,9 @@ import type { VisibleRange, UpdateLevel } from '../layout/pane'
 import { getVisibleRange } from '../viewport/viewport'
 import { getPhysicalKLineConfig } from '../utils/klineConfig'
 
+const COMPARISON_PALETTE = ['#f59e0b', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16', '#f97316']
+const DEFAULT_COMPARISON_COLOR = '#f59e0b'
+
 export interface DataDependencies {
   getOption: () => { kWidth: number; kGap: number }
   getEffectiveDpr: () => number
@@ -35,6 +38,8 @@ export class ChartDataManager {
   private _comparisonData: Map<string, KLineData[]> = new Map()
   private _comparisonBuffers: Map<string, DataBuffer> = new Map()
   private _comparisonBufferUnsubs: Map<string, () => void> = new Map()
+  private _comparisonColors: Map<string, string> = new Map()
+  private _comparisonColorsSignal = createSignal<ReadonlyMap<string, string>>(new Map())
 
   private _dataSignal = createSignal<ReadonlyArray<KLineData>>([])
   private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
@@ -175,6 +180,14 @@ export class ChartDataManager {
     return this._dataBuffer
   }
 
+  get comparisonColors(): Signal<ReadonlyMap<string, string>> {
+    return this._comparisonColorsSignal
+  }
+
+  getComparisonColors(): Map<string, string> {
+    return this._comparisonColors
+  }
+
   updateData(data: KLineData[]): void {
     this._internalData = data ?? []
     this._dataSignal.set([...this._internalData])
@@ -313,6 +326,8 @@ export class ChartDataManager {
     for (const buffer of this._comparisonBuffers.values()) buffer.dispose()
     this._comparisonBuffers.clear()
     this._comparisonData.clear()
+    this._comparisonColors.clear()
+    this._comparisonColorsSignal.set(new Map())
     this._comparisonSpecs = []
   }
 
@@ -320,6 +335,11 @@ export class ChartDataManager {
     const key = spec.symbol
     if (this._comparisonBuffers.has(key)) return
     this._comparisonSpecs.push(spec)
+
+    const color = COMPARISON_PALETTE[this._comparisonColors.size % COMPARISON_PALETTE.length] ?? DEFAULT_COMPARISON_COLOR
+    this._comparisonColors.set(key, color)
+    this._comparisonColorsSignal.set(new Map(this._comparisonColors))
+
     if (!this._dataFetcher) return
 
     const newBuffer = new DataBuffer()
@@ -343,6 +363,8 @@ export class ChartDataManager {
     this._comparisonBuffers.get(key)?.dispose()
     this._comparisonBuffers.delete(key)
     this._comparisonData.delete(key)
+    this._comparisonColors.delete(key)
+    this._comparisonColorsSignal.set(new Map(this._comparisonColors))
     this._comparisonSpecs = this._comparisonSpecs.filter((s) => s.symbol !== symbol)
     this._symbolsSignal.set([this._symbolsSignal.peek()[0]!, ...this._comparisonSpecs])
   }

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -40,6 +40,8 @@ export class ChartDataManager {
   private _comparisonBufferUnsubs: Map<string, () => void> = new Map()
   private _comparisonColors: Map<string, string> = new Map()
   private _comparisonColorsSignal = createSignal<ReadonlyMap<string, string>>(new Map())
+  private _comparisonLoadingUnsubs: Map<string, () => void> = new Map()
+  private _comparisonLoadingSignal = createSignal<boolean>(false)
 
   private _dataSignal = createSignal<ReadonlyArray<KLineData>>([])
   private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
@@ -184,8 +186,17 @@ export class ChartDataManager {
     return this._comparisonColorsSignal
   }
 
+  get comparisonLoading(): Signal<boolean> {
+    return this._comparisonLoadingSignal
+  }
+
   getComparisonColors(): Map<string, string> {
     return this._comparisonColors
+  }
+
+  private recomputeComparisonLoading(): void {
+    const anyLoading = Array.from(this._comparisonBuffers.values()).some((b) => b.loading.peek())
+    this._comparisonLoadingSignal.set(anyLoading)
   }
 
   updateData(data: KLineData[]): void {
@@ -312,6 +323,8 @@ export class ChartDataManager {
           this.deps.scheduleDraw()
         })
         this._comparisonBufferUnsubs.set(key, unsubscribe)
+        const unsubLoading = newBuffer.loading.subscribe(() => this.recomputeComparisonLoading())
+        this._comparisonLoadingUnsubs.set(key, unsubLoading)
         buffer = newBuffer
       } else {
         buffer.setFetcher(this._dataFetcher)
@@ -323,11 +336,14 @@ export class ChartDataManager {
   private clearComparisonBuffers(): void {
     for (const unsubscribe of this._comparisonBufferUnsubs.values()) unsubscribe()
     this._comparisonBufferUnsubs.clear()
+    for (const unsub of this._comparisonLoadingUnsubs.values()) unsub()
+    this._comparisonLoadingUnsubs.clear()
     for (const buffer of this._comparisonBuffers.values()) buffer.dispose()
     this._comparisonBuffers.clear()
     this._comparisonData.clear()
     this._comparisonColors.clear()
     this._comparisonColorsSignal.set(new Map())
+    this._comparisonLoadingSignal.set(false)
     this._comparisonSpecs = []
   }
 
@@ -350,6 +366,8 @@ export class ChartDataManager {
       this.deps.scheduleDraw()
     })
     this._comparisonBufferUnsubs.set(key, unsubscribe)
+    const unsubLoading = newBuffer.loading.subscribe(() => this.recomputeComparisonLoading())
+    this._comparisonLoadingUnsubs.set(key, unsubLoading)
     newBuffer.setSymbol(spec)
     this._symbolsSignal.set([this._symbolsSignal.peek()[0]!, ...this._comparisonSpecs])
   }
@@ -360,6 +378,8 @@ export class ChartDataManager {
 
     this._comparisonBufferUnsubs.get(key)?.()
     this._comparisonBufferUnsubs.delete(key)
+    this._comparisonLoadingUnsubs.get(key)?.()
+    this._comparisonLoadingUnsubs.delete(key)
     this._comparisonBuffers.get(key)?.dispose()
     this._comparisonBuffers.delete(key)
     this._comparisonData.delete(key)
@@ -367,6 +387,7 @@ export class ChartDataManager {
     this._comparisonColorsSignal.set(new Map(this._comparisonColors))
     this._comparisonSpecs = this._comparisonSpecs.filter((s) => s.symbol !== symbol)
     this._symbolsSignal.set([this._symbolsSignal.peek()[0]!, ...this._comparisonSpecs])
+    this.recomputeComparisonLoading()
   }
 
   setSymbols(specs: ReadonlyArray<SymbolSpec>): void {

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -310,6 +310,37 @@ export class ChartDataManager {
     this._comparisonSpecs = []
   }
 
+  addComparisonSymbol(spec: SymbolSpec): void {
+    const key = spec.symbol
+    if (this._comparisonBuffers.has(key)) return
+    this._comparisonSpecs.push(spec)
+    if (!this._dataFetcher) return
+
+    const newBuffer = new DataBuffer()
+    newBuffer.setFetcher(this._dataFetcher)
+    this._comparisonBuffers.set(key, newBuffer)
+    const unsubscribe = newBuffer.data.subscribe(() => {
+      this._comparisonData.set(key, [...newBuffer.data.peek()])
+      this.deps.scheduleDraw()
+    })
+    this._comparisonBufferUnsubs.set(key, unsubscribe)
+    newBuffer.setSymbol(spec)
+    this._symbolsSignal.set([this._symbolsSignal.peek()[0]!, ...this._comparisonSpecs])
+  }
+
+  removeComparisonSymbol(symbol: string): void {
+    const key = symbol
+    if (!this._comparisonBuffers.has(key)) return
+
+    this._comparisonBufferUnsubs.get(key)?.()
+    this._comparisonBufferUnsubs.delete(key)
+    this._comparisonBuffers.get(key)?.dispose()
+    this._comparisonBuffers.delete(key)
+    this._comparisonData.delete(key)
+    this._comparisonSpecs = this._comparisonSpecs.filter((s) => s.symbol !== symbol)
+    this._symbolsSignal.set([this._symbolsSignal.peek()[0]!, ...this._comparisonSpecs])
+  }
+
   setSymbols(specs: ReadonlyArray<SymbolSpec>): void {
     this._symbolsSignal.set(specs)
     if (specs.length === 0) {

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -329,7 +329,8 @@ export class ChartDataManager {
       } else {
         buffer.setFetcher(this._dataFetcher)
       }
-      buffer.setSymbol(spec)
+      const mainEarliest = this._dataBuffer.loadedWindow?.earliestTs
+      buffer.setSymbol(spec, mainEarliest)
     }
   }
 
@@ -368,7 +369,8 @@ export class ChartDataManager {
     this._comparisonBufferUnsubs.set(key, unsubscribe)
     const unsubLoading = newBuffer.loading.subscribe(() => this.recomputeComparisonLoading())
     this._comparisonLoadingUnsubs.set(key, unsubLoading)
-    newBuffer.setSymbol(spec)
+    const mainEarliest = this._dataBuffer.loadedWindow?.earliestTs
+    newBuffer.setSymbol(spec, mainEarliest)
     this._symbolsSignal.set([this._symbolsSignal.peek()[0]!, ...this._comparisonSpecs])
   }
 

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -46,6 +46,17 @@ export class ChartDataManager {
   private _dataSignal = createSignal<ReadonlyArray<KLineData>>([])
   private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
 
+  private _pendingFetches: Array<{
+    source: string
+    spec: SymbolSpec
+    startTs: number
+    endTs: number
+    resolve: (data: ReadonlyArray<KLineData>) => void
+    reject: (err: Error) => void
+  }> = []
+
+  private _batchFlushScheduled = false
+
   private incrementalLoadHintEl: HTMLDivElement | null = null
   private incrementalLoadHintTimer: number | null = null
   private pendingPrependedCount = 0
@@ -263,9 +274,63 @@ export class ChartDataManager {
 
   setDataFetcher(fetcher: DataFetcher | null): void {
     this._dataFetcher = fetcher
-    this._dataBuffer.setFetcher(fetcher)
+    if (!fetcher) {
+      this._dataBuffer.setRequestFetch(null)
+      for (const buffer of this._comparisonBuffers.values()) {
+        buffer.setRequestFetch(null)
+      }
+      return
+    }
+    const handler = this._createBatchHandler(fetcher)
+    this._dataBuffer.setRequestFetch(handler)
     for (const buffer of this._comparisonBuffers.values()) {
-      buffer.setFetcher(fetcher)
+      buffer.setRequestFetch(handler)
+    }
+  }
+
+  private _createBatchHandler(
+    fetcher: DataFetcher,
+  ): (spec: SymbolSpec, startTs: number, endTs: number) => Promise<ReadonlyArray<KLineData>> {
+    return (spec, startTs, endTs) =>
+      new Promise<ReadonlyArray<KLineData>>((resolve, reject) => {
+        this._pendingFetches.push({
+          source: spec.source ?? 'baostock',
+          spec,
+          startTs,
+          endTs,
+          resolve,
+          reject,
+        })
+        this._scheduleBatchFlush()
+      })
+  }
+
+  private _scheduleBatchFlush(): void {
+    if (this._batchFlushScheduled) return
+    this._batchFlushScheduled = true
+    Promise.resolve().then(() => this._flushBatch())
+  }
+
+  private async _flushBatch(): Promise<void> {
+    this._batchFlushScheduled = false
+    const batch = this._pendingFetches.splice(0)
+    if (batch.length === 0 || !this._dataFetcher) return
+    const fetcher = this._dataFetcher
+    const CONCURRENCY = 4
+    for (let i = 0; i < batch.length; i += CONCURRENCY) {
+      const chunk = batch.slice(i, i + CONCURRENCY)
+      await Promise.allSettled(
+        chunk.map(({ source, spec, startTs, endTs, resolve, reject }) =>
+          fetcher(source, {
+            symbol: spec.symbol,
+            startDate: batchFormatDate(startTs),
+            endDate: batchFormatDate(endTs),
+            period: spec.period ?? 'daily',
+            adjust: spec.adjust ?? 'none',
+            exchange: spec.exchange,
+          }).then(resolve, reject),
+        ),
+      )
     }
   }
 
@@ -317,6 +382,9 @@ export class ChartDataManager {
       if (!buffer) {
         const newBuffer = new DataBuffer()
         newBuffer.setFetcher(this._dataFetcher)
+        if (this._dataFetcher) {
+          newBuffer.setRequestFetch(this._createBatchHandler(this._dataFetcher))
+        }
         this._comparisonBuffers.set(key, newBuffer)
         const unsubscribe = newBuffer.data.subscribe(() => {
           this._comparisonData.set(key, [...newBuffer.data.peek()])
@@ -328,6 +396,9 @@ export class ChartDataManager {
         buffer = newBuffer
       } else {
         buffer.setFetcher(this._dataFetcher)
+        if (this._dataFetcher) {
+          buffer.setRequestFetch(this._createBatchHandler(this._dataFetcher))
+        }
       }
       const mainEarliest = this._dataBuffer.loadedWindow?.earliestTs
       buffer.setSymbol(spec, mainEarliest)
@@ -361,6 +432,9 @@ export class ChartDataManager {
 
     const newBuffer = new DataBuffer()
     newBuffer.setFetcher(this._dataFetcher)
+    if (this._dataFetcher) {
+      newBuffer.setRequestFetch(this._createBatchHandler(this._dataFetcher))
+    }
     this._comparisonBuffers.set(key, newBuffer)
     const unsubscribe = newBuffer.data.subscribe(() => {
       this._comparisonData.set(key, [...newBuffer.data.peek()])
@@ -606,4 +680,12 @@ function findComparisonBaselineByTimestamp(data: ReadonlyArray<KLineData>, times
     if (item.timestamp >= timestamp) return item
   }
   return null
+}
+
+function batchFormatDate(ts: number): string {
+  const d = new Date(ts)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
 }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -403,6 +403,7 @@ export class ChartRenderer {
         data: dataManager.getInternalData(),
         comparisonData: dataManager.getComparisonData(),
         comparisonSymbols: dataManager.getComparisonSpecs(),
+        comparisonColors: dataManager.getComparisonColors(),
         range,
         scrollLeft: vp.scrollLeft,
         kWidth: opt.kWidth,

--- a/packages/core/src/engine/renderers/Indicator/mainIndicatorLegend.ts
+++ b/packages/core/src/engine/renderers/Indicator/mainIndicatorLegend.ts
@@ -218,7 +218,7 @@ function pushComparisonLegendRows(
 
         const sign = pct > 0 ? '+' : ''
         const pctText = `${sign}${pct.toFixed(2)}%`
-        overlayCtx.fillStyle = pct > 0 ? colors.price.upTick : pct < 0 ? colors.price.downTick : colors.text.primary
+        overlayCtx.fillStyle = pct > 0 ? colors.candleUpBody : pct < 0 ? colors.candleDownBody : colors.text.primary
         overlayCtx.fillText(pctText, x, y + 1)
       },
     })

--- a/packages/core/src/engine/renderers/Indicator/mainIndicatorLegend.ts
+++ b/packages/core/src/engine/renderers/Indicator/mainIndicatorLegend.ts
@@ -105,12 +105,10 @@ export function createMainIndicatorLegendRendererPlugin(options: {
 
             let x = legendX
             let y = config.yPaddingPx / 2 + legendYOffset + rowIndex * lineHeight
-            // 指标名称
             overlayCtx.fillStyle = colors.text.primary
             overlayCtx.fillText(titleInfo.name, x, y)
             x += measureTextWidth(overlayCtx, titleInfo.name)
 
-            // 指标参数
             if (titleInfo.params && titleInfo.params.length > 0) {
               const paramText = `(${titleInfo.params.join(',')})`
               overlayCtx.fillStyle = colors.text.tertiary
@@ -120,7 +118,6 @@ export function createMainIndicatorLegendRendererPlugin(options: {
               x += gap
             }
 
-            // 指标数值
             if (titleInfo.values) {
               y += 1
               for (const item of titleInfo.values) {
@@ -133,6 +130,8 @@ export function createMainIndicatorLegendRendererPlugin(options: {
           }
         })
       }
+
+      pushComparisonLegendRows(context, klineData, targetIndex, range, rows, config.yPaddingPx, overlayCtx, legendX, legendYOffset, lineHeight, gap, colors)
 
       rows.forEach((row, index) => row.draw(index))
       overlayCtx.restore()
@@ -150,4 +149,92 @@ export function createMainIndicatorLegendRendererPlugin(options: {
       }
     },
   }
+}
+
+function pushComparisonLegendRows(
+  context: RenderContext,
+  klineData: KLineData[],
+  targetIndex: number,
+  range: { start: number; end: number },
+  rows: Array<{ draw: (rowIndex: number) => void }>,
+  yPaddingPx: number,
+  overlayCtx: CanvasRenderingContext2D,
+  legendX: number,
+  legendYOffset: number,
+  lineHeight: number,
+  gap: number,
+  colors: ReturnType<typeof resolveThemeColors>,
+): void {
+  const comparisonSymbols = context.comparisonSymbols
+  const comparisonData = context.comparisonData
+  const comparisonColors = context.comparisonColors
+  if (!comparisonSymbols?.length || !comparisonData?.size) return
+
+  const baseIndex = Math.max(0, range.start)
+  const baseItem = klineData[baseIndex]
+  if (!baseItem || !Number.isFinite(baseItem.close) || baseItem.close <= 0) return
+
+  const baseDate = baseItem.date ?? ''
+
+  for (const spec of comparisonSymbols) {
+    const data = comparisonData.get(spec.symbol)
+    if (!data?.length) continue
+
+    const baseline = baseDate
+      ? findBaselineByDate(data, baseDate)
+      : findBaselineByTimestamp(data, baseItem.timestamp)
+    if (!baseline || baseline.close <= 0) continue
+
+    const byDate = new Map<string, KLineData>()
+    for (const item of data) {
+      byDate.set(item.date ?? String(item.timestamp), item)
+    }
+
+    const mainItem = klineData[targetIndex]
+    if (!mainItem) continue
+    const key = mainItem.date ?? String(mainItem.timestamp)
+    const currentItem = byDate.get(key)
+    if (!currentItem || !Number.isFinite(currentItem.close)) continue
+
+    const pct = ((currentItem.close - baseline.close) / baseline.close) * 100
+    const color = comparisonColors?.get(spec.symbol) ?? '#f59e0b'
+
+    rows.push({
+      draw: (rowIndex: number) => {
+        let x = legendX
+        const y = yPaddingPx / 2 + legendYOffset + rowIndex * lineHeight
+
+        const dotRadius = 4
+        overlayCtx.fillStyle = color
+        overlayCtx.beginPath()
+        const fontSize = lineHeight - 6
+        overlayCtx.arc(x + dotRadius, y + fontSize / 2 - 1, dotRadius, 0, Math.PI * 2)
+        overlayCtx.fill()
+        x += dotRadius * 2 + 4
+
+        overlayCtx.fillStyle = colors.text.primary
+        overlayCtx.fillText(spec.symbol, x, y)
+        x += measureTextWidth(overlayCtx, spec.symbol) + gap
+
+        const sign = pct > 0 ? '+' : ''
+        const pctText = `${sign}${pct.toFixed(2)}%`
+        overlayCtx.fillStyle = pct > 0 ? colors.price.upTick : pct < 0 ? colors.price.downTick : colors.text.primary
+        overlayCtx.fillText(pctText, x, y + 1)
+      },
+    })
+  }
+}
+
+function findBaselineByDate(data: ReadonlyArray<KLineData>, date: string): KLineData | null {
+  for (const item of data) {
+    if (item.date && item.date >= date) return item
+  }
+  return null
+}
+
+function findBaselineByTimestamp(data: ReadonlyArray<KLineData>, timestamp: number): KLineData | null {
+  for (const item of data) {
+    if (item.timestamp >= timestamp) return item
+  }
+  return null
 }

--- a/packages/core/src/engine/renderers/comparisonLine.ts
+++ b/packages/core/src/engine/renderers/comparisonLine.ts
@@ -2,7 +2,7 @@ import type { RendererPlugin, RenderContext } from '../../plugin'
 import { RENDERER_PRIORITY } from '../../plugin'
 import type { KLineData } from '../../types/price'
 
-const COMPARISON_COLORS = ['#f59e0b', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16', '#f97316']
+const DEFAULT_COMPARISON_COLOR = '#f59e0b'
 
 export function createComparisonLineRenderer(): RendererPlugin {
     return {
@@ -45,8 +45,10 @@ export function createComparisonLineRenderer(): RendererPlugin {
                   else byDate.set(String(item.timestamp), item)
                 }
 
+                const colors = context.comparisonColors
+
                 ctx.beginPath()
-                ctx.strokeStyle = COMPARISON_COLORS[symbolIndex % COMPARISON_COLORS.length]!
+                ctx.strokeStyle = colors?.get(spec.symbol) ?? DEFAULT_COMPARISON_COLOR
                 let hasPath = false
                 let previousHadPoint = false
 

--- a/packages/core/src/engine/renderers/comparisonLine.ts
+++ b/packages/core/src/engine/renderers/comparisonLine.ts
@@ -21,9 +21,10 @@ export function createComparisonLineRenderer(): RendererPlugin {
             if (context.pane.id !== 'main') return
 
             const baseIndex = Math.max(0, context.range.start)
-            const mainBase = mainData[baseIndex]?.close
-            const baseTimestamp = mainData[baseIndex]?.timestamp
-            if (!Number.isFinite(mainBase) || mainBase <= 0 || baseTimestamp === undefined) return
+            const baseItem = mainData[baseIndex]
+            if (!baseItem || !Number.isFinite(baseItem.close) || baseItem.close <= 0) return
+            const mainBase = baseItem.close
+            const baseDate = baseItem.date ?? ''
 
             const ctx = context.ctx
             ctx.save()
@@ -31,15 +32,18 @@ export function createComparisonLineRenderer(): RendererPlugin {
             ctx.lineWidth = Math.max(1, 1.5 / context.dpr)
 
             for (let symbolIndex = 0; symbolIndex < comparisonSymbols.length; symbolIndex++) {
-                const spec = comparisonSymbols[symbolIndex]
+                const spec = comparisonSymbols[symbolIndex]!
                 const data = comparisonData.get(spec.symbol)
                 if (!data?.length) continue
 
-                const baseline = findBaseline(data, baseTimestamp)
+                const baseline = baseDate ? findBaselineByDate(data, baseDate) : findBaselineByTimestamp(data, baseItem.timestamp)
                 if (!baseline || baseline.close <= 0) continue
 
-                const byTimestamp = new Map<number, KLineData>()
-                for (const item of data) byTimestamp.set(item.timestamp, item)
+                const byDate = new Map<string, KLineData>()
+                for (const item of data) {
+                  if (item.date) byDate.set(item.date, item)
+                  else byDate.set(String(item.timestamp), item)
+                }
 
                 ctx.beginPath()
                 ctx.strokeStyle = COMPARISON_COLORS[symbolIndex % COMPARISON_COLORS.length]!
@@ -52,7 +56,8 @@ export function createComparisonLineRenderer(): RendererPlugin {
                         previousHadPoint = false
                         continue
                     }
-                    const item = byTimestamp.get(mainItem.timestamp)
+                    const key = mainItem.date ?? String(mainItem.timestamp)
+                    const item = byDate.get(key)
                     const x = context.kLineCenters[i - context.range.start]
                     if (!item || x === undefined || !Number.isFinite(item.close)) {
                         previousHadPoint = false
@@ -81,7 +86,14 @@ export function createComparisonLineRenderer(): RendererPlugin {
     }
 }
 
-function findBaseline(data: ReadonlyArray<KLineData>, timestamp: number): KLineData | null {
+function findBaselineByDate(data: ReadonlyArray<KLineData>, date: string): KLineData | null {
+    for (const item of data) {
+        if (item.date && item.date >= date) return item
+    }
+    return null
+}
+
+function findBaselineByTimestamp(data: ReadonlyArray<KLineData>, timestamp: number): KLineData | null {
     for (const item of data) {
         if (item.timestamp >= timestamp) return item
     }

--- a/packages/core/src/plugin/types.ts
+++ b/packages/core/src/plugin/types.ts
@@ -275,6 +275,7 @@ export interface RenderContext {
   data: unknown[]
   comparisonData?: ReadonlyMap<string, ReadonlyArray<KLineData>>
   comparisonSymbols?: ReadonlyArray<import('../controllers/types').SymbolSpec>
+  comparisonColors?: ReadonlyMap<string, string>
   range: { start: number; end: number }
   scrollLeft: number
   kWidth: number

--- a/packages/core/src/tokens/__tests__/__snapshots__/baseline.test.ts.snap
+++ b/packages/core/src/tokens/__tests__/__snapshots__/baseline.test.ts.snap
@@ -57,10 +57,6 @@ exports[`theme baseline — dark > CSS declaration block (snapshot) 1`] = `
   --klc-color-text-tertiary: hsl(210, 6%, 60%);
   --klc-color-text-weak: hsl(210, 5%, 45%);
   --klc-color-text-white: rgba(255, 255, 255, 0.95);
-  --klc-color-price-up-light: rgba(255, 80, 100, 0.85);
-  --klc-color-price-up-tick: hsl(0, 70%, 60%);
-  --klc-color-price-down-light: rgba(60, 200, 160, 0.85);
-  --klc-color-price-down-tick: hsl(150, 50%, 65%);
   --klc-color-price-last-price: rgba(230, 100, 115, 0.95);
   --klc-color-tag-bg-white: rgb(40, 40, 55);
   --klc-color-tag-bg-light-gray: rgba(50, 50, 65, 0.92);
@@ -254,11 +250,7 @@ exports[`theme baseline — light > CSS declaration block (snapshot) 1`] = `
   --klc-color-text-tertiary: hsl(210, 8%, 50%);
   --klc-color-text-weak: hsl(210, 7%, 65%);
   --klc-color-text-white: rgba(255, 255, 255, 0.92);
-  --klc-color-price-up-light: rgba(214, 10, 34, 0.92);
-  --klc-color-price-up-tick: hsl(0, 60%, 50%);
-  --klc-color-price-down-light: rgba(3, 123, 102, 0.92);
-  --klc-color-price-down-tick: hsl(150, 30%, 60%);
-  --klc-color-price-last-price: rgba(196, 74, 86, 0.95);
+  --klc-color-price-last-price: rgba(230, 100, 115, 0.95);
   --klc-color-tag-bg-white: rgb(255, 255, 255);
   --klc-color-tag-bg-light-gray: rgba(255, 255, 255, 0.92);
   --klc-color-tag-bg-pure-white: #ffffff;

--- a/packages/core/src/tokens/theme-china.ts
+++ b/packages/core/src/tokens/theme-china.ts
@@ -56,10 +56,6 @@ export function withAsiaMarketColors(theme: Theme): Theme {
             // ── Nested: price accents ──
             price: {
                 ...theme.colors.price,
-                upLight: theme.colors.price.downLight,
-                downLight: theme.colors.price.upLight,
-                upTick: theme.colors.price.downTick,
-                downTick: theme.colors.price.upTick,
             },
 
             // ── Nested: MACD histogram bars ──

--- a/packages/core/src/tokens/theme-dark.ts
+++ b/packages/core/src/tokens/theme-dark.ts
@@ -96,10 +96,6 @@ export const darkTheme: Theme = {
             white: 'rgba(255, 255, 255, 0.95)',
         },
         price: {
-            upLight: 'rgba(255, 80, 100, 0.85)',
-            upTick: 'hsl(0, 70%, 60%)',
-            downLight: 'rgba(60, 200, 160, 0.85)',
-            downTick: 'hsl(150, 50%, 65%)',
             lastPrice: 'rgba(230, 100, 115, 0.95)',
         },
         tagBg: {

--- a/packages/core/src/tokens/theme-light.ts
+++ b/packages/core/src/tokens/theme-light.ts
@@ -101,12 +101,8 @@ export const lightTheme: Theme = {
             weak: 'hsl(210, 7%, 65%)',
             white: 'rgba(255, 255, 255, 0.92)',
         },
-        price: {
-            upLight: 'rgba(214, 10, 34, 0.92)',
-            upTick: 'hsl(0, 60%, 50%)',
-            downLight: 'rgba(3, 123, 102, 0.92)',
-            downTick: 'hsl(150, 30%, 60%)',
-            lastPrice: 'rgba(196, 74, 86, 0.95)',
+price: {
+            lastPrice: 'rgba(230, 100, 115, 0.95)',
         },
         tagBg: {
             white: 'rgb(255, 255, 255)',

--- a/packages/core/src/tokens/types.ts
+++ b/packages/core/src/tokens/types.ts
@@ -85,10 +85,6 @@ export interface TextColors {
  * (candleUpBody / candleDownBody); this group covers extras.
  */
 export interface PriceColors {
-    readonly upLight: ColorValue
-    readonly upTick: ColorValue
-    readonly downLight: ColorValue
-    readonly downTick: ColorValue
     readonly lastPrice: ColorValue
 }
 

--- a/packages/core/src/types/price.ts
+++ b/packages/core/src/types/price.ts
@@ -1,6 +1,8 @@
 export interface KLineData {
   /* 时间戳（毫秒） */
   timestamp: number
+  /** 日期字符串（如 "2025-06-16"），用于跨品种精确匹配 */
+  date?: string
   /* 开盘价 */
   open: number
   /* 最高价 */

--- a/packages/vue/preview/vite.config.ts
+++ b/packages/vue/preview/vite.config.ts
@@ -26,6 +26,9 @@ function r(rest: string): string {
 
 export default defineConfig({
     root: fileURLToPath(new URL('.', import.meta.url)),
+    optimizeDeps: {
+        exclude: ['@363045841yyt/klinechart-core'],
+    },
     server: {
         host: '0.0.0.0',
     },

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -11,10 +11,8 @@
     >
       <span class="compare-chip__icon" aria-hidden="true">+</span>
       <span class="compare-chip__text">比较商品</span>
-      <span v-if="selected.length > 0" class="compare-chip__badge">
-        <span v-if="comparisonLoading" class="compare-chip__spinner" />
-        <span v-else>{{ selected.length }}</span>
-      </span>
+      <span v-if="comparisonLoading" class="compare-chip__spinner" />
+      <span v-if="selected.length > 0" class="compare-chip__badge">{{ selected.length }}</span>
     </button>
     <Transition name="symbol-popover">
       <div v-if="showPopup" class="compare-popover" role="dialog" aria-label="比较商品">
@@ -291,9 +289,9 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
 
 .compare-chip__spinner {
   display: inline-block;
-  width: 10px;
-  height: 10px;
-  border: 2px solid var(--klc-color-background);
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--klc-color-axis-text);
   border-top-color: transparent;
   border-radius: 50%;
   animation: compare-spin 0.6s linear infinite;

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -11,7 +11,10 @@
     >
       <span class="compare-chip__icon" aria-hidden="true">+</span>
       <span class="compare-chip__text">比较商品</span>
-      <span v-if="selected.length > 0" class="compare-chip__badge">{{ selected.length }}</span>
+      <span v-if="selected.length > 0" class="compare-chip__badge">
+        <span v-if="comparisonLoading" class="compare-chip__spinner" />
+        <span v-else>{{ selected.length }}</span>
+      </span>
     </button>
     <Transition name="symbol-popover">
       <div v-if="showPopup" class="compare-popover" role="dialog" aria-label="比较商品">
@@ -145,6 +148,7 @@ const props = withDefaults(defineProps<{
   symbols: SymbolItem[]
   selected?: string[]
   comparisonColors?: Map<string, string>
+  comparisonLoading?: boolean
 }>(), {
   selected: () => [],
 })
@@ -283,6 +287,20 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
   font-size: 10px;
   font-weight: 600;
   line-height: 1;
+}
+
+.compare-chip__spinner {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--klc-color-background);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: compare-spin 0.6s linear infinite;
+}
+
+@keyframes compare-spin {
+  to { transform: rotate(360deg); }
 }
 
 .compare-popover {

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -65,6 +65,10 @@
               :key="item.code"
               class="compare-selected__item"
             >
+              <span
+                class="compare-selected__color"
+                :style="{ background: comparisonColors?.get(item.code) ?? '#888' }"
+              />
               <span class="compare-selected__code">{{ item.code }}</span>
               <span class="compare-selected__desc">{{ item.description }}</span>
               <button
@@ -140,6 +144,7 @@ import type { SymbolItem } from './SymbolSelector.vue'
 const props = withDefaults(defineProps<{
   symbols: SymbolItem[]
   selected?: string[]
+  comparisonColors?: Map<string, string>
 }>(), {
   selected: () => [],
 })
@@ -404,6 +409,14 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
   background: var(--klc-color-grid-minor);
   font-size: 12px;
   line-height: 1.3;
+}
+
+.compare-selected__color {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .compare-selected__code {

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -6,6 +6,7 @@
       :symbol-loading="symbolLoading"
       :symbol-error="symbolError"
       :overlay-symbols="overlaySymbols"
+      :comparison-colors="comparisonColorsMap"
       @add-overlay-symbol="onAddOverlaySymbol"
       @remove-overlay-symbol="onRemoveOverlaySymbol"
       @k-line-level-change="onKLineLevelChange"

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -296,6 +296,7 @@ const viewWidth = ref(0)
 const paneRatios = ref<Record<string, number>>({})
 const selectedDrawingId = ref<string | null>(null)
 const drawings = ref<DrawingObject[]>([])
+const comparisonColorsMap = ref<Map<string, string>>(new Map())
 
 // 初始化 kWidth / kGap（与 Chart 引擎 zoom→物理值 转换一致）
 const initZoom = zoomLevel.value
@@ -983,6 +984,10 @@ function setupChartCallbacks(ctrl: ChartController): void {
     indicatorParams.value = nextParams
   })
 
+  const unsubscribeComparisonColors = ctrl.comparisonColors.subscribe(() => {
+    comparisonColorsMap.value = new Map(ctrl.comparisonColors.peek())
+  })
+
   onUnmounted(() => {
     unsubscribeViewport()
     unsubscribeData()
@@ -992,6 +997,7 @@ function setupChartCallbacks(ctrl: ChartController): void {
     unsubscribeTheme()
     unsubscribeIndicators()
     unsubscribeSubPanes()
+    unsubscribeComparisonColors()
     autoThemeMediaQuery?.removeEventListener('change', onSystemThemeChange)
   })
 }

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -7,6 +7,7 @@
       :symbol-error="symbolError"
       :overlay-symbols="overlaySymbols"
       :comparison-colors="comparisonColorsMap"
+      :comparison-loading="comparisonLoading"
       @add-overlay-symbol="onAddOverlaySymbol"
       @remove-overlay-symbol="onRemoveOverlaySymbol"
       @k-line-level-change="onKLineLevelChange"
@@ -298,6 +299,7 @@ const paneRatios = ref<Record<string, number>>({})
 const selectedDrawingId = ref<string | null>(null)
 const drawings = ref<DrawingObject[]>([])
 const comparisonColorsMap = ref<Map<string, string>>(new Map())
+const comparisonLoading = ref(false)
 
 // 初始化 kWidth / kGap（与 Chart 引擎 zoom→物理值 转换一致）
 const initZoom = zoomLevel.value
@@ -989,6 +991,10 @@ function setupChartCallbacks(ctrl: ChartController): void {
     comparisonColorsMap.value = new Map(ctrl.comparisonColors.peek())
   })
 
+  const unsubscribeComparisonLoading = ctrl.comparisonLoading.subscribe(() => {
+    comparisonLoading.value = ctrl.comparisonLoading.peek()
+  })
+
   onUnmounted(() => {
     unsubscribeViewport()
     unsubscribeData()
@@ -999,6 +1005,7 @@ function setupChartCallbacks(ctrl: ChartController): void {
     unsubscribeIndicators()
     unsubscribeSubPanes()
     unsubscribeComparisonColors()
+    unsubscribeComparisonLoading()
     autoThemeMediaQuery?.removeEventListener('change', onSystemThemeChange)
   })
 }

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -235,13 +235,13 @@ function onAddOverlaySymbol(item: SymbolItem) {
   overlaySymbolItems.value = [...overlaySymbolItems.value, item]
   overlaySymbols.value = overlaySymbolItems.value.map((symbol) => symbol.code)
   forcePercentAxis()
-  syncSymbolsToController()
+  controller.value?.addComparisonSymbol(toSymbolSpec(item))
 }
 
 function onRemoveOverlaySymbol(code: string) {
   overlaySymbolItems.value = overlaySymbolItems.value.filter((item) => item.code !== code)
   overlaySymbols.value = overlaySymbolItems.value.map((symbol) => symbol.code)
-  syncSymbolsToController()
+  controller.value?.removeComparisonSymbol(code)
 }
 
 function toSymbolSpec(item: SymbolItem): SymbolSpec {

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -12,6 +12,7 @@
       :symbols="symbolPool"
       :selected="overlaySymbols"
       :comparison-colors="comparisonColors"
+      :comparison-loading="comparisonLoading"
       @add="emit('addOverlaySymbol', $event)"
       @remove="emit('removeOverlaySymbol', $event)"
     />
@@ -49,6 +50,7 @@ const props = defineProps<{
   symbolError?: boolean
   overlaySymbols?: string[]
   comparisonColors?: Map<string, string>
+  comparisonLoading?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -11,6 +11,7 @@
     <CompareSymbolSelector
       :symbols="symbolPool"
       :selected="overlaySymbols"
+      :comparison-colors="comparisonColors"
       @add="emit('addOverlaySymbol', $event)"
       @remove="emit('removeOverlaySymbol', $event)"
     />
@@ -47,6 +48,7 @@ const props = defineProps<{
   symbolLoading?: boolean
   symbolError?: boolean
   overlaySymbols?: string[]
+  comparisonColors?: Map<string, string>
 }>()
 
 const emit = defineEmits<{


### PR DESCRIPTION
## 变更内容

### 功能
- **比较商品增量加载**:  循环处理比较缓冲，左滚加载历史数据（`dataBuffer.ts`、`chartDataManager.ts`）
- **批量并发请求**: 引入  回调， 协调批量请求，并发度 4，微任务合并（`dataBuffer.ts`、`chartDataManager.ts`）
- **比较商品主图图例**: 在  中绘制比较商品的圆点 + 名称 + 涨跌幅百分比行（`mainIndicatorLegend.ts`）
- **比较商品初始加载范围**: 新增 、 支持 ，比较商品初始化时与主商品数据范围对齐（`dataBuffer.ts`、`chartDataManager.ts`）

### 修复
- **轴类型被意外覆盖**:  只在 payload 包含 `axisType` 键时才应用，避免改  时重置 log/percent 轴（`chart.ts`）
- **比较图例涨跌色错位**: 改用  替代 ，修复 base dark theme 本身 upTick/downTick 方向与 candle 不一致导致的 Asia 市场下颜色反转（`mainIndicatorLegend.ts`）
- **fetcher 错误传播和重试**: / 将静默 `return []` 改为 `throw`， 加入 2 次指数退避重试（`dataBuffer.ts`、`tradingview.ts`、`baostock.ts`）
- **清理死代码**: 移除 （无消费方）（`types.ts`、`theme-dark.ts`、`theme-light.ts`、`theme-china.ts`）

### UI
- 比较商品标签增加圆点（标识线色）和加载 spinner（`CompareSymbolSelector.vue`、`KLineChart.vue`、`TopToolbar.vue`）

### 重构
- 提取  独立函数
- 提取 / 工具函数