### PR TITLE
feat(range-select): range selection tool with batch CSV export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ pnpm stockbao
 - **Controller factory injection**: Vue package uses `__setControllerFactory(createChartController)` at import time. Tests override via `__setControllerFactory(null/mock)` in setup.
 - **Generated files**: `components.d.ts` (by `unplugin-vue-components` + `unplugin-icons`) — regenerated on dev server start.
 - **`vue-tsc` for type-checking**: not `tsc`. Runs against `tsconfig.app.json`.
+- **Vue SFC composable extraction**: always extract logic into composables (`useXxx`); avoid coupling logic inside `<script setup>` blocks.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 ## Committing
 
 - **Must use commit-message-generator skill**: When committing, always load the skill at `.claude/skills/commit/SKILL.md` via `skill("commit-message-generator")` to generate conventional commit messages.
+- **PR descriptions should cover the entire branch**: When creating a PR, describe the full scope of changes across all commits in the branch, not just the latest commit.
 
 ## Monorepo
 

--- a/packages/core/src/config/chartSettings.ts
+++ b/packages/core/src/config/chartSettings.ts
@@ -50,19 +50,23 @@ const ENABLE_WEBGL_DEFAULT = getDeviceType() === 'desktop'
 export const DEFAULT_SETTINGS = [
   { key: 'showGridLines', label: '显示网格', type: 'boolean', default: true, group: 'main' },
   { key: 'showVolumePriceMarkers', label: '显示量价关系标记', type: 'boolean', default: false, group: 'main' },
-  { key: 'axisType', label: '轴类型', type: 'select', default: 'linear', group: 'main', options: [
-    { value: 'linear', label: '常规轴' },
-    { value: 'log', label: '对数轴' },
-    { value: 'percent', label: '百分比轴' },
-  ] },
+  {
+    key: 'axisType', label: '轴类型', type: 'select', default: 'linear', group: 'main', options: [
+      { value: 'linear', label: '常规轴' },
+      { value: 'log', label: '对数轴' },
+      { value: 'percent', label: '百分比轴' },
+    ]
+  },
   { key: 'disableMainPaneVerticalScroll', label: '主图纵轴刻度自适应调整', type: 'boolean', default: true, group: 'main' },
   { key: 'isAsiaMarket', label: '亚洲市场颜色（红涨绿跌）', type: 'boolean', default: false, group: 'style' },
   { key: 'enableWebGLRendering', label: '启用 WebGL 硬件加速渲染', type: 'boolean', default: ENABLE_WEBGL_DEFAULT, group: 'main' },
-  { key: 'theme', label: '主题', type: 'select', default: 'light', group: 'main', options: [
-    { value: 'light', label: '浅色' },
-    { value: 'dark', label: '深色' },
-    { value: 'auto', label: '跟随系统' },
-  ] },
+  {
+    key: 'theme', label: '主题', type: 'select', default: 'dark', group: 'main', options: [
+      { value: 'light', label: '浅色' },
+      { value: 'dark', label: '深色' },
+      { value: 'auto', label: '跟随系统' },
+    ]
+  },
   { key: 'enableCanvasProfiler', label: 'Canvas 性能分析插桩', type: 'boolean', default: false, group: 'experimental' },
 ] as const
 

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -535,6 +535,14 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
         chart.setDataFetcher(fetcher)
     }
 
+    function ensureDataRange(startTs: number): void {
+        if (disposed) return
+        const buf = chart.dataBuffer
+        const win = buf.loadedWindow
+        if (!win || startTs >= win.earliestTs) return
+        buf.ensureRange(startTs, win.earliestTs)
+    }
+
     function appendData(next: ReadonlyArray<KLineData>): void {
         if (disposed) return
         const current = data.peek()
@@ -852,6 +860,7 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
         addComparisonSymbol,
         removeComparisonSymbol,
         setDataFetcher,
+        ensureDataRange,
         setData,
         appendData,
         updateData: setData,

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -268,6 +268,8 @@ export interface ChartController extends DrawingChartAdapter {
     updateData(next: ReadonlyArray<KLineData>): void
     getData(): ReadonlyArray<KLineData>
     getZoomLevelCount(): number
+    /** Request data for dates earlier than the currently loaded window */
+    ensureDataRange(startTs: number): void
 
     // ---- Theme ----
     setTheme(theme: 'light' | 'dark'): void

--- a/packages/core/src/data-fetchers/__tests__/dataBuffer.test.ts
+++ b/packages/core/src/data-fetchers/__tests__/dataBuffer.test.ts
@@ -190,7 +190,7 @@ describe('DataBuffer', () => {
         })
 
         buffer.ensureRange(oneYearAgo - 30 * MS_PER_DAY, oneYearAgo)
-        buffer.ensureRange(oneYearAgo - 60 * MS_PER_DAY, oneYearAgo)
+        buffer.ensureRange(oneYearAgo - 120 * MS_PER_DAY, oneYearAgo)
 
         await vi.waitFor(() => {
             expect(buffer.loading()).toBe(false)

--- a/packages/core/src/data-fetchers/dataBuffer.ts
+++ b/packages/core/src/data-fetchers/dataBuffer.ts
@@ -97,15 +97,12 @@ export class DataBuffer {
 
         if (requestStartTs >= this._loadedWindow.earliestTs) return
 
-        const incrementalStart = requestStartTs - INCREMENTAL_LOAD_DAYS * MS_PER_DAY
         const incrementalEnd = this._loadedWindow.earliestTs
-
-        if (incrementalEnd <= incrementalStart) return
 
         if (this._attemptedBoundaries.has(incrementalEnd)) return
 
         this._attemptedBoundaries.add(incrementalEnd)
-        this.fetchRange(incrementalStart, incrementalEnd)
+        this.fetchRange(requestStartTs, incrementalEnd)
     }
 
     private loadInitial(): void {

--- a/packages/core/src/data-fetchers/gotdx.ts
+++ b/packages/core/src/data-fetchers/gotdx.ts
@@ -42,6 +42,7 @@ interface SecurityBar {
   Turnover: number
   RisePrice: number
   RiseRate: number
+  Amplitude: number
   Year: number
   Month: number
   Day: number
@@ -76,6 +77,7 @@ function mapBar(item: SecurityBar, code: string): KLineData {
     turnoverRate: item.Turnover,
     changeAmount: item.RisePrice,
     changePercent: item.RiseRate,
+    amplitude: item.Amplitude,
     stockCode: code,
   }
 }

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -348,7 +348,7 @@ export class ChartDataManager {
     let firstVisibleTs: number | undefined
 
     if (range.start < 0 && this._dataFetcher) {
-      const earlierThanEarliest = window.earliestTs - 90 * MS_PER_DAY
+      const earlierThanEarliest = window.earliestTs - 365 * MS_PER_DAY
       this._dataBuffer.ensureRange(earlierThanEarliest, window.earliestTs)
       firstVisibleTs = this._internalData[0]?.timestamp
     } else if (range.start < this._internalData.length) {

--- a/packages/vue/src/components/BatchStockDialog.vue
+++ b/packages/vue/src/components/BatchStockDialog.vue
@@ -1,0 +1,293 @@
+<template>
+  <Teleport :to="teleportTarget">
+    <Transition name="overlay">
+      <div v-if="show" class="batch-overlay" @click="emit('close')">
+        <Transition name="modal">
+          <div class="batch-modal" @click.stop>
+            <div class="batch-header">
+              <span class="batch-title">批量设置股票代码</span>
+              <button class="batch-close-btn" @click="emit('close')">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            <div class="batch-body">
+              <textarea
+                v-model="codesText"
+                class="batch-textarea"
+                placeholder="每行一个股票代码&#10;例如:&#10;000001&#10;600036&#10;002415"
+                rows="8"
+                spellcheck="false"
+              />
+            </div>
+
+            <div class="batch-footer">
+              <button class="batch-btn batch-btn--cancel" @click="emit('close')">取消</button>
+              <button class="batch-btn batch-btn--confirm" @click="onApply">应用</button>
+            </div>
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+
+const props = defineProps<{
+  show: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  apply: [codes: string[]]
+}>()
+
+const teleportTarget = useFullscreenTeleportTarget()
+
+const codes = ref<string[]>([])
+
+const codesText = computed({
+  get: () => codes.value.join('\n'),
+  set: (val: string) => {
+    codes.value = val
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  },
+})
+
+function onApply() {
+  if (codes.value.length === 0) return
+  emit('apply', codes.value)
+  emit('close')
+}
+</script>
+
+<style scoped>
+.batch-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(4px);
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.batch-modal {
+  background: var(--klc-color-tag-bg-white);
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 10px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.15);
+  min-width: 360px;
+  max-width: 400px;
+  width: min(92vw, 400px);
+  max-height: min(600px, calc(100vh - 48px));
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.batch-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px 14px 20px;
+  background: var(--klc-color-background);
+  border-bottom: 1px solid var(--klc-color-grid-major);
+  flex-shrink: 0;
+}
+
+.batch-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--klc-color-foreground);
+  line-height: 1.35;
+}
+
+.batch-close-btn {
+  background: var(--klc-color-tag-bg-white);
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 7px;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--klc-color-axis-text);
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+  padding: 0;
+}
+
+.batch-close-btn:hover {
+  background: var(--klc-color-tag-bg-hover);
+  color: var(--klc-color-foreground);
+  border-color: var(--klc-color-axis-line);
+}
+
+.batch-close-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.batch-body {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.batch-textarea {
+  width: 100%;
+  min-height: 160px;
+  padding: 10px 12px;
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 6px;
+  background: var(--klc-color-background);
+  color: var(--klc-color-foreground);
+  font-size: 13px;
+  font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+
+.batch-textarea:focus {
+  border-color: var(--klc-color-axis-text);
+}
+
+.batch-textarea::placeholder {
+  color: var(--klc-color-axis-text);
+  opacity: 0.5;
+}
+
+.batch-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  background: var(--klc-color-background);
+  border-top: 1px solid var(--klc-color-grid-major);
+  flex-shrink: 0;
+}
+
+.batch-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 68px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s,
+    box-shadow 0.15s,
+    transform 0.15s;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.batch-btn--cancel {
+  background: transparent;
+  border-color: var(--klc-color-axis-line);
+  color: var(--klc-color-axis-text);
+}
+
+.batch-btn--cancel:hover {
+  background: var(--klc-color-tag-bg-hover);
+  color: var(--klc-color-foreground);
+  border-color: var(--klc-color-axis-text);
+}
+
+.batch-btn--confirm {
+  background: var(--klc-color-foreground);
+  border-color: var(--klc-color-foreground);
+  color: var(--klc-color-background);
+}
+
+.batch-btn--confirm:hover {
+  background: var(--klc-color-foreground);
+  border-color: var(--klc-color-foreground);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+  transform: translateY(-1px);
+}
+
+.batch-btn--confirm:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.overlay-enter-active,
+.overlay-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.overlay-enter-from,
+.overlay-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active {
+  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.modal-leave-active {
+  transition: all 0.16s ease-in;
+}
+
+.modal-enter-from {
+  opacity: 0;
+  transform: scale(0.96) translateY(-10px);
+}
+
+.modal-leave-to {
+  opacity: 0;
+  transform: scale(0.98) translateY(8px);
+}
+
+@media (max-width: 480px) {
+  .batch-overlay {
+    padding: 12px;
+    align-items: flex-end;
+  }
+
+  .batch-modal {
+    min-width: 0;
+    width: 100%;
+    max-height: calc(100vh - 24px);
+    border-radius: 10px;
+  }
+
+  .batch-header,
+  .batch-body,
+  .batch-footer {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .batch-footer {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+}
+</style>

--- a/packages/vue/src/components/ExportProgressDialog.vue
+++ b/packages/vue/src/components/ExportProgressDialog.vue
@@ -1,0 +1,226 @@
+<template>
+  <Teleport :to="teleportTarget">
+    <Transition name="overlay">
+      <div v-if="progress" class="export-overlay">
+        <Transition name="modal">
+          <div class="export-modal" @click.stop>
+            <div class="export-header">
+              <span class="export-title">导出数据</span>
+              <button class="export-close-btn" @click="emit('close')">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div class="export-body">
+              <div class="export-label">{{ progress.label }}</div>
+              <div class="export-bar-track">
+                <div
+                  class="export-bar-fill"
+                  :style="{ width: pct + '%' }"
+                />
+              </div>
+              <div class="export-counter">{{ progress.current }} / {{ progress.total }}</div>
+              <button
+                v-if="progress.current === progress.total"
+                class="export-done-btn"
+                @click="emit('close')"
+              >完成</button>
+            </div>
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+
+const props = defineProps<{
+  progress: { current: number; total: number; label: string } | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const teleportTarget = useFullscreenTeleportTarget()
+
+const pct = computed(() => {
+  if (!props.progress || props.progress.total <= 0) return 0
+  return Math.min(100, Math.round((props.progress.current / props.progress.total) * 100))
+})
+</script>
+
+<style scoped>
+.export-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(4px);
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.export-modal {
+  background: var(--klc-color-tag-bg-white);
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 10px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.15);
+  min-width: 320px;
+  max-width: 380px;
+  width: min(88vw, 380px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.export-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px 0 20px;
+}
+
+.export-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--klc-color-foreground);
+  line-height: 1.35;
+}
+
+.export-close-btn {
+  background: var(--klc-color-tag-bg-white);
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 7px;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--klc-color-axis-text);
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+  padding: 0;
+}
+
+.export-close-btn:hover {
+  background: var(--klc-color-tag-bg-hover);
+  color: var(--klc-color-foreground);
+  border-color: var(--klc-color-axis-line);
+}
+
+.export-close-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.export-body {
+  padding: 16px 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.export-label {
+  font-size: 13px;
+  color: var(--klc-color-axis-text);
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.export-bar-track {
+  width: 100%;
+  height: 6px;
+  background: var(--klc-color-grid-major);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.export-bar-fill {
+  height: 100%;
+  background: var(--klc-color-foreground);
+  border-radius: 999px;
+  transition: width 0.25s ease;
+}
+
+.export-counter {
+  font-size: 12px;
+  color: var(--klc-color-axis-text);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.export-done-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 20px;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: var(--klc-color-foreground);
+  border-color: var(--klc-color-foreground);
+  color: var(--klc-color-background);
+  align-self: center;
+  transition:
+    background 0.15s,
+    box-shadow 0.15s,
+    transform 0.15s;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.export-done-btn:hover {
+  background: var(--klc-color-foreground);
+  border-color: var(--klc-color-foreground);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+  transform: translateY(-1px);
+}
+
+.export-done-btn:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.overlay-enter-active,
+.overlay-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.overlay-enter-from,
+.overlay-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active {
+  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.modal-leave-active {
+  transition: all 0.16s ease-in;
+}
+
+.modal-enter-from {
+  opacity: 0;
+  transform: scale(0.96) translateY(-10px);
+}
+
+.modal-leave-to {
+  opacity: 0;
+  transform: scale(0.98) translateY(8px);
+}
+</style>

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -87,10 +87,30 @@
                 <button
                   type="button"
                   class="toolbar-btn"
+                  title="批量设置"
+                  @click.stop="showBatchStockDialog = true"
+                >
+                  批量设置
+                </button>
+                <button
+                  type="button"
+                  class="toolbar-btn"
                   title="导出"
                   @click.stop="exportRangeToCsv"
                 >
                   导出
+                </button>
+                <button
+                  type="button"
+                  class="toolbar-btn delete-btn"
+                  title="删除选区"
+                  @click.stop="clearRangeSelection"
+                >
+                  <svg class="delete-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M3 6h18" />
+                    <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                    <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                  </svg>
                 </button>
               </div>
             </div>
@@ -165,6 +185,12 @@
         ></div>
       </div>
     </div>
+    <ExportProgressDialog :progress="exportingProgress" @close="exportingProgress = null" />
+    <BatchStockDialog
+      :show="showBatchStockDialog"
+      @close="showBatchStockDialog = false"
+      @apply="onBatchApply"
+    />
     <IndicatorSelector
       ref="indicatorSelectorRef"
       :active-indicators="activeIndicators"
@@ -203,6 +229,8 @@ import { SETTINGS_STORAGE_KEY } from '@363045841yyt/klinechart-core/config'
 import { useRangeSelection } from '../composables/chart/useRangeSelection'
 import LeftToolbar from './LeftToolbar.vue'
 import TopToolbar, { type SymbolItem } from './TopToolbar.vue'
+import BatchStockDialog from './BatchStockDialog.vue'
+import ExportProgressDialog from './ExportProgressDialog.vue'
 
 // ── Props & Emits ──
 const props = withDefaults(
@@ -369,6 +397,8 @@ const semanticController = shallowRef<SemanticChartController | null>(null)
 /* ========== 本地响应式状态 ========== */
 const dataLength = ref(0)
 const dataVersion = ref(0)
+const showBatchStockDialog = ref(false)
+const batchStockCodes = ref<string[]>([])
 const viewportVersion = ref(0)
 const viewportDpr = ref(1)
 const zoomLevel = ref(props.initialZoomLevel ?? 1)
@@ -427,6 +457,7 @@ const {
   handleRangePointerMove,
   handleRangePointerUp,
   exportRangeToCsv,
+  exportingProgress,
   onEdgePointerDown,
   onEdgePointerMove,
   onEdgePointerUp,
@@ -438,6 +469,8 @@ const {
   containerRef,
   dataVersion,
   viewportVersion,
+  dataFetcher: computed(() => props.dataFetcher),
+  batchStockCodes,
 })
 
 // ── Viewport Initial Values ──
@@ -594,6 +627,10 @@ const chartData = computed(() => {
 // ── Pointer Event Handlers ──
 function onToggleIndicator() {
   indicatorSelectorRef.value?.toggleMenu()
+}
+
+function onBatchApply(codes: string[]) {
+  batchStockCodes.value = codes
 }
 
 function handleSelectTool(toolId: string) {
@@ -1157,6 +1194,23 @@ watch(
   border-color: var(--klc-color-axis-line);
   background: var(--klc-color-grid-minor);
   color: var(--klc-color-foreground);
+}
+
+.range-selection-export .toolbar-btn.delete-btn {
+  padding: 0;
+  width: 24px;
+  border-color: transparent;
+}
+
+.range-selection-export .toolbar-btn.delete-btn:hover {
+  color: #dc2626;
+  border-color: #fca5a5;
+  background: #fef2f2;
+}
+
+.range-selection-export .delete-icon {
+  width: 14px;
+  height: 14px;
 }
 
 .range-selection-export__label {

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -66,21 +66,6 @@
                 @update-style="onUpdateDrawingStyle"
                 @delete="onDeleteDrawing"
               />
-            </div>
-            <div
-              v-if="rangeSelectionOverlayStyle"
-              class="range-selection-overlay"
-              :class="{ 'is-dragging': rangeSelection.isDragging }"
-              :style="rangeSelectionOverlayStyle"
-              aria-label="已选择的 K 线区间"
-            >
-              <div
-                v-if="rangeSelectionReady"
-                class="range-selection-handle range-selection-handle--left"
-                @pointerdown.stop="onEdgePointerDown('left', $event)"
-                @pointermove.stop="onEdgePointerMove($event)"
-                @pointerup.stop="onEdgePointerUp($event)"
-              />
               <div
                 v-if="rangeSelectionReady"
                 class="range-selection-export"
@@ -108,6 +93,21 @@
                   导出
                 </button>
               </div>
+            </div>
+            <div
+              v-if="rangeSelectionOverlayStyle"
+              class="range-selection-overlay"
+              :class="{ 'is-dragging': rangeSelection.isDragging }"
+              :style="rangeSelectionOverlayStyle"
+              aria-label="已选择的 K 线区间"
+            >
+              <div
+                v-if="rangeSelectionReady"
+                class="range-selection-handle range-selection-handle--left"
+                @pointerdown.stop="onEdgePointerDown('left', $event)"
+                @pointermove.stop="onEdgePointerMove($event)"
+                @pointerup.stop="onEdgePointerUp($event)"
+              />
               <div
                 v-if="rangeSelectionReady"
                 class="range-selection-handle range-selection-handle--right"
@@ -434,6 +434,7 @@ const {
   controller,
   activeToolId,
   containerRef,
+  dataVersion,
 })
 
 // ── Viewport Initial Values ──
@@ -786,7 +787,6 @@ function setupChartCallbacks(ctrl: ChartController): void {
     const data = ctrl.data.peek()
     dataLength.value = data.length
     dataVersion.value++
-    clearRangeSelection()
     symbolError.value = data.length === 0
   })
 

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -369,6 +369,7 @@ const semanticController = shallowRef<SemanticChartController | null>(null)
 /* ========== 本地响应式状态 ========== */
 const dataLength = ref(0)
 const dataVersion = ref(0)
+const viewportVersion = ref(0)
 const viewportDpr = ref(1)
 const zoomLevel = ref(props.initialZoomLevel ?? 1)
 const kWidth = ref(0)
@@ -425,16 +426,18 @@ const {
   handleRangePointerDown,
   handleRangePointerMove,
   handleRangePointerUp,
+  exportRangeToCsv,
   onEdgePointerDown,
   onEdgePointerMove,
   onEdgePointerUp,
-  exportRangeToCsv,
   onScroll: onRangeScroll,
+  syncScrollLeft: syncRangeScrollLeft,
 } = useRangeSelection({
   controller,
   activeToolId,
   containerRef,
   dataVersion,
+  viewportVersion,
 })
 
 // ── Viewport Initial Values ──
@@ -770,6 +773,8 @@ function setupChartCallbacks(ctrl: ChartController): void {
   const unsubscribeViewport = ctrl.viewport.subscribe(() => {
     const vp = ctrl.viewport.peek()
 
+    viewportVersion.value++
+
     if (viewportDpr.value !== vp.dpr) {
       viewportDpr.value = vp.dpr
     }
@@ -781,6 +786,12 @@ function setupChartCallbacks(ctrl: ChartController): void {
       kWidth.value = vp.kWidth
       kGap.value = vp.kGap
     }
+
+    nextTick(() => {
+      requestAnimationFrame(() => {
+        syncRangeScrollLeft()
+      })
+    })
   })
 
   const unsubscribeData = ctrl.data.subscribe(() => {

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -67,6 +67,31 @@
                 @delete="onDeleteDrawing"
               />
             </div>
+            <div
+              v-if="rangeSelectionOverlayStyle"
+              class="range-selection-overlay"
+              :class="{ 'is-dragging': rangeSelection.isDragging }"
+              :style="rangeSelectionOverlayStyle"
+              aria-label="已选择的 K 线区间"
+            >
+              <div
+                v-if="rangeSelectionReady"
+                class="range-selection-export"
+                @pointerdown.stop
+                @pointermove.stop
+                @pointerup.stop
+              >
+                <span class="range-selection-export__label">{{ rangeSelectionDateLabel }}</span>
+                <button
+                  type="button"
+                  class="toolbar-btn"
+                  title="导出"
+                  @click.stop="exportRangeToCsv"
+                >
+                  导出
+                </button>
+              </div>
+            </div>
           </div>
         </div>
         <Teleport v-if="tooltipLayerRef" :to="tooltipLayerRef">
@@ -143,7 +168,6 @@ import {
   createChartController,
   type ChartController,
   type InteractionSnapshot,
-  type KLineData,
   type SymbolSpec,
   zoomLevelToKWidth,
   kGapFromKWidth,
@@ -152,6 +176,7 @@ import { useChartTheme } from '../composables/chart/useChartTheme'
 import { useIndicatorManager } from '../composables/chart/useIndicatorManager'
 import { useDrawingManager } from '../composables/chart/useDrawingManager'
 import { SETTINGS_STORAGE_KEY } from '@363045841yyt/klinechart-core/config'
+import { useRangeSelection } from '../composables/chart/useRangeSelection'
 import LeftToolbar from './LeftToolbar.vue'
 import TopToolbar, { type SymbolItem } from './TopToolbar.vue'
 
@@ -328,6 +353,7 @@ const viewWidth = ref(0)
 const paneRatios = ref<Record<string, number>>({})
 const comparisonColorsMap = ref<Map<string, string>>(new Map())
 const comparisonLoading = ref(false)
+const activeToolId = ref('cursor')
 
 const {
   mainActiveIndicators,
@@ -354,11 +380,31 @@ const {
   selectedDrawingId,
   selectedDrawing,
   drawings,
-  handleSelectTool,
+  handleSelectTool: handleDrawingToolSelect,
   onUpdateDrawingStyle,
   onDeleteDrawing,
   setupDrawing,
 } = useDrawingManager(controller)
+
+const {
+  rangeSelection,
+  containerScrollLeft,
+  isRangeSelectActive,
+  rangeSelectionReady,
+  rangeSelectionBounds,
+  rangeSelectionDateLabel,
+  rangeSelectionOverlayStyle,
+  clearRangeSelection,
+  handleRangePointerDown,
+  handleRangePointerMove,
+  handleRangePointerUp,
+  exportRangeToCsv,
+  onScroll: onRangeScroll,
+} = useRangeSelection({
+  controller,
+  activeToolId,
+  containerRef,
+})
 
 // ── Viewport Initial Values ──
 // 初始化 kWidth / kGap（与 Chart 引擎 zoom→物理值 转换一致）
@@ -516,9 +562,24 @@ function onToggleIndicator() {
   indicatorSelectorRef.value?.toggleMenu()
 }
 
+function handleSelectTool(toolId: string) {
+  activeToolId.value = toolId
+  if (toolId === 'range-select') {
+    drawingController.value?.setTool('cursor')
+    selectedDrawingId.value = null
+    return
+  }
+
+  clearRangeSelection()
+  handleDrawingToolSelect(toolId)
+}
+
 function onPointerDown(e: PointerEvent) {
   controller.value?.handlePointerEvent(e, {
     onPointerDown: (event, container) => {
+      if (handleRangePointerDown(event, container)) {
+        return true
+      }
       if (drawingController.value?.onPointerDown(event, container)) {
         return true
       }
@@ -538,6 +599,9 @@ function onPointerMove(e: PointerEvent) {
   }
   controller.value?.handlePointerEvent(e, {
     onPointerMove: (event, container) => {
+      if (handleRangePointerMove(event, container)) {
+        return true
+      }
       if (drawingController.value?.onPointerMove(event, container)) {
         drawings.value = drawingController.value.getDrawings()
         return true
@@ -550,6 +614,9 @@ function onPointerMove(e: PointerEvent) {
 function onPointerUp(e: PointerEvent) {
   controller.value?.handlePointerEvent(e, {
     onPointerUp: (event, container) => {
+      if (handleRangePointerUp(event, container)) {
+        return true
+      }
       if (drawingController.value?.onPointerUp(event, container)) {
         return true
       }
@@ -579,6 +646,7 @@ function onRightAxisPointerLeave(e: PointerEvent) {
 }
 
 function onScroll() {
+  onRangeScroll()
   controller.value?.handleScrollEvent()
 }
 
@@ -688,6 +756,7 @@ function setupChartCallbacks(ctrl: ChartController): void {
     const data = ctrl.data.peek()
     dataLength.value = data.length
     dataVersion.value++
+    clearRangeSelection()
     symbolError.value = data.length === 0
   })
 
@@ -973,6 +1042,72 @@ watch(
   height: 100%;
   min-height: inherit;
   position: relative;
+}
+
+.range-selection-overlay {
+  position: absolute;
+  top: 0;
+  z-index: 25;
+  box-sizing: border-box;
+  border: 1px solid rgba(24, 144, 255, 0.75);
+  background: rgba(24, 144, 255, 0.14);
+  pointer-events: none;
+}
+
+.range-selection-overlay.is-dragging {
+  background: rgba(24, 144, 255, 0.2);
+}
+
+.range-selection-export {
+  position: absolute;
+  left: 50%;
+  top: 8px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  height: 32px;
+  background: color-mix(in srgb, var(--klc-color-tag-bg-white) 88%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  z-index: 100;
+  user-select: none;
+  pointer-events: auto;
+}
+
+.range-selection-export .toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 24px;
+  padding: 0 8px;
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--klc-color-axis-text);
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    color 0.15s ease;
+  white-space: nowrap;
+}
+
+.range-selection-export .toolbar-btn:hover {
+  border-color: var(--klc-color-axis-line);
+  background: var(--klc-color-grid-minor);
+  color: var(--klc-color-foreground);
+}
+
+.range-selection-export__label {
+  color: var(--klc-color-axis-text);
+  font-size: 11px;
+  white-space: nowrap;
 }
 
 .canvas-layer {

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -76,12 +76,29 @@
             >
               <div
                 v-if="rangeSelectionReady"
+                class="range-selection-handle range-selection-handle--left"
+                @pointerdown.stop="onEdgePointerDown('left', $event)"
+                @pointermove.stop="onEdgePointerMove($event)"
+                @pointerup.stop="onEdgePointerUp($event)"
+              />
+              <div
+                v-if="rangeSelectionReady"
                 class="range-selection-export"
                 @pointerdown.stop
                 @pointermove.stop
                 @pointerup.stop
               >
-                <span class="range-selection-export__label">{{ rangeSelectionDateLabel }}</span>
+                <input
+                  class="range-selection-export__label"
+                  v-model="customStartDate"
+                  :placeholder="rangeSelectionStartLabel"
+                />
+                <span class="range-selection-export__sep">~</span>
+                <input
+                  class="range-selection-export__label"
+                  v-model="customEndDate"
+                  :placeholder="rangeSelectionEndLabel"
+                />
                 <button
                   type="button"
                   class="toolbar-btn"
@@ -91,6 +108,13 @@
                   导出
                 </button>
               </div>
+              <div
+                v-if="rangeSelectionReady"
+                class="range-selection-handle range-selection-handle--right"
+                @pointerdown.stop="onEdgePointerDown('right', $event)"
+                @pointermove.stop="onEdgePointerMove($event)"
+                @pointerup.stop="onEdgePointerUp($event)"
+              />
             </div>
           </div>
         </div>
@@ -388,16 +412,22 @@ const {
 
 const {
   rangeSelection,
+  customStartDate,
+  customEndDate,
   containerScrollLeft,
   isRangeSelectActive,
   rangeSelectionReady,
   rangeSelectionBounds,
-  rangeSelectionDateLabel,
+  rangeSelectionStartLabel,
+  rangeSelectionEndLabel,
   rangeSelectionOverlayStyle,
   clearRangeSelection,
   handleRangePointerDown,
   handleRangePointerMove,
   handleRangePointerUp,
+  onEdgePointerDown,
+  onEdgePointerMove,
+  onEdgePointerUp,
   exportRangeToCsv,
   onScroll: onRangeScroll,
 } = useRangeSelection({
@@ -1058,6 +1088,20 @@ watch(
   background: rgba(24, 144, 255, 0.2);
 }
 
+.range-selection-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  cursor: ew-resize;
+  pointer-events: auto;
+  z-index: 101;
+}
+
+.range-selection-handle--left { left: -4px; }
+
+.range-selection-handle--right { right: -4px; }
+
 .range-selection-export {
   position: absolute;
   left: 50%;
@@ -1108,6 +1152,20 @@ watch(
   color: var(--klc-color-axis-text);
   font-size: 11px;
   white-space: nowrap;
+  border: 1px solid var(--klc-color-border-button);
+  background: none;
+  outline: none;
+  padding: 1px 4px;
+  width: 80px;
+  font-family: inherit;
+  border-radius: 3px;
+  text-align: center;
+}
+
+.range-selection-export__sep {
+  color: var(--klc-color-axis-text);
+  font-size: 11px;
+  user-select: none;
 }
 
 .canvas-layer {

--- a/packages/vue/src/composables/chart/useRangeSelection.ts
+++ b/packages/vue/src/composables/chart/useRangeSelection.ts
@@ -1,6 +1,6 @@
 import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
 import { formatTimestamp } from '@363045841yyt/klinechart-core'
-import type { KLineData, ChartController } from '@363045841yyt/klinechart-core/controllers'
+import type { KLineData, ChartController, DataFetcher } from '@363045841yyt/klinechart-core/controllers'
 import { calcRangeOverlayPixel } from '../../tools/calcRangeOverlayPixel'
 import type { Bounds } from '../../tools/calcRangeOverlayPixel'
 import {
@@ -20,10 +20,12 @@ function fmtDate(item: KLineData | undefined): string {
   return new Date(item.timestamp).toISOString().slice(0, 10)
 }
 
-function formatRangeFileDate(item: KLineData | undefined): string {
-  if (!item) return 'unknown'
-  if (item.date) return item.date.replace(/[\\/:*?"<>|\s]+/g, '-')
-  return new Date(item.timestamp).toISOString().slice(0, 10)
+function toYYYYMMDD(ts: number): string {
+  const d = new Date(ts)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}${m}${day}`
 }
 
 function normalizeDateInput(input: string): string | null {
@@ -54,13 +56,16 @@ export function useRangeSelection(options: {
   containerRef: Ref<HTMLElement | null>
   dataVersion: Ref<number>
   viewportVersion: Ref<number>
+  dataFetcher: Ref<DataFetcher | null>
+  batchStockCodes: Ref<string[]>
 }) {
-  const { controller, activeToolId, containerRef, dataVersion, viewportVersion } = options
+  const { controller, activeToolId, containerRef, dataVersion, viewportVersion, dataFetcher, batchStockCodes } = options
 
   const containerScrollLeft = ref(0)
   const customStartDate = ref('')
   const customEndDate = ref('')
   const resizeSide = ref<'left' | 'right' | null>(null)
+  const exportingProgress = ref<{ current: number; total: number; label: string } | null>(null)
 
   const rangeSelection = ref<RangeSelectionState>({
     startTimestamp: null,
@@ -148,10 +153,6 @@ export function useRangeSelection(options: {
       controller.value?.ensureDataRange(targetTs)
     }
   })
-
-  function sanitizeLabel(label: string): string {
-    return label.replace(/[\\/:*?"<>|\s]+/g, '-')
-  }
 
   function getRangeSelectionIndex(e: PointerEvent, container: HTMLElement): number | null {
     const data = controller.value?.getData() ?? []
@@ -281,48 +282,106 @@ export function useRangeSelection(options: {
     resizeSide.value = null
   }
 
-  function exportRangeToCsv() {
-    const bounds = rangeSelectionBounds.value
-    const data = controller.value?.getData() ?? []
-    if (!bounds || data.length === 0) return
+  const CSV_FIELDS: Array<keyof KLineData> = [
+    'timestamp',
+    'open',
+    'high',
+    'low',
+    'close',
+    'volume',
+    'turnover',
+    'turnoverRate',
+    'amplitude',
+    'changePercent',
+    'changeAmount',
+  ]
 
-    const fields: Array<keyof KLineData> = [
-      'timestamp',
-      'open',
-      'high',
-      'low',
-      'close',
-      'volume',
-      'turnover',
-      'turnoverRate',
-      'stockCode',
-      'amplitude',
-      'changePercent',
-      'changeAmount',
-    ]
-    const selected = data.slice(bounds.start, bounds.end + 1)
-    const header = `time,${fields.join(',')}`
+  function downloadCsv(
+    items: ReadonlyArray<KLineData>,
+    prefix: string,
+    startTs: number,
+    endTs: number,
+  ) {
+    const header = `stockCode,time,${CSV_FIELDS.join(',')}`
     const rows = [
       header,
-      ...selected.map((item) => {
+      ...items.map((item) => {
         const timeStr = toCsvCell(formatTimestamp(item.timestamp, { showTime: true }))
-        return `${timeStr},${fields.map((field) => toCsvCell(item[field])).join(',')}`
+        const code = toCsvCell(item.stockCode ?? prefix)
+        return `${code},${timeStr},${CSV_FIELDS.map((field) => toCsvCell(item[field])).join(',')}`
       }),
     ]
     const blob = new Blob([`\uFEFF${rows.join('\n')}`], { type: 'text/csv;charset=utf-8' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    const startLabel = customStartDate.value || formatRangeFileDate(data[bounds.start])
-    const endLabel = customEndDate.value || formatRangeFileDate(data[bounds.end])
-    a.download = `kline-range-${sanitizeLabel(startLabel)}-${sanitizeLabel(endLabel)}.csv`
+    a.download = `${prefix}-${toYYYYMMDD(startTs)}-${toYYYYMMDD(endTs)}.csv`
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
   }
 
-  function onScroll() {
+  async function exportRangeToCsv() {
+    const bounds = rangeSelectionBounds.value
+    const data = controller.value?.getData() ?? []
+    if (!bounds || data.length === 0) return
+
+    const startTs = data[bounds.start]!.timestamp
+    const endTs = data[bounds.end]!.timestamp
+    const mainStockCode = controller.value?.symbols.peek()?.[0]?.symbol ?? 'unknown'
+    const batchCodes = batchStockCodes.value
+    const total = 1 + batchCodes.length
+    const prefix = batchCodes.length > 0 ? `batch${total}` : mainStockCode
+
+    const allItems: KLineData[] = []
+
+    exportingProgress.value = { current: 0, total, label: '正在准备主品种数据...' }
+
+    // Main stock
+    for (const item of data.slice(bounds.start, bounds.end + 1)) {
+      allItems.push(item)
+    }
+    exportingProgress.value = { current: 1, total, label: '主品种数据已就绪' }
+
+    // Batch stocks (sequential)
+    const fetchFn = dataFetcher.value
+    if (fetchFn && batchCodes.length > 0) {
+      const spec = controller.value?.symbols.peek()?.[0]
+      const startDate = formatTimestamp(startTs)
+      const endDate = formatTimestamp(endTs)
+      const period = spec?.period ?? 'daily'
+      const adjust = spec?.adjust ?? 'none'
+      const exchange = spec?.exchange
+      const source = spec?.source ?? 'gotdx'
+
+      for (let i = 0; i < batchCodes.length; i++) {
+        const code = batchCodes[i]!
+        exportingProgress.value = { current: 1 + i, total, label: `正在获取 ${code}...` }
+        try {
+          const items = await fetchFn(source, {
+            symbol: code,
+            startDate,
+            endDate,
+            period,
+            adjust,
+            exchange,
+          })
+          for (const item of items) {
+            allItems.push(item)
+          }
+        } catch {
+          continue
+        }
+      }
+    }
+
+    exportingProgress.value = { current: total, total, label: '正在生成文件...' }
+    downloadCsv(allItems, prefix, startTs, endTs)
+    exportingProgress.value = { current: total, total, label: '导出完成' }
+  }
+
+    function onScroll() {
     const cont = containerRef.value
     if (cont) containerScrollLeft.value = cont.scrollLeft
   }
@@ -348,6 +407,7 @@ export function useRangeSelection(options: {
     handleRangePointerMove,
     handleRangePointerUp,
     exportRangeToCsv,
+    exportingProgress,
     onEdgePointerDown,
     onEdgePointerMove,
     onEdgePointerUp,

--- a/packages/vue/src/composables/chart/useRangeSelection.ts
+++ b/packages/vue/src/composables/chart/useRangeSelection.ts
@@ -3,7 +3,10 @@ import { formatTimestamp } from '@363045841yyt/klinechart-core'
 import type { KLineData, ChartController } from '@363045841yyt/klinechart-core/controllers'
 import { calcRangeOverlayPixel } from '../../tools/calcRangeOverlayPixel'
 import type { Bounds } from '../../tools/calcRangeOverlayPixel'
-import { getKLineIndexByTimestamp } from '../../tools/getKLineIndexByTimestamp'
+import {
+  getKLineIndexByTimestamp,
+  findNearestKLineIndex,
+} from '../../tools/getKLineIndexByTimestamp'
 
 interface RangeSelectionState {
   startTimestamp: number | null
@@ -50,8 +53,9 @@ export function useRangeSelection(options: {
   activeToolId: Ref<string>
   containerRef: Ref<HTMLElement | null>
   dataVersion: Ref<number>
+  viewportVersion: Ref<number>
 }) {
-  const { controller, activeToolId, containerRef, dataVersion } = options
+  const { controller, activeToolId, containerRef, dataVersion, viewportVersion } = options
 
   const containerScrollLeft = ref(0)
   const customStartDate = ref('')
@@ -78,11 +82,11 @@ export function useRangeSelection(options: {
     const { startTimestamp, endTimestamp } = rangeSelection.value
     if (startTimestamp === null || endTimestamp === null || data.length === 0) return null
 
-    const start = getKLineIndexByTimestamp(data, startTimestamp)
-    const end = getKLineIndexByTimestamp(data, endTimestamp)
-    if (start === null || end === null) return null
+    const rawStart = findNearestKLineIndex(data, startTimestamp, 'left')
+    const rawEnd = findNearestKLineIndex(data, endTimestamp, 'right')
+    if (rawStart === null || rawEnd === null) return null
 
-    return { start: Math.min(start, end), end: Math.max(start, end) }
+    return { start: Math.min(rawStart, rawEnd), end: Math.max(rawStart, rawEnd) }
   })
 
   const rangeSelectionStartLabel: ComputedRef<string> = computed(() => {
@@ -104,6 +108,7 @@ export function useRangeSelection(options: {
     if (!bounds) return null
 
     void containerScrollLeft.value
+    void viewportVersion.value
 
     const ctrl = controller.value
     const viewport = ctrl?.getViewport()
@@ -124,61 +129,22 @@ export function useRangeSelection(options: {
     customEndDate.value = ''
   }
 
-  function getIndexByDate(dateStr: string): number | null {
-    const data = controller.value?.getData() ?? []
-    if (!data.length || !dateStr.trim()) return null
-    const trimmed = dateStr.trim()
-    const normalized = normalizeDateInput(trimmed)
-
-    for (let i = 0; i < data.length; i++) {
-      const item = data[i]
-      if (item.date === trimmed || (normalized !== null && item.date === normalized)) return i
-      if (!item.date) {
-        if (new Date(item.timestamp).toISOString().slice(0, 10) === trimmed) return i
-        if (
-          normalized !== null &&
-          new Date(item.timestamp).toISOString().slice(0, 10) === normalized
-        )
-          return i
-      }
-    }
-    return null
-  }
-
   watch(customStartDate, (val) => {
     const data = controller.value?.getData() ?? []
-    const idx = getIndexByDate(val)
-    if (idx !== null && data[idx]) {
-      rangeSelection.value = {
-        ...rangeSelection.value,
-        startTimestamp: data[idx]!.timestamp,
-        isDragging: false,
-      }
-      return
-    }
     const targetTs = parseDateToTimestamp(val)
     if (targetTs === null || data.length === 0) return
+    rangeSelection.value = { ...rangeSelection.value, startTimestamp: targetTs, isDragging: false }
     if (targetTs < data[0]!.timestamp) {
-      rangeSelection.value = { ...rangeSelection.value, startTimestamp: targetTs, isDragging: false }
       controller.value?.ensureDataRange(targetTs)
     }
   })
 
   watch(customEndDate, (val) => {
     const data = controller.value?.getData() ?? []
-    const idx = getIndexByDate(val)
-    if (idx !== null && data[idx]) {
-      rangeSelection.value = {
-        ...rangeSelection.value,
-        endTimestamp: data[idx]!.timestamp,
-        isDragging: false,
-      }
-      return
-    }
     const targetTs = parseDateToTimestamp(val)
     if (targetTs === null || data.length === 0) return
+    rangeSelection.value = { ...rangeSelection.value, endTimestamp: targetTs, isDragging: false }
     if (targetTs < data[0]!.timestamp) {
-      rangeSelection.value = { ...rangeSelection.value, endTimestamp: targetTs, isDragging: false }
       controller.value?.ensureDataRange(targetTs)
     }
   })
@@ -361,6 +327,11 @@ export function useRangeSelection(options: {
     if (cont) containerScrollLeft.value = cont.scrollLeft
   }
 
+  function syncScrollLeft() {
+    const cont = containerRef.value
+    if (cont) containerScrollLeft.value = cont.scrollLeft
+  }
+
   return {
     rangeSelection,
     customStartDate,
@@ -381,5 +352,6 @@ export function useRangeSelection(options: {
     onEdgePointerMove,
     onEdgePointerUp,
     onScroll,
+    syncScrollLeft,
   }
 }

--- a/packages/vue/src/composables/chart/useRangeSelection.ts
+++ b/packages/vue/src/composables/chart/useRangeSelection.ts
@@ -3,10 +3,11 @@ import { formatTimestamp } from '@363045841yyt/klinechart-core'
 import type { KLineData, ChartController } from '@363045841yyt/klinechart-core/controllers'
 import { calcRangeOverlayPixel } from '../../tools/calcRangeOverlayPixel'
 import type { Bounds } from '../../tools/calcRangeOverlayPixel'
+import { getKLineIndexByTimestamp } from '../../tools/getKLineIndexByTimestamp'
 
 interface RangeSelectionState {
-  startIndex: number | null
-  endIndex: number | null
+  startTimestamp: number | null
+  endTimestamp: number | null
   isDragging: boolean
 }
 
@@ -41,8 +42,9 @@ export function useRangeSelection(options: {
   controller: Ref<ChartController | null>
   activeToolId: Ref<string>
   containerRef: Ref<HTMLElement | null>
+  dataVersion: Ref<number>
 }) {
-  const { controller, activeToolId, containerRef } = options
+  const { controller, activeToolId, containerRef, dataVersion } = options
 
   const containerScrollLeft = ref(0)
   const customStartDate = ref('')
@@ -50,8 +52,8 @@ export function useRangeSelection(options: {
   const resizeSide = ref<'left' | 'right' | null>(null)
 
   const rangeSelection = ref<RangeSelectionState>({
-    startIndex: null,
-    endIndex: null,
+    startTimestamp: null,
+    endTimestamp: null,
     isDragging: false,
   })
 
@@ -59,18 +61,21 @@ export function useRangeSelection(options: {
 
   const rangeSelectionReady = computed(
     () =>
-      rangeSelection.value.startIndex !== null && rangeSelection.value.endIndex !== null,
+      rangeSelection.value.startTimestamp !== null &&
+      rangeSelection.value.endTimestamp !== null,
   )
 
   const rangeSelectionBounds: ComputedRef<Bounds | null> = computed(() => {
+    void dataVersion.value
     const data = controller.value?.getData() ?? []
-    const { startIndex, endIndex } = rangeSelection.value
-    if (startIndex === null || endIndex === null || data.length === 0) return null
+    const { startTimestamp, endTimestamp } = rangeSelection.value
+    if (startTimestamp === null || endTimestamp === null || data.length === 0) return null
 
-    const last = data.length - 1
-    const start = Math.max(0, Math.min(startIndex, endIndex, last))
-    const end = Math.max(0, Math.min(Math.max(startIndex, endIndex), last))
-    return { start, end }
+    const start = getKLineIndexByTimestamp(data, startTimestamp)
+    const end = getKLineIndexByTimestamp(data, endTimestamp)
+    if (start === null || end === null) return null
+
+    return { start: Math.min(start, end), end: Math.max(start, end) }
   })
 
   const rangeSelectionStartLabel: ComputedRef<string> = computed(() => {
@@ -91,6 +96,8 @@ export function useRangeSelection(options: {
     const bounds = rangeSelectionBounds.value
     if (!bounds) return null
 
+    void containerScrollLeft.value
+
     const ctrl = controller.value
     const viewport = ctrl?.getViewport()
     const container = containerRef.value
@@ -105,7 +112,7 @@ export function useRangeSelection(options: {
   })
 
   function clearRangeSelection() {
-    rangeSelection.value = { startIndex: null, endIndex: null, isDragging: false }
+    rangeSelection.value = { startTimestamp: null, endTimestamp: null, isDragging: false }
     customStartDate.value = ''
     customEndDate.value = ''
   }
@@ -121,7 +128,11 @@ export function useRangeSelection(options: {
       if (item.date === trimmed || (normalized !== null && item.date === normalized)) return i
       if (!item.date) {
         if (new Date(item.timestamp).toISOString().slice(0, 10) === trimmed) return i
-        if (normalized !== null && new Date(item.timestamp).toISOString().slice(0, 10) === normalized) return i
+        if (
+          normalized !== null &&
+          new Date(item.timestamp).toISOString().slice(0, 10) === normalized
+        )
+          return i
       }
     }
     return null
@@ -130,14 +141,22 @@ export function useRangeSelection(options: {
   watch(customStartDate, (val) => {
     const idx = getIndexByDate(val)
     if (idx !== null) {
-      rangeSelection.value = { ...rangeSelection.value, startIndex: idx, isDragging: false }
+      const data = controller.value?.getData() ?? []
+      const ts = data[idx]?.timestamp
+      if (ts !== undefined) {
+        rangeSelection.value = { ...rangeSelection.value, startTimestamp: ts, isDragging: false }
+      }
     }
   })
 
   watch(customEndDate, (val) => {
     const idx = getIndexByDate(val)
     if (idx !== null) {
-      rangeSelection.value = { ...rangeSelection.value, endIndex: idx, isDragging: false }
+      const data = controller.value?.getData() ?? []
+      const ts = data[idx]?.timestamp
+      if (ts !== undefined) {
+        rangeSelection.value = { ...rangeSelection.value, endTimestamp: ts, isDragging: false }
+      }
     }
   })
 
@@ -157,10 +176,21 @@ export function useRangeSelection(options: {
 
   function handleRangePointerDown(e: PointerEvent, container: HTMLElement): boolean {
     if (!isRangeSelectActive.value) return false
+    if (
+      rangeSelection.value.startTimestamp !== null &&
+      rangeSelection.value.endTimestamp !== null &&
+      !rangeSelection.value.isDragging
+    ) {
+      return false
+    }
     const index = getRangeSelectionIndex(e, container)
     if (index === null) return true
 
-    rangeSelection.value = { startIndex: index, endIndex: index, isDragging: true }
+    const data = controller.value?.getData() ?? []
+    const ts = data[index]?.timestamp
+    if (ts === undefined) return true
+
+    rangeSelection.value = { startTimestamp: ts, endTimestamp: ts, isDragging: true }
     customStartDate.value = ''
     customEndDate.value = ''
     container.setPointerCapture?.(e.pointerId)
@@ -172,7 +202,11 @@ export function useRangeSelection(options: {
     if (!isRangeSelectActive.value || !rangeSelection.value.isDragging) return false
     const index = getRangeSelectionIndex(e, container)
     if (index !== null) {
-      rangeSelection.value = { ...rangeSelection.value, endIndex: index }
+      const data = controller.value?.getData() ?? []
+      const ts = data[index]?.timestamp
+      if (ts !== undefined) {
+        rangeSelection.value = { ...rangeSelection.value, endTimestamp: ts }
+      }
     }
     e.preventDefault()
     return true
@@ -181,10 +215,20 @@ export function useRangeSelection(options: {
   function handleRangePointerUp(e: PointerEvent, container: HTMLElement): boolean {
     if (!isRangeSelectActive.value || !rangeSelection.value.isDragging) return false
     const index = getRangeSelectionIndex(e, container)
-    rangeSelection.value = {
-      ...rangeSelection.value,
-      endIndex: index ?? rangeSelection.value.endIndex,
-      isDragging: false,
+    if (index !== null) {
+      const data = controller.value?.getData() ?? []
+      const ts = data[index]?.timestamp
+      if (ts !== undefined) {
+        rangeSelection.value = {
+          ...rangeSelection.value,
+          endTimestamp: ts,
+          isDragging: false,
+        }
+      } else {
+        rangeSelection.value = { ...rangeSelection.value, isDragging: false }
+      }
+    } else {
+      rangeSelection.value = { ...rangeSelection.value, isDragging: false }
     }
     container.releasePointerCapture?.(e.pointerId)
     e.preventDefault()
@@ -200,7 +244,12 @@ export function useRangeSelection(options: {
   }
 
   function onEdgePointerMove(e: PointerEvent) {
-    if (!resizeSide.value || rangeSelection.value.startIndex === null || rangeSelection.value.endIndex === null) return
+    if (
+      !resizeSide.value ||
+      rangeSelection.value.startTimestamp === null ||
+      rangeSelection.value.endTimestamp === null
+    )
+      return
     const rect = containerRef.value?.getBoundingClientRect()
     if (!rect) return
     const data = controller.value?.getData() ?? []
@@ -208,13 +257,31 @@ export function useRangeSelection(options: {
     const rawIndex = controller.value?.getLogicalIndexAtX(e.clientX - rect.left)
     if (rawIndex === null || rawIndex === undefined) return
     const index = Math.max(0, Math.min(rawIndex, data.length - 1))
+    const ts = data[index]?.timestamp
+    if (ts === undefined) return
 
     if (resizeSide.value === 'left') {
-      const end = rangeSelection.value.endIndex
-      rangeSelection.value = { ...rangeSelection.value, startIndex: Math.min(index, end) }
+      if (ts > rangeSelection.value.endTimestamp) {
+        rangeSelection.value = {
+          startTimestamp: rangeSelection.value.endTimestamp,
+          endTimestamp: ts,
+          isDragging: false,
+        }
+        resizeSide.value = 'right'
+      } else {
+        rangeSelection.value = { ...rangeSelection.value, startTimestamp: ts }
+      }
     } else {
-      const start = rangeSelection.value.startIndex
-      rangeSelection.value = { ...rangeSelection.value, endIndex: Math.max(index, start) }
+      if (ts < rangeSelection.value.startTimestamp) {
+        rangeSelection.value = {
+          startTimestamp: ts,
+          endTimestamp: rangeSelection.value.startTimestamp,
+          isDragging: false,
+        }
+        resizeSide.value = 'left'
+      } else {
+        rangeSelection.value = { ...rangeSelection.value, endTimestamp: ts }
+      }
     }
   }
 

--- a/packages/vue/src/composables/chart/useRangeSelection.ts
+++ b/packages/vue/src/composables/chart/useRangeSelection.ts
@@ -1,6 +1,8 @@
-import { ref, computed, type Ref, type ComputedRef } from 'vue'
+import { ref, computed, watch, type Ref, type ComputedRef } from 'vue'
 import { formatTimestamp } from '@363045841yyt/klinechart-core'
 import type { KLineData, ChartController } from '@363045841yyt/klinechart-core/controllers'
+import { calcRangeOverlayPixel } from '../../tools/calcRangeOverlayPixel'
+import type { Bounds } from '../../tools/calcRangeOverlayPixel'
 
 interface RangeSelectionState {
   startIndex: number | null
@@ -8,15 +10,25 @@ interface RangeSelectionState {
   isDragging: boolean
 }
 
-interface Bounds {
-  start: number
-  end: number
+function fmtDate(item: KLineData | undefined): string {
+  if (!item) return '?'
+  if (item.date) return item.date
+  return new Date(item.timestamp).toISOString().slice(0, 10)
 }
 
 function formatRangeFileDate(item: KLineData | undefined): string {
   if (!item) return 'unknown'
   if (item.date) return item.date.replace(/[\\/:*?"<>|\s]+/g, '-')
   return new Date(item.timestamp).toISOString().slice(0, 10)
+}
+
+function normalizeDateInput(input: string): string | null {
+  const parts = input.trim().split(/[-/]/)
+  if (parts.length !== 3) return null
+  const y = parts[0]!.padStart(4, '0')
+  const m = parts[1]!.padStart(2, '0')
+  const d = parts[2]!.padStart(2, '0')
+  return `${y}-${m}-${d}`
 }
 
 function toCsvCell(value: unknown): string {
@@ -33,6 +45,10 @@ export function useRangeSelection(options: {
   const { controller, activeToolId, containerRef } = options
 
   const containerScrollLeft = ref(0)
+  const customStartDate = ref('')
+  const customEndDate = ref('')
+  const resizeSide = ref<'left' | 'right' | null>(null)
+
   const rangeSelection = ref<RangeSelectionState>({
     startIndex: null,
     endIndex: null,
@@ -57,20 +73,18 @@ export function useRangeSelection(options: {
     return { start, end }
   })
 
-  const rangeSelectionDateLabel: ComputedRef<string> = computed(() => {
+  const rangeSelectionStartLabel: ComputedRef<string> = computed(() => {
     const bounds = rangeSelectionBounds.value
     const data = controller.value?.getData() ?? []
     if (!bounds || data.length === 0) return ''
+    return fmtDate(data[bounds.start])
+  })
 
-    const first = data[bounds.start]
-    const last = data[bounds.end]
-    const fmt = (item: KLineData | undefined) => {
-      if (!item) return '?'
-      if (item.date) return item.date
-      return new Date(item.timestamp).toISOString().slice(0, 10)
-    }
-    if (bounds.start === bounds.end) return fmt(first)
-    return `${fmt(first)} ~ ${fmt(last)}`
+  const rangeSelectionEndLabel: ComputedRef<string> = computed(() => {
+    const bounds = rangeSelectionBounds.value
+    const data = controller.value?.getData() ?? []
+    if (!bounds || data.length === 0) return ''
+    return fmtDate(data[bounds.end])
   })
 
   const rangeSelectionOverlayStyle = computed(() => {
@@ -82,28 +96,53 @@ export function useRangeSelection(options: {
     const container = containerRef.value
     if (!ctrl || !viewport || !container) return null
 
-    const { kWidth: currentKWidth, kGap: currentKGap } = ctrl.getKWidthKGap()
-    const dpr = ctrl.getCurrentDpr()
-    const kWidthPx = Math.max(
-      1,
-      Math.round(currentKWidth * dpr) + (Math.round(currentKWidth * dpr) % 2 === 0 ? 1 : 0),
-    )
-    const kGapPx = Math.round(currentKGap * dpr)
-    const unitPx = kWidthPx + kGapPx
-    const startXPx = kGapPx
-
-    const leftBuffer = container.scrollLeft - viewport.scrollLeft
-    const left = leftBuffer + (startXPx + bounds.start * unitPx) / dpr
-    const right = leftBuffer + (startXPx + bounds.end * unitPx + kWidthPx) / dpr
+    const px = calcRangeOverlayPixel(bounds, ctrl, container, viewport)
     return {
-      left: `${left}px`,
-      width: `${right - left}px`,
-      height: `${viewport.plotHeight}px`,
+      left: `${px.left}px`,
+      width: `${px.width}px`,
+      height: `${px.height}px`,
     }
   })
 
   function clearRangeSelection() {
     rangeSelection.value = { startIndex: null, endIndex: null, isDragging: false }
+    customStartDate.value = ''
+    customEndDate.value = ''
+  }
+
+  function getIndexByDate(dateStr: string): number | null {
+    const data = controller.value?.getData() ?? []
+    if (!data.length || !dateStr.trim()) return null
+    const trimmed = dateStr.trim()
+    const normalized = normalizeDateInput(trimmed)
+
+    for (let i = 0; i < data.length; i++) {
+      const item = data[i]
+      if (item.date === trimmed || (normalized !== null && item.date === normalized)) return i
+      if (!item.date) {
+        if (new Date(item.timestamp).toISOString().slice(0, 10) === trimmed) return i
+        if (normalized !== null && new Date(item.timestamp).toISOString().slice(0, 10) === normalized) return i
+      }
+    }
+    return null
+  }
+
+  watch(customStartDate, (val) => {
+    const idx = getIndexByDate(val)
+    if (idx !== null) {
+      rangeSelection.value = { ...rangeSelection.value, startIndex: idx, isDragging: false }
+    }
+  })
+
+  watch(customEndDate, (val) => {
+    const idx = getIndexByDate(val)
+    if (idx !== null) {
+      rangeSelection.value = { ...rangeSelection.value, endIndex: idx, isDragging: false }
+    }
+  })
+
+  function sanitizeLabel(label: string): string {
+    return label.replace(/[\\/:*?"<>|\s]+/g, '-')
   }
 
   function getRangeSelectionIndex(e: PointerEvent, container: HTMLElement): number | null {
@@ -122,6 +161,8 @@ export function useRangeSelection(options: {
     if (index === null) return true
 
     rangeSelection.value = { startIndex: index, endIndex: index, isDragging: true }
+    customStartDate.value = ''
+    customEndDate.value = ''
     container.setPointerCapture?.(e.pointerId)
     e.preventDefault()
     return true
@@ -148,6 +189,40 @@ export function useRangeSelection(options: {
     container.releasePointerCapture?.(e.pointerId)
     e.preventDefault()
     return true
+  }
+
+  function onEdgePointerDown(side: 'left' | 'right', e: PointerEvent) {
+    if (!isRangeSelectActive.value) return
+    resizeSide.value = side
+    const el = e.currentTarget as HTMLElement
+    el.setPointerCapture?.(e.pointerId)
+    e.preventDefault()
+  }
+
+  function onEdgePointerMove(e: PointerEvent) {
+    if (!resizeSide.value || rangeSelection.value.startIndex === null || rangeSelection.value.endIndex === null) return
+    const rect = containerRef.value?.getBoundingClientRect()
+    if (!rect) return
+    const data = controller.value?.getData() ?? []
+    if (!data.length) return
+    const rawIndex = controller.value?.getLogicalIndexAtX(e.clientX - rect.left)
+    if (rawIndex === null || rawIndex === undefined) return
+    const index = Math.max(0, Math.min(rawIndex, data.length - 1))
+
+    if (resizeSide.value === 'left') {
+      const end = rangeSelection.value.endIndex
+      rangeSelection.value = { ...rangeSelection.value, startIndex: Math.min(index, end) }
+    } else {
+      const start = rangeSelection.value.startIndex
+      rangeSelection.value = { ...rangeSelection.value, endIndex: Math.max(index, start) }
+    }
+  }
+
+  function onEdgePointerUp(e: PointerEvent) {
+    if (!resizeSide.value) return
+    const el = e.currentTarget as HTMLElement
+    el.releasePointerCapture?.(e.pointerId)
+    resizeSide.value = null
   }
 
   function exportRangeToCsv() {
@@ -182,7 +257,9 @@ export function useRangeSelection(options: {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `kline-range-${formatRangeFileDate(data[bounds.start])}-${formatRangeFileDate(data[bounds.end])}.csv`
+    const startLabel = customStartDate.value || formatRangeFileDate(data[bounds.start])
+    const endLabel = customEndDate.value || formatRangeFileDate(data[bounds.end])
+    a.download = `kline-range-${sanitizeLabel(startLabel)}-${sanitizeLabel(endLabel)}.csv`
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
@@ -196,17 +273,23 @@ export function useRangeSelection(options: {
 
   return {
     rangeSelection,
+    customStartDate,
+    customEndDate,
     containerScrollLeft,
     isRangeSelectActive,
     rangeSelectionReady,
     rangeSelectionBounds,
-    rangeSelectionDateLabel,
+    rangeSelectionStartLabel,
+    rangeSelectionEndLabel,
     rangeSelectionOverlayStyle,
     clearRangeSelection,
     handleRangePointerDown,
     handleRangePointerMove,
     handleRangePointerUp,
     exportRangeToCsv,
+    onEdgePointerDown,
+    onEdgePointerMove,
+    onEdgePointerUp,
     onScroll,
   }
 }

--- a/packages/vue/src/composables/chart/useRangeSelection.ts
+++ b/packages/vue/src/composables/chart/useRangeSelection.ts
@@ -38,6 +38,13 @@ function toCsvCell(value: unknown): string {
   return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
 }
 
+function parseDateToTimestamp(input: string): number | null {
+  const normalized = normalizeDateInput(input)
+  if (!normalized) return null
+  const d = new Date(normalized)
+  return isNaN(d.getTime()) ? null : d.getTime()
+}
+
 export function useRangeSelection(options: {
   controller: Ref<ChartController | null>
   activeToolId: Ref<string>
@@ -139,24 +146,40 @@ export function useRangeSelection(options: {
   }
 
   watch(customStartDate, (val) => {
+    const data = controller.value?.getData() ?? []
     const idx = getIndexByDate(val)
-    if (idx !== null) {
-      const data = controller.value?.getData() ?? []
-      const ts = data[idx]?.timestamp
-      if (ts !== undefined) {
-        rangeSelection.value = { ...rangeSelection.value, startTimestamp: ts, isDragging: false }
+    if (idx !== null && data[idx]) {
+      rangeSelection.value = {
+        ...rangeSelection.value,
+        startTimestamp: data[idx]!.timestamp,
+        isDragging: false,
       }
+      return
+    }
+    const targetTs = parseDateToTimestamp(val)
+    if (targetTs === null || data.length === 0) return
+    if (targetTs < data[0]!.timestamp) {
+      rangeSelection.value = { ...rangeSelection.value, startTimestamp: targetTs, isDragging: false }
+      controller.value?.ensureDataRange(targetTs)
     }
   })
 
   watch(customEndDate, (val) => {
+    const data = controller.value?.getData() ?? []
     const idx = getIndexByDate(val)
-    if (idx !== null) {
-      const data = controller.value?.getData() ?? []
-      const ts = data[idx]?.timestamp
-      if (ts !== undefined) {
-        rangeSelection.value = { ...rangeSelection.value, endTimestamp: ts, isDragging: false }
+    if (idx !== null && data[idx]) {
+      rangeSelection.value = {
+        ...rangeSelection.value,
+        endTimestamp: data[idx]!.timestamp,
+        isDragging: false,
       }
+      return
+    }
+    const targetTs = parseDateToTimestamp(val)
+    if (targetTs === null || data.length === 0) return
+    if (targetTs < data[0]!.timestamp) {
+      rangeSelection.value = { ...rangeSelection.value, endTimestamp: targetTs, isDragging: false }
+      controller.value?.ensureDataRange(targetTs)
     }
   })
 

--- a/packages/vue/src/composables/chart/useRangeSelection.ts
+++ b/packages/vue/src/composables/chart/useRangeSelection.ts
@@ -1,0 +1,212 @@
+import { ref, computed, type Ref, type ComputedRef } from 'vue'
+import { formatTimestamp } from '@363045841yyt/klinechart-core'
+import type { KLineData, ChartController } from '@363045841yyt/klinechart-core/controllers'
+
+interface RangeSelectionState {
+  startIndex: number | null
+  endIndex: number | null
+  isDragging: boolean
+}
+
+interface Bounds {
+  start: number
+  end: number
+}
+
+function formatRangeFileDate(item: KLineData | undefined): string {
+  if (!item) return 'unknown'
+  if (item.date) return item.date.replace(/[\\/:*?"<>|\s]+/g, '-')
+  return new Date(item.timestamp).toISOString().slice(0, 10)
+}
+
+function toCsvCell(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  const text = String(value)
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
+}
+
+export function useRangeSelection(options: {
+  controller: Ref<ChartController | null>
+  activeToolId: Ref<string>
+  containerRef: Ref<HTMLElement | null>
+}) {
+  const { controller, activeToolId, containerRef } = options
+
+  const containerScrollLeft = ref(0)
+  const rangeSelection = ref<RangeSelectionState>({
+    startIndex: null,
+    endIndex: null,
+    isDragging: false,
+  })
+
+  const isRangeSelectActive = computed(() => activeToolId.value === 'range-select')
+
+  const rangeSelectionReady = computed(
+    () =>
+      rangeSelection.value.startIndex !== null && rangeSelection.value.endIndex !== null,
+  )
+
+  const rangeSelectionBounds: ComputedRef<Bounds | null> = computed(() => {
+    const data = controller.value?.getData() ?? []
+    const { startIndex, endIndex } = rangeSelection.value
+    if (startIndex === null || endIndex === null || data.length === 0) return null
+
+    const last = data.length - 1
+    const start = Math.max(0, Math.min(startIndex, endIndex, last))
+    const end = Math.max(0, Math.min(Math.max(startIndex, endIndex), last))
+    return { start, end }
+  })
+
+  const rangeSelectionDateLabel: ComputedRef<string> = computed(() => {
+    const bounds = rangeSelectionBounds.value
+    const data = controller.value?.getData() ?? []
+    if (!bounds || data.length === 0) return ''
+
+    const first = data[bounds.start]
+    const last = data[bounds.end]
+    const fmt = (item: KLineData | undefined) => {
+      if (!item) return '?'
+      if (item.date) return item.date
+      return new Date(item.timestamp).toISOString().slice(0, 10)
+    }
+    if (bounds.start === bounds.end) return fmt(first)
+    return `${fmt(first)} ~ ${fmt(last)}`
+  })
+
+  const rangeSelectionOverlayStyle = computed(() => {
+    const bounds = rangeSelectionBounds.value
+    if (!bounds) return null
+
+    const ctrl = controller.value
+    const viewport = ctrl?.getViewport()
+    const container = containerRef.value
+    if (!ctrl || !viewport || !container) return null
+
+    const { kWidth: currentKWidth, kGap: currentKGap } = ctrl.getKWidthKGap()
+    const dpr = ctrl.getCurrentDpr()
+    const kWidthPx = Math.max(
+      1,
+      Math.round(currentKWidth * dpr) + (Math.round(currentKWidth * dpr) % 2 === 0 ? 1 : 0),
+    )
+    const kGapPx = Math.round(currentKGap * dpr)
+    const unitPx = kWidthPx + kGapPx
+    const startXPx = kGapPx
+
+    const leftBuffer = container.scrollLeft - viewport.scrollLeft
+    const left = leftBuffer + (startXPx + bounds.start * unitPx) / dpr
+    const right = leftBuffer + (startXPx + bounds.end * unitPx + kWidthPx) / dpr
+    return {
+      left: `${left}px`,
+      width: `${right - left}px`,
+      height: `${viewport.plotHeight}px`,
+    }
+  })
+
+  function clearRangeSelection() {
+    rangeSelection.value = { startIndex: null, endIndex: null, isDragging: false }
+  }
+
+  function getRangeSelectionIndex(e: PointerEvent, container: HTMLElement): number | null {
+    const data = controller.value?.getData() ?? []
+    if (data.length === 0) return null
+
+    const rect = container.getBoundingClientRect()
+    const rawIndex = controller.value?.getLogicalIndexAtX(e.clientX - rect.left)
+    if (rawIndex === null || rawIndex === undefined) return null
+    return Math.max(0, Math.min(rawIndex, data.length - 1))
+  }
+
+  function handleRangePointerDown(e: PointerEvent, container: HTMLElement): boolean {
+    if (!isRangeSelectActive.value) return false
+    const index = getRangeSelectionIndex(e, container)
+    if (index === null) return true
+
+    rangeSelection.value = { startIndex: index, endIndex: index, isDragging: true }
+    container.setPointerCapture?.(e.pointerId)
+    e.preventDefault()
+    return true
+  }
+
+  function handleRangePointerMove(e: PointerEvent, container: HTMLElement): boolean {
+    if (!isRangeSelectActive.value || !rangeSelection.value.isDragging) return false
+    const index = getRangeSelectionIndex(e, container)
+    if (index !== null) {
+      rangeSelection.value = { ...rangeSelection.value, endIndex: index }
+    }
+    e.preventDefault()
+    return true
+  }
+
+  function handleRangePointerUp(e: PointerEvent, container: HTMLElement): boolean {
+    if (!isRangeSelectActive.value || !rangeSelection.value.isDragging) return false
+    const index = getRangeSelectionIndex(e, container)
+    rangeSelection.value = {
+      ...rangeSelection.value,
+      endIndex: index ?? rangeSelection.value.endIndex,
+      isDragging: false,
+    }
+    container.releasePointerCapture?.(e.pointerId)
+    e.preventDefault()
+    return true
+  }
+
+  function exportRangeToCsv() {
+    const bounds = rangeSelectionBounds.value
+    const data = controller.value?.getData() ?? []
+    if (!bounds || data.length === 0) return
+
+    const fields: Array<keyof KLineData> = [
+      'timestamp',
+      'open',
+      'high',
+      'low',
+      'close',
+      'volume',
+      'turnover',
+      'turnoverRate',
+      'stockCode',
+      'amplitude',
+      'changePercent',
+      'changeAmount',
+    ]
+    const selected = data.slice(bounds.start, bounds.end + 1)
+    const header = `time,${fields.join(',')}`
+    const rows = [
+      header,
+      ...selected.map((item) => {
+        const timeStr = toCsvCell(formatTimestamp(item.timestamp, { showTime: true }))
+        return `${timeStr},${fields.map((field) => toCsvCell(item[field])).join(',')}`
+      }),
+    ]
+    const blob = new Blob([`\uFEFF${rows.join('\n')}`], { type: 'text/csv;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `kline-range-${formatRangeFileDate(data[bounds.start])}-${formatRangeFileDate(data[bounds.end])}.csv`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  function onScroll() {
+    const cont = containerRef.value
+    if (cont) containerScrollLeft.value = cont.scrollLeft
+  }
+
+  return {
+    rangeSelection,
+    containerScrollLeft,
+    isRangeSelectActive,
+    rangeSelectionReady,
+    rangeSelectionBounds,
+    rangeSelectionDateLabel,
+    rangeSelectionOverlayStyle,
+    clearRangeSelection,
+    handleRangePointerDown,
+    handleRangePointerMove,
+    handleRangePointerUp,
+    exportRangeToCsv,
+    onScroll,
+  }
+}

--- a/packages/vue/src/tools/calcRangeOverlayPixel.ts
+++ b/packages/vue/src/tools/calcRangeOverlayPixel.ts
@@ -1,0 +1,28 @@
+import type { ChartController } from '@363045841yyt/klinechart-core/controllers'
+
+export interface Bounds {
+  start: number
+  end: number
+}
+
+export function calcRangeOverlayPixel(
+  bounds: Bounds,
+  controller: ChartController,
+  container: HTMLElement,
+  viewport: { scrollLeft: number; plotWidth: number; plotHeight: number },
+): { left: number; width: number; height: number } {
+  const { kWidth: currentKWidth, kGap: currentKGap } = controller.getKWidthKGap()
+  const dpr = controller.getCurrentDpr()
+  const kWidthPx = Math.max(
+    1,
+    Math.round(currentKWidth * dpr) + (Math.round(currentKWidth * dpr) % 2 === 0 ? 1 : 0),
+  )
+  const kGapPx = Math.round(currentKGap * dpr)
+  const unitPx = kWidthPx + kGapPx
+  const startXPx = kGapPx
+
+  const leftBuffer = container.scrollLeft - viewport.scrollLeft
+  const left = leftBuffer + (startXPx + bounds.start * unitPx) / dpr
+  const right = leftBuffer + (startXPx + bounds.end * unitPx + kWidthPx) / dpr
+  return { left, width: right - left, height: viewport.plotHeight }
+}

--- a/packages/vue/src/tools/getKLineIndexByTimestamp.ts
+++ b/packages/vue/src/tools/getKLineIndexByTimestamp.ts
@@ -1,17 +1,40 @@
 import type { KLineData } from '@363045841yyt/klinechart-core/controllers'
 
-export function getKLineIndexByTimestamp(
+function binarySearch(
   data: ReadonlyArray<KLineData>,
   timestamp: number,
-): number | null {
+): { low: number; high: number } {
   let low = 0
   let high = data.length - 1
   while (low <= high) {
     const mid = (low + high) >>> 1
     const ts = data[mid]!.timestamp
-    if (ts === timestamp) return mid
+    if (ts === timestamp) return { low: mid, high: mid }
     if (ts < timestamp) low = mid + 1
     else high = mid - 1
   }
-  return null
+  return { low, high }
+}
+
+export function getKLineIndexByTimestamp(
+  data: ReadonlyArray<KLineData>,
+  timestamp: number,
+): number | null {
+  if (data.length === 0) return null
+  const { low, high } = binarySearch(data, timestamp)
+  return low === high ? low : null
+}
+
+export function findNearestKLineIndex(
+  data: ReadonlyArray<KLineData>,
+  timestamp: number,
+  direction: 'left' | 'right',
+): number | null {
+  if (data.length === 0) return null
+  const { low, high } = binarySearch(data, timestamp)
+  if (low === high) return low
+  if (direction === 'left') {
+    return high >= 0 ? high : (low < data.length ? low : null)
+  }
+  return low < data.length ? low : high
 }

--- a/packages/vue/src/tools/getKLineIndexByTimestamp.ts
+++ b/packages/vue/src/tools/getKLineIndexByTimestamp.ts
@@ -1,0 +1,17 @@
+import type { KLineData } from '@363045841yyt/klinechart-core/controllers'
+
+export function getKLineIndexByTimestamp(
+  data: ReadonlyArray<KLineData>,
+  timestamp: number,
+): number | null {
+  let low = 0
+  let high = data.length - 1
+  while (low <= high) {
+    const mid = (low + high) >>> 1
+    const ts = data[mid]!.timestamp
+    if (ts === timestamp) return mid
+    if (ts < timestamp) low = mid + 1
+    else high = mid - 1
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Add a complete range-select tool to the KLineChart: drag-select a K-line interval, see a visual overlay, edit start/end dates, auto-fetch earlier data, export as CSV with batch multi-stock support.

## Changes

### Core Engine
- **DataBuffer.ensureRange**: Remove 90-day fetch truncation — callers pass the full desired range directly
- **ChartController.ensureDataRange**: New method delegating to dataBuffer.ensureRange
- **ChartDataManager**: Scroll-edge incremental load window increased from 90 → 365 days
- **ChartSettings**: Add `rangeSelectTool` config entry

### Fetcher
- **gotdx**: Map `Amplitude` API field → `KLineData.amplitude`

### Vue Components
- **range-select tool** in LeftToolbar (icon `IconTablerArrowsHorizontal`)
- **Visual overlay** inside `.scroll-content`, with edge drag handles that swap when dragged past the opposite boundary
- **Export toolbar** centered in chart viewport with date inputs, export / delete / batch-set buttons
- **BatchStockDialog**: Modal for entering multiple stock codes
- **ExportProgressDialog**: Progress bar + status label + counter modal

### Composable
- **useRangeSelection**: Timestamp-based anchoring (`startTimestamp`/`endTimestamp` → index via binary search), drag-select, edge resize, date watchers with auto-fetch, CSV export
- Non-trading-day dates: start snaps left, end snaps right
- CSV: `stockCode, time, timestamp, open, high, low, close, volume, turnover, turnoverRate, amplitude, changePercent, changeAmount`
- Batch export: single CSV with A-B-C-D concatenation, sequential fetch
- Filename: `batch{total}-{start}-{end}.csv` / `{mainCode}-{start}-{end}.csv`

### Tools
- **calcRangeOverlayPixel**: Pure function for overlay pixel geometry
- **getKLineIndexByTimestamp**: Binary search + `findNearestKLineIndex` with directional bias

### Files Changed (14 files, +1295/-18)

| Area | Change |
|------|--------|
| core/controllers | +ensureDataRange, interface updates |
| core/data-fetchers | Remove 90-day truncation, Amplitude mapping |
| core/engine/data | 90→365 day scroll-edge window |
| vue/components | BatchStockDialog, ExportProgressDialog (new) |
| vue/components/KLineChart | Tool wiring, viewportVersion, subscriptions |
| vue/composables | Full useRangeSelection logic |
| vue/tools | calcRangeOverlayPixel, getKLineIndexByTimestamp