### PR TITLE
refactor(data-fetchers): extract `@DataFetcher` decorator AOP for fetcher registration

### DIFF
--- a/packages/core/src/data-fetchers/__tests__/fetcherRegistry.test.ts
+++ b/packages/core/src/data-fetchers/__tests__/fetcherRegistry.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  DataFetcher,
+  getRegisteredFetcher,
+  fetcherSupportsPeriod,
+  clearRegisteredFetchersForTest,
+} from '../fetcherDefinitionRegistry'
+import { routerDataFetcher } from '../router'
+import type { DataFetcherFn } from '../types'
+import type { KLineData } from '../../controllers/types'
+
+const mockFetch = vi.fn<() => Promise<ReadonlyArray<KLineData>>>()
+
+const fetchFn: DataFetcherFn = async () => mockFetch()
+
+const defaultConfig = {
+  symbol: '000001',
+  startDate: '2024-01-01',
+  endDate: '2024-01-31',
+  period: 'daily',
+  adjust: 'none',
+}
+
+describe('DataFetcher registry', () => {
+  beforeEach(() => {
+    clearRegisteredFetchersForTest()
+  })
+
+  it('collects decorated fetcher definition with metadata', () => {
+    @DataFetcher({
+      name: 'test',
+      displayName: 'Test',
+      version: '1.0.0',
+      capabilities: ['daily', 'weekly'],
+    })
+    class TestFetcher {
+      static fetcher = fetchFn
+    }
+    void TestFetcher
+
+    const def = getRegisteredFetcher('test')
+    expect(def).toBeDefined()
+    expect(def!.name).toBe('test')
+    expect(def!.displayName).toBe('Test')
+    expect(def!.version).toBe('1.0.0')
+    expect(def!.capabilities).toEqual(['daily', 'weekly'])
+    expect(def!.fetcher).toBe(fetchFn)
+  })
+
+  it('fetcherSupportsPeriod returns true for exact match', () => {
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: ['daily', 'weekly'] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    expect(fetcherSupportsPeriod('test', 'daily')).toBe(true)
+    expect(fetcherSupportsPeriod('test', 'weekly')).toBe(true)
+  })
+
+  it('fetcherSupportsPeriod returns false for unsupported period', () => {
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: ['weekly'] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    expect(fetcherSupportsPeriod('test', 'daily')).toBe(false)
+    expect(fetcherSupportsPeriod('test', '5min')).toBe(false)
+  })
+
+  it('fetcherSupportsPeriod accepts wildcard * for any period', () => {
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: ['*'] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    expect(fetcherSupportsPeriod('test', 'daily')).toBe(true)
+    expect(fetcherSupportsPeriod('test', '5min')).toBe(true)
+    expect(fetcherSupportsPeriod('test', 'quarterly')).toBe(true)
+  })
+
+  it('fetcherSupportsPeriod returns false for empty capabilities', () => {
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: [] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    expect(fetcherSupportsPeriod('test', 'daily')).toBe(false)
+  })
+
+  it('fetcherSupportsPeriod returns false when capabilities not set', () => {
+    @DataFetcher({ name: 'test', displayName: 'Test' })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    expect(fetcherSupportsPeriod('test', 'daily')).toBe(false)
+  })
+
+  it('fetcherSupportsPeriod returns false for unknown source', () => {
+    expect(fetcherSupportsPeriod('nonexistent', 'daily')).toBe(false)
+  })
+
+  it('clearRegisteredFetchersForTest removes all definitions', () => {
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: ['daily'] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    expect(getRegisteredFetcher('test')).toBeDefined()
+    clearRegisteredFetchersForTest()
+    expect(getRegisteredFetcher('test')).toBeUndefined()
+  })
+})
+
+describe('routerDataFetcher capability check', () => {
+  beforeEach(() => {
+    clearRegisteredFetchersForTest()
+    mockFetch.mockReset()
+  })
+
+  it('passes through request when period is supported', async () => {
+    const data: KLineData[] = [{ timestamp: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 }]
+    mockFetch.mockResolvedValue(data)
+
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: ['daily'] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    const result = await routerDataFetcher('test', defaultConfig)
+    expect(result).toBe(data)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes through request when capabilities are wildcard', async () => {
+    const data: KLineData[] = [{ timestamp: 1000, open: 100, high: 110, low: 90, close: 105, volume: 1000 }]
+    mockFetch.mockResolvedValue(data)
+
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: ['*'] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    const result = await routerDataFetcher('test', { ...defaultConfig, period: '5min' })
+    expect(result).toBe(data)
+  })
+
+  it('throws when period is not in capabilities', async () => {
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: ['weekly'] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    await expect(
+      routerDataFetcher('test', defaultConfig),
+    ).rejects.toThrow(/does not support period/)
+  })
+
+  it('throws with error message listing supported capabilities', async () => {
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: ['weekly', 'monthly'] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    await expect(
+      routerDataFetcher('test', { ...defaultConfig, period: '5min' }),
+    ).rejects.toThrow(/weekly, monthly/)
+  })
+
+  it('throws when capabilities is empty array', async () => {
+    @DataFetcher({ name: 'test', displayName: 'Test', capabilities: [] })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    await expect(
+      routerDataFetcher('test', defaultConfig),
+    ).rejects.toThrow(/does not support period/)
+  })
+
+  it('throws when capabilities is not set', async () => {
+    @DataFetcher({ name: 'test', displayName: 'Test' })
+    class TestFetcher { static fetcher = fetchFn }
+    void TestFetcher
+
+    await expect(
+      routerDataFetcher('test', defaultConfig),
+    ).rejects.toThrow(/does not support period/)
+  })
+
+  it('falls back to registered baostock for unknown source', async () => {
+    const data: KLineData[] = [{ timestamp: 2000, open: 200, high: 210, low: 190, close: 205, volume: 2000 }]
+    const baostockFn = vi.fn<DataFetcherFn>().mockResolvedValue(data)
+
+    @DataFetcher({ name: 'baostock', displayName: 'BaoStock', capabilities: ['*'] })
+    class BaoStockStub { static fetcher = baostockFn }
+    void BaoStockStub
+
+    const result = await routerDataFetcher('nonexistent', defaultConfig)
+    expect(result).toBe(data)
+    expect(baostockFn).toHaveBeenCalledWith('nonexistent', expect.objectContaining({ period: 'daily' }))
+  })
+})

--- a/packages/core/src/data-fetchers/baostock.ts
+++ b/packages/core/src/data-fetchers/baostock.ts
@@ -1,34 +1,67 @@
-import type { DataFetcher, KLineData } from '../controllers/types'
+import type { KLineData } from '../controllers/types'
+import { DataFetcher } from './fetcherDefinitionRegistry'
+import type { FetchConfig } from './types'
 
-export const baostockDataFetcher: DataFetcher = async (source, config) => {
-  console.log(`[baostock] fetching ${config.symbol} ${config.period} ${config.startDate}~${config.endDate}`)
-  const baseUrl = source === 'baostock' ? 'http://localhost:8000' : ''
-  const adjustMap: Record<string, string> = { qfq: '2', hfq: '1', none: '3' }
-const periodMap: Record<string, string> = { daily: 'd', weekly: 'w', monthly: 'm', '5min': '5', '15min': '15', '30min': '30', '60min': '60' }
-  const adjustflag = adjustMap[config.adjust] ?? '3'
-  const url = `${baseUrl}/api/stock/kdata?stock_code=${config.symbol}&start_date=${config.startDate}&end_date=${config.endDate}&frequency=${periodMap[config.period] ?? 'd'}&adjustflag=${adjustflag}`
+const ADJUST_MAP: Record<string, string> = { qfq: '2', hfq: '1', none: '3' }
+
+const PERIOD_MAP: Record<string, string> = {
+  daily: 'd',
+  weekly: 'w',
+  monthly: 'm',
+  '5min': '5',
+  '15min': '15',
+  '30min': '30',
+  '60min': '60',
+}
+
+const BASE_URL = 'http://localhost:8000'
+
+async function fetchBaoStock(
+  _source: string,
+  config: FetchConfig,
+): Promise<ReadonlyArray<KLineData>> {
+  console.log(
+    `[baostock] fetching ${config.symbol} ${config.period} ${config.startDate}~${config.endDate}`,
+  )
+  const url = `${BASE_URL}/api/stock/kdata?stock_code=${config.symbol}&start_date=${config.startDate}&end_date=${config.endDate}&frequency=${PERIOD_MAP[config.period] ?? 'd'}&adjustflag=${ADJUST_MAP[config.adjust] ?? '3'}`
   try {
     const res = await fetch(url)
-    console.log(res)
     if (!res.ok) {
       throw new Error(`[baostock] fetch failed: ${res.status} ${res.statusText}`)
     }
     const json = await res.json()
-    console.log(json)
-    return (json.data ?? json).map((item: Record<string, unknown>) => ({
-      timestamp: new Date(item.date as string).getTime(),
-      date: item.date as string,
-      open: Number(item.open),
-      high: Number(item.high),
-      low: Number(item.low),
-      close: Number(item.close),
-      volume: Number(item.volume),
-      turnover: Number(item.amount ?? 0),
-      turnoverRate: item.turn === '' ? 0 : Number(item.turn),
-      stockCode: String(item.code ?? config.symbol),
-    })) as KLineData[]
+    return (json.data ?? json).map(
+      (item: Record<string, unknown>) =>
+        ({
+          timestamp: new Date(item.date as string).getTime(),
+          date: item.date as string,
+          open: Number(item.open),
+          high: Number(item.high),
+          low: Number(item.low),
+          close: Number(item.close),
+          volume: Number(item.volume),
+          turnover: Number(item.amount ?? 0),
+          turnoverRate: item.turn === '' ? 0 : Number(item.turn),
+          stockCode: String(item.code ?? config.symbol),
+        }) as KLineData,
+    )
   } catch (err) {
     console.warn('[baostock] network error:', err)
     throw err
   }
 }
+
+@DataFetcher({
+  name: 'baostock',
+  displayName: 'BaoStock',
+  description: 'BaoStock data source via local proxy',
+  version: '1.0.0',
+  priority: 20,
+  capabilities: ['daily', 'weekly', 'monthly', '5min', '15min', '30min', '60min'],
+})
+export class BaoStockFetcher {
+  static fetcher = fetchBaoStock
+}
+
+/** @deprecated Use `BaoStockFetcher.fetcher` directly or rely on routerDataFetcher. */
+export const baostockDataFetcher = fetchBaoStock

--- a/packages/core/src/data-fetchers/baostock.ts
+++ b/packages/core/src/data-fetchers/baostock.ts
@@ -56,7 +56,6 @@ async function fetchBaoStock(
   displayName: 'BaoStock',
   description: 'BaoStock data source via local proxy',
   version: '1.0.0',
-  priority: 20,
   capabilities: ['daily', 'weekly', 'monthly', '5min', '15min', '30min', '60min'],
 })
 export class BaoStockFetcher {

--- a/packages/core/src/data-fetchers/fetcherDefinitionRegistry.ts
+++ b/packages/core/src/data-fetchers/fetcherDefinitionRegistry.ts
@@ -1,0 +1,40 @@
+import type { DataFetcherDefinitionConfig, DataFetcherDefinition, DataFetcherFn } from './types'
+
+type DataFetcherClass = {
+  new(...args: never[]): unknown
+  fetcher: DataFetcherFn
+}
+
+const definitions = new Map<string, DataFetcherDefinition>()
+
+export function DataFetcher(config: DataFetcherDefinitionConfig) {
+  return function <T extends DataFetcherClass>(value: T, context: ClassDecoratorContext<T>): T {
+    context.addInitializer(function (this: T) {
+      if (typeof this.fetcher !== 'function') {
+        throw new Error(
+          `[DataFetcher] '${config.name}' definition must expose static fetcher`,
+        )
+      }
+      definitions.set(config.name, {
+        ...config,
+        priority: config.priority ?? 10,
+        fetcher: this.fetcher,
+      })
+    })
+    return value
+  }
+}
+
+export function getRegisteredFetcher(
+  name: string,
+): DataFetcherDefinition | undefined {
+  return definitions.get(name)
+}
+
+export function getRegisteredFetchers(): DataFetcherDefinition[] {
+  return Array.from(definitions.values())
+}
+
+export function clearRegisteredFetchersForTest(): void {
+  definitions.clear()
+}

--- a/packages/core/src/data-fetchers/fetcherDefinitionRegistry.ts
+++ b/packages/core/src/data-fetchers/fetcherDefinitionRegistry.ts
@@ -17,7 +17,6 @@ export function DataFetcher(config: DataFetcherDefinitionConfig) {
       }
       definitions.set(config.name, {
         ...config,
-        priority: config.priority ?? 10,
         fetcher: this.fetcher,
       })
     })
@@ -33,6 +32,17 @@ export function getRegisteredFetcher(
 
 export function getRegisteredFetchers(): DataFetcherDefinition[] {
   return Array.from(definitions.values())
+}
+
+export function fetcherHasCapability(name: string, capability: string): boolean {
+  return definitions.get(name)?.capabilities?.includes(capability) ?? false
+}
+
+export function fetcherSupportsPeriod(name: string, period: string): boolean {
+  const def = definitions.get(name)
+  if (!def) return false
+  if (!def.capabilities || def.capabilities.length === 0) return false
+  return def.capabilities.includes('*') || def.capabilities.includes(period)
 }
 
 export function clearRegisteredFetchersForTest(): void {

--- a/packages/core/src/data-fetchers/gotdx.ts
+++ b/packages/core/src/data-fetchers/gotdx.ts
@@ -147,7 +147,6 @@ async function fetchGotdx(
   displayName: 'GOTDX',
   description: 'TDX data source via local proxy',
   version: '1.0.0',
-  priority: 30,
   capabilities: [
     '1min', '5min', '15min', '30min', '60min',
     'daily', 'weekly', 'monthly', 'quarterly', 'yearly',

--- a/packages/core/src/data-fetchers/gotdx.ts
+++ b/packages/core/src/data-fetchers/gotdx.ts
@@ -1,4 +1,6 @@
-import type { DataFetcher, KLineData } from '../controllers/types'
+import type { KLineData } from '../controllers/types'
+import { DataFetcher } from './fetcherDefinitionRegistry'
+import type { FetchConfig } from './types'
 
 const PERIOD_TO_CATEGORY: Record<string, number> = {
   '1min': 8,
@@ -26,6 +28,8 @@ const EXCHANGE_EX_CATEGORY: Record<string, number> = {
   SG: 78,
   DE: 73,
 }
+
+const BASE_URL = 'http://127.0.0.1:8080'
 
 interface SecurityBar {
   Last: number
@@ -91,9 +95,10 @@ function mapExItem(item: ExKLineItem, code: string): KLineData {
   }
 }
 
-export const gotdxDataFetcher: DataFetcher = async (source, config) => {
-  const baseUrl = source === 'gotdx' ? 'http://127.0.0.1:8080' : ''
-
+async function fetchGotdx(
+  _source: string,
+  config: FetchConfig,
+): Promise<ReadonlyArray<KLineData>> {
   if (config.exchange && config.exchange in EXCHANGE_EX_CATEGORY) {
     const category = EXCHANGE_EX_CATEGORY[config.exchange]
     const period = PERIOD_TO_CATEGORY[config.period] ?? 4
@@ -105,7 +110,7 @@ export const gotdxDataFetcher: DataFetcher = async (source, config) => {
       end_date: config.endDate,
       times: 1,
     }
-    const res = await fetch(`${baseUrl}/api/ex/kline-by-date`, {
+    const res = await fetch(`${BASE_URL}/api/ex/kline-by-date`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -127,7 +132,7 @@ export const gotdxDataFetcher: DataFetcher = async (source, config) => {
     times: 1,
     adjust,
   }
-  const res = await fetch(`${baseUrl}/api/stock/kline-by-date`, {
+  const res = await fetch(`${BASE_URL}/api/stock/kline-by-date`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -136,3 +141,21 @@ export const gotdxDataFetcher: DataFetcher = async (source, config) => {
   const list: SecurityBar[] = await res.json()
   return list.map((item) => mapBar(item, config.symbol))
 }
+
+@DataFetcher({
+  name: 'gotdx',
+  displayName: 'GOTDX',
+  description: 'TDX data source via local proxy',
+  version: '1.0.0',
+  priority: 30,
+  capabilities: [
+    '1min', '5min', '15min', '30min', '60min',
+    'daily', 'weekly', 'monthly', 'quarterly', 'yearly',
+  ],
+})
+export class GotdxFetcher {
+  static fetcher = fetchGotdx
+}
+
+/** @deprecated Use `GotdxFetcher.fetcher` directly or rely on routerDataFetcher. */
+export const gotdxDataFetcher = fetchGotdx

--- a/packages/core/src/data-fetchers/hundred-mock.ts
+++ b/packages/core/src/data-fetchers/hundred-mock.ts
@@ -1,6 +1,11 @@
-import type { DataFetcher, KLineData } from '../controllers/types'
+import type { KLineData } from '../controllers/types'
+import { DataFetcher } from './fetcherDefinitionRegistry'
+import type { FetchConfig } from './types'
 
-export const hundredMockDataFetcher: DataFetcher = async (_source, config) => {
+async function fetchHundredMock(
+  _source: string,
+  config: FetchConfig,
+): Promise<ReadonlyArray<KLineData>> {
   console.log(`[hundred-mock] generating ${config.symbol} ${config.period}`)
   const start = new Date(config.startDate).getTime()
   const end = new Date(config.endDate).getTime()
@@ -25,7 +30,6 @@ export const hundredMockDataFetcher: DataFetcher = async (_source, config) => {
 
   const meanReversionStrength = 0.005
 
-  // raw random walk with mean reversion (close prices before bridge)
   const rawWalk: number[] = [basePrice]
   for (let i = 1; i < totalDays; i++) {
     const prev = rawWalk[i - 1]!
@@ -34,7 +38,6 @@ export const hundredMockDataFetcher: DataFetcher = async (_source, config) => {
     rawWalk.push(prev + change)
   }
 
-  // Brownian bridge: subtract linear drift so last close = basePrice
   const finalOffset = rawWalk[totalDays - 1]! - basePrice
   for (let i = 0; i < totalDays; i++) {
     const bridge = finalOffset * (i / (totalDays - 1))
@@ -59,3 +62,18 @@ export const hundredMockDataFetcher: DataFetcher = async (_source, config) => {
 
   return data
 }
+
+@DataFetcher({
+  name: 'mock-100',
+  displayName: 'Mock 100',
+  description: 'Generates ~100 random K-line bars with Brownian bridge',
+  version: '1.0.0',
+  priority: 1,
+  capabilities: ['mock'],
+})
+export class HundredMockFetcher {
+  static fetcher = fetchHundredMock
+}
+
+/** @deprecated Use `HundredMockFetcher.fetcher` directly or rely on routerDataFetcher. */
+export const hundredMockDataFetcher = fetchHundredMock

--- a/packages/core/src/data-fetchers/hundred-mock.ts
+++ b/packages/core/src/data-fetchers/hundred-mock.ts
@@ -68,8 +68,7 @@ async function fetchHundredMock(
   displayName: 'Mock 100',
   description: 'Generates ~100 random K-line bars with Brownian bridge',
   version: '1.0.0',
-  priority: 1,
-  capabilities: ['mock'],
+  capabilities: ['*'],
 })
 export class HundredMockFetcher {
   static fetcher = fetchHundredMock

--- a/packages/core/src/data-fetchers/index.ts
+++ b/packages/core/src/data-fetchers/index.ts
@@ -1,8 +1,20 @@
-export { thousandMockDataFetcher } from './thousand-mock'
-export { hundredMockDataFetcher } from './hundred-mock'
-export { baostockDataFetcher } from './baostock'
-export { tradingviewDataFetcher } from './tradingview'
-export { gotdxDataFetcher } from './gotdx'
+export { HundredMockFetcher, hundredMockDataFetcher } from './hundred-mock'
+export { ThousandMockFetcher, thousandMockDataFetcher } from './thousand-mock'
+export { BaoStockFetcher, baostockDataFetcher } from './baostock'
+export { TradingviewFetcher, tradingviewDataFetcher } from './tradingview'
+export { GotdxFetcher, gotdxDataFetcher } from './gotdx'
 export { routerDataFetcher } from './router'
 export { DataBuffer } from './dataBuffer'
 export type { DataWindow } from './dataBuffer'
+export {
+  DataFetcher,
+  getRegisteredFetcher,
+  getRegisteredFetchers,
+  clearRegisteredFetchersForTest,
+} from './fetcherDefinitionRegistry'
+export type {
+  FetchConfig,
+  DataFetcherDefinitionConfig,
+  DataFetcherDefinition,
+  DataFetcherFn,
+} from './types'

--- a/packages/core/src/data-fetchers/index.ts
+++ b/packages/core/src/data-fetchers/index.ts
@@ -10,6 +10,8 @@ export {
   DataFetcher,
   getRegisteredFetcher,
   getRegisteredFetchers,
+  fetcherHasCapability,
+  fetcherSupportsPeriod,
   clearRegisteredFetchersForTest,
 } from './fetcherDefinitionRegistry'
 export type {

--- a/packages/core/src/data-fetchers/router.ts
+++ b/packages/core/src/data-fetchers/router.ts
@@ -1,5 +1,5 @@
 import type { DataFetcher } from '../controllers/types'
-import { getRegisteredFetcher } from './fetcherDefinitionRegistry'
+import { getRegisteredFetcher, fetcherSupportsPeriod } from './fetcherDefinitionRegistry'
 
 const FALLBACK_SOURCE = 'baostock'
 
@@ -19,5 +19,14 @@ export const routerDataFetcher: DataFetcher = (source, config) => {
     }
     return fallback.fetcher(source, config)
   }
+
+  if (!fetcherSupportsPeriod(source, config.period)) {
+    return Promise.reject(
+      new Error(
+        `[DataFetcher] "${source}" does not support period "${config.period}". Supported: ${def.capabilities?.join(', ') ?? 'none'}`,
+      ),
+    )
+  }
+
   return def.fetcher(source, config)
 }

--- a/packages/core/src/data-fetchers/router.ts
+++ b/packages/core/src/data-fetchers/router.ts
@@ -1,23 +1,23 @@
 import type { DataFetcher } from '../controllers/types'
-import { baostockDataFetcher } from './baostock'
-import { gotdxDataFetcher } from './gotdx'
-import { hundredMockDataFetcher } from './hundred-mock'
-import { thousandMockDataFetcher } from './thousand-mock'
-import { tradingviewDataFetcher } from './tradingview'
+import { getRegisteredFetcher } from './fetcherDefinitionRegistry'
+
+const FALLBACK_SOURCE = 'baostock'
 
 export const routerDataFetcher: DataFetcher = (source, config) => {
-  switch (source) {
-    case 'baostock':
-      return baostockDataFetcher(source, config)
-    case 'gotdx':
-      return gotdxDataFetcher(source, config)
-    case 'tradingview':
-      return tradingviewDataFetcher(source, config)
-    case 'mock-100':
-      return hundredMockDataFetcher(source, config)
-    case 'mock-10000':
-      return thousandMockDataFetcher(source, config)
-    default:
-      return hundredMockDataFetcher(source, config)
+  const def = getRegisteredFetcher(source)
+  if (!def) {
+    console.warn(
+      `[DataFetcher] unknown source "${source}", falling back to "${FALLBACK_SOURCE}"`,
+    )
+    const fallback = getRegisteredFetcher(FALLBACK_SOURCE)
+    if (!fallback) {
+      return Promise.reject(
+        new Error(
+          `[DataFetcher] no fetcher registered for "${source}" and no fallback available`,
+        ),
+      )
+    }
+    return fallback.fetcher(source, config)
   }
+  return def.fetcher(source, config)
 }

--- a/packages/core/src/data-fetchers/thousand-mock.ts
+++ b/packages/core/src/data-fetchers/thousand-mock.ts
@@ -53,8 +53,7 @@ async function fetchThousandMock(
   displayName: 'Mock 10000',
   description: 'Generates ~10,000 random K-line bars with Brownian bridge',
   version: '1.0.0',
-  priority: 1,
-  capabilities: ['mock'],
+  capabilities: ['*'],
 })
 export class ThousandMockFetcher {
   static fetcher = fetchThousandMock

--- a/packages/core/src/data-fetchers/thousand-mock.ts
+++ b/packages/core/src/data-fetchers/thousand-mock.ts
@@ -1,6 +1,11 @@
-import type { DataFetcher, KLineData } from '../controllers/types'
+import type { KLineData } from '../controllers/types'
+import { DataFetcher } from './fetcherDefinitionRegistry'
+import type { FetchConfig } from './types'
 
-export const thousandMockDataFetcher: DataFetcher = async (_source, _config) => {
+async function fetchThousandMock(
+  _source: string,
+  _config: FetchConfig,
+): Promise<ReadonlyArray<KLineData>> {
   console.log('[thousand-mock] generating 10k K-lines')
   const data: KLineData[] = []
   const startTime = new Date('2020-01-01').getTime()
@@ -11,7 +16,6 @@ export const thousandMockDataFetcher: DataFetcher = async (_source, _config) => 
   const meanReversionStrength = 0.0005
   const volatility = 0.02
 
-  // raw random walk with mean reversion (close prices before bridge)
   const rawWalk: number[] = [basePrice]
   for (let i = 1; i < totalDays; i++) {
     const prev = rawWalk[i - 1]!
@@ -20,7 +24,6 @@ export const thousandMockDataFetcher: DataFetcher = async (_source, _config) => 
     rawWalk.push(prev + change)
   }
 
-  // Brownian bridge: subtract linear drift so last close = basePrice
   const finalOffset = rawWalk[totalDays - 1]! - basePrice
   for (let i = 0; i < totalDays; i++) {
     const bridge = finalOffset * (i / (totalDays - 1))
@@ -44,3 +47,18 @@ export const thousandMockDataFetcher: DataFetcher = async (_source, _config) => 
 
   return data
 }
+
+@DataFetcher({
+  name: 'mock-10000',
+  displayName: 'Mock 10000',
+  description: 'Generates ~10,000 random K-line bars with Brownian bridge',
+  version: '1.0.0',
+  priority: 1,
+  capabilities: ['mock'],
+})
+export class ThousandMockFetcher {
+  static fetcher = fetchThousandMock
+}
+
+/** @deprecated Use `ThousandMockFetcher.fetcher` directly or rely on routerDataFetcher. */
+export const thousandMockDataFetcher = fetchThousandMock

--- a/packages/core/src/data-fetchers/tradingview.ts
+++ b/packages/core/src/data-fetchers/tradingview.ts
@@ -1,4 +1,6 @@
-import type { DataFetcher, KLineData } from '../controllers/types'
+import type { KLineData } from '../controllers/types'
+import { DataFetcher } from './fetcherDefinitionRegistry'
+import type { FetchConfig } from './types'
 
 const PERIOD_TO_TIMEFRAME: Record<string, string> = {
   daily: '1d',
@@ -10,21 +12,25 @@ const PERIOD_TO_TIMEFRAME: Record<string, string> = {
   '60min': '60m',
 }
 
-export const tradingviewDataFetcher: DataFetcher = async (source, config) => {
-  const baseUrl = source === 'tradingview' ? 'http://localhost:8000' : ''
+const ADJUST_TO_TV: Record<string, string | undefined> = {
+  qfq: 'dividends',
+  splits: 'splits',
+  none: 'none',
+}
+
+const BASE_URL = 'http://localhost:8000'
+
+async function fetchTradingview(
+  _source: string,
+  config: FetchConfig,
+): Promise<ReadonlyArray<KLineData>> {
   const timeframe = PERIOD_TO_TIMEFRAME[config.period] ?? '1d'
   const startDate = config.startDate.split('T')[0]
   const endDate = config.endDate.split('T')[0]
-
-  const ADJUST_TO_TV: Record<string, string | undefined> = {
-    qfq: 'dividends',
-    splits: 'splits',
-    none: 'none',
-  }
   const tvAdjust = ADJUST_TO_TV[config.adjust]
   const exchangeQ = config.exchange ? `&exchange=${config.exchange}` : ''
   const adjustQ = tvAdjust ? `&adjust=${tvAdjust}` : ''
-  const url = `${baseUrl}/api/tradingview/kdata?symbol=${config.symbol}&timeframe=${timeframe}&start_date=${startDate}&end_date=${endDate}${exchangeQ}${adjustQ}`
+  const url = `${BASE_URL}/api/tradingview/kdata?symbol=${config.symbol}&timeframe=${timeframe}&start_date=${startDate}&end_date=${endDate}${exchangeQ}${adjustQ}`
   try {
     const res = await fetch(url)
     if (!res.ok) {
@@ -37,7 +43,6 @@ export const tradingviewDataFetcher: DataFetcher = async (source, config) => {
     if (json.warning) {
       console.warn(`[tradingview] ${json.warning}`)
     }
-
     return (json.data ?? []).map((item: Record<string, unknown>) => ({
       timestamp: item.ts_open as number,
       date: item.date as string,
@@ -53,3 +58,18 @@ export const tradingviewDataFetcher: DataFetcher = async (source, config) => {
     throw err
   }
 }
+
+@DataFetcher({
+  name: 'tradingview',
+  displayName: 'TradingView',
+  description: 'TradingView-style data source via local proxy',
+  version: '1.0.0',
+  priority: 40,
+  capabilities: ['daily', 'weekly', 'monthly', '5min', '15min', '30min', '60min'],
+})
+export class TradingviewFetcher {
+  static fetcher = fetchTradingview
+}
+
+/** @deprecated Use `TradingviewFetcher.fetcher` directly or rely on routerDataFetcher. */
+export const tradingviewDataFetcher = fetchTradingview

--- a/packages/core/src/data-fetchers/tradingview.ts
+++ b/packages/core/src/data-fetchers/tradingview.ts
@@ -64,7 +64,6 @@ async function fetchTradingview(
   displayName: 'TradingView',
   description: 'TradingView-style data source via local proxy',
   version: '1.0.0',
-  priority: 40,
   capabilities: ['daily', 'weekly', 'monthly', '5min', '15min', '30min', '60min'],
 })
 export class TradingviewFetcher {

--- a/packages/core/src/data-fetchers/types.ts
+++ b/packages/core/src/data-fetchers/types.ts
@@ -19,7 +19,6 @@ export interface DataFetcherDefinitionConfig {
   displayName: string
   description?: string
   version?: string
-  priority?: number
   capabilities?: string[]
 }
 

--- a/packages/core/src/data-fetchers/types.ts
+++ b/packages/core/src/data-fetchers/types.ts
@@ -1,0 +1,28 @@
+import type { KLineData } from '../controllers/types'
+
+export type FetchConfig = {
+  symbol: string
+  startDate: string
+  endDate: string
+  period: string
+  adjust: string
+  exchange?: string
+}
+
+export type DataFetcherFn = (
+  source: string,
+  config: FetchConfig,
+) => Promise<ReadonlyArray<KLineData>>
+
+export interface DataFetcherDefinitionConfig {
+  name: string
+  displayName: string
+  description?: string
+  version?: string
+  priority?: number
+  capabilities?: string[]
+}
+
+export interface DataFetcherDefinition extends DataFetcherDefinitionConfig {
+  fetcher: DataFetcherFn
+}


### PR DESCRIPTION
## Summary

Extract a decorator-based AOP layer for data fetchers, mirroring the existing @Indicator pattern used by renderers. Replaces ad-hoc standalone functions with declarative metadata annotations.

## Changes

- `types.ts`: shared `FetchConfig`, `DataFetcherDefinitionConfig`, `DataFetcherDefinition` types
- `fetcherDefinitionRegistry.ts`: `@DataFetcher` decorator + `getRegisteredFetcher`/`fetcherSupportsPeriod`
- 5 fetchers: refactored to `@DataFetcher` class + static `fetcher`; removed hardcoded source->baseUrl inference
- `router.ts`: `switch-case` replaced with `getRegisteredFetcher()` + capability guard
- `dataBuffer.ts` / consumers: zero modifications -- backward compatible via `xxxDataFetcher` aliases

## Capability Guard

`routerDataFetcher` now rejects unsupported periods with `Promise.reject` before dispatching. Fetchers declare `capabilities` (period names) or `['*']` (wildcard) in the decorator.

## Testing

`fetcherRegistry.test.ts` (15 test cases) covers registry metadata, `fetcherSupportsPeriod` (exact match / wildcard / empty / missing / unknown), router pass-through, rejection, and fallback.