### PR TITLE
refactor(vue): extract BaseModal and unify dialog/modals

### DIFF
--- a/packages/vue/src/components/BaseModal.vue
+++ b/packages/vue/src/components/BaseModal.vue
@@ -1,0 +1,292 @@
+<template>
+  <Teleport :to="teleportTarget">
+    <Transition name="overlay">
+      <div
+        v-if="show"
+        class="base-overlay"
+        :style="{ zIndex, padding: overlayPadding }"
+        @click="closeOnOverlay ? emit('close') : undefined"
+      >
+        <Transition :name="modalTransitionName">
+          <div
+            class="base-modal"
+            :style="modalStyle"
+            @click.stop
+          >
+            <div v-if="$slots.header || title" class="base-header">
+              <slot name="header">
+                <div class="base-header-left">
+                  <span class="base-title">{{ title }}</span>
+                  <span v-if="subtitle" class="base-subtitle">{{ subtitle }}</span>
+                </div>
+              </slot>
+              <div v-if="showClose" class="base-header-right">
+                <slot name="header-extra" />
+                <button class="base-close-btn" @click="emit('close')">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M18 6L6 18M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            <div v-if="$slots.subheader" class="base-subheader">
+              <slot name="subheader" />
+            </div>
+
+            <div class="base-body" :style="{ padding: bodyPadding }">
+              <slot />
+            </div>
+
+            <div v-if="$slots.footer" class="base-footer" :style="{ justifyContent: footerAlign }">
+              <slot name="footer" />
+            </div>
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+
+const props = withDefaults(
+  defineProps<{
+    show: boolean
+    title?: string
+    subtitle?: string
+    zIndex?: number
+    width?: string
+    maxWidth?: string
+    maxHeight?: string
+    overlayPadding?: string
+    bodyPadding?: string
+    footerAlign?: 'flex-end' | 'center' | 'flex-start' | 'space-between'
+    closeOnOverlay?: boolean
+    showClose?: boolean
+    transitionVariant?: 'default' | 'compact'
+  }>(),
+  {
+    title: '',
+    subtitle: '',
+    zIndex: 1000,
+    width: 'min(92vw, 400px)',
+    maxWidth: '',
+    maxHeight: 'min(600px, calc(100vh - 48px))',
+    overlayPadding: '24px',
+    bodyPadding: '16px 20px',
+    footerAlign: 'flex-end',
+    closeOnOverlay: true,
+    showClose: true,
+    transitionVariant: 'default',
+  },
+)
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const teleportTarget = useFullscreenTeleportTarget()
+
+const modalTransitionName = computed(() =>
+  props.transitionVariant === 'compact' ? 'modal-compact' : 'modal',
+)
+
+const modalStyle = computed(() => ({
+  width: props.width,
+  maxWidth: props.maxWidth || undefined,
+  maxHeight: props.maxHeight,
+}))
+</script>
+
+<style scoped>
+.base-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.base-modal {
+  background: var(--klc-color-background);
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 10px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.base-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px 14px 20px;
+  background: var(--klc-color-background);
+  border-bottom: 1px solid var(--klc-color-grid-major);
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.base-header-left {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.base-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--klc-color-foreground);
+  line-height: 1.35;
+}
+
+.base-subtitle {
+  font-size: 11px;
+  color: var(--klc-color-axis-text);
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.base-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.base-close-btn {
+  background: var(--klc-color-background);
+  border: 1px solid var(--klc-color-border-button);
+  border-radius: 7px;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--klc-color-axis-text);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  padding: 0;
+}
+
+.base-close-btn:hover {
+  background: var(--klc-color-tag-bg-hover);
+  color: var(--klc-color-foreground);
+  border-color: var(--klc-color-axis-line);
+}
+
+.base-close-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.base-subheader {
+  flex-shrink: 0;
+  padding: 16px 20px;
+  background: var(--klc-color-background);
+  border-bottom: 1px solid var(--klc-color-grid-major);
+}
+
+.base-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--klc-color-background);
+}
+
+.base-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.base-body::-webkit-scrollbar-track {
+  background: var(--klc-color-background);
+}
+
+.base-body::-webkit-scrollbar-thumb {
+  background: var(--klc-color-axis-line);
+  border: 2px solid var(--klc-color-background);
+  border-radius: 999px;
+}
+
+.base-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px;
+  background: var(--klc-color-background);
+  border-top: 1px solid var(--klc-color-grid-major);
+  flex-shrink: 0;
+}
+
+/* ── Overlay transition ── */
+.overlay-enter-active,
+.overlay-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.overlay-enter-from,
+.overlay-leave-to {
+  opacity: 0;
+}
+
+/* ── Modal transition (default variant) ── */
+.modal-enter-active {
+  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.modal-leave-active {
+  transition: all 0.16s ease-in;
+}
+
+.modal-enter-from {
+  opacity: 0;
+  transform: scale(0.96) translateY(-10px);
+}
+
+.modal-leave-to {
+  opacity: 0;
+  transform: scale(0.98) translateY(8px);
+}
+
+/* ── Modal transition (compact variant) ── */
+.modal-compact-enter-active {
+  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.modal-compact-leave-active {
+  transition: all 0.16s ease-in;
+}
+
+.modal-compact-enter-from {
+  opacity: 0;
+  transform: scale(0.88) translateY(-16px);
+}
+
+.modal-compact-leave-to {
+  opacity: 0;
+  transform: scale(0.94) translateY(8px);
+}
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .base-overlay {
+    padding: 12px;
+    align-items: flex-end;
+  }
+
+  .base-modal {
+    min-width: 0;
+    width: 100% !important;
+    max-height: calc(100vh - 24px);
+    border-radius: 10px;
+  }
+}
+</style>

--- a/packages/vue/src/components/BatchStockDialog.vue
+++ b/packages/vue/src/components/BatchStockDialog.vue
@@ -1,42 +1,22 @@
 <template>
-  <Teleport :to="teleportTarget">
-    <Transition name="overlay">
-      <div v-if="show" class="batch-overlay" @click="emit('close')">
-        <Transition name="modal">
-          <div class="batch-modal" @click.stop>
-            <div class="batch-header">
-              <span class="batch-title">批量设置股票代码</span>
-              <button class="batch-close-btn" @click="emit('close')">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M18 6L6 18M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-
-            <div class="batch-body">
-              <textarea
-                v-model="codesText"
-                class="batch-textarea"
-                placeholder="每行一个股票代码&#10;例如:&#10;000001&#10;600036&#10;002415"
-                rows="8"
-                spellcheck="false"
-              />
-            </div>
-
-            <div class="batch-footer">
-              <button class="batch-btn batch-btn--cancel" @click="emit('close')">取消</button>
-              <button class="batch-btn batch-btn--confirm" @click="onApply">应用</button>
-            </div>
-          </div>
-        </Transition>
-      </div>
-    </Transition>
-  </Teleport>
+  <BaseModal title="批量设置股票代码" :show="show" @close="emit('close')">
+    <textarea
+      v-model="codesText"
+      class="batch-textarea"
+      placeholder="每行一个股票代码，导出时会将所选区间内这些品种的数据一并导出&#10;例如:&#10;000001&#10;600036&#10;002415"
+      rows="8"
+      spellcheck="false"
+    />
+    <template #footer>
+      <button class="batch-btn batch-btn--cancel" @click="emit('close')">取消</button>
+      <button class="batch-btn batch-btn--confirm" @click="onApply">应用</button>
+    </template>
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+import BaseModal from './BaseModal.vue'
 
 const props = defineProps<{
   show: boolean
@@ -46,8 +26,6 @@ const emit = defineEmits<{
   close: []
   apply: [codes: string[]]
 }>()
-
-const teleportTarget = useFullscreenTeleportTarget()
 
 const codes = ref<string[]>([])
 
@@ -69,88 +47,10 @@ function onApply() {
 </script>
 
 <style scoped>
-.batch-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(4px);
-  padding: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.batch-modal {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 10px;
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.15);
-  min-width: 360px;
-  max-width: 400px;
-  width: min(92vw, 400px);
-  max-height: min(600px, calc(100vh - 48px));
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.batch-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 14px 18px 14px 20px;
-  background: var(--klc-color-background);
-  border-bottom: 1px solid var(--klc-color-grid-major);
-  flex-shrink: 0;
-}
-
-.batch-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--klc-color-foreground);
-  line-height: 1.35;
-}
-
-.batch-close-btn {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 7px;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--klc-color-axis-text);
-  transition:
-    background 0.15s,
-    color 0.15s,
-    border-color 0.15s;
-  padding: 0;
-}
-
-.batch-close-btn:hover {
-  background: var(--klc-color-tag-bg-hover);
-  color: var(--klc-color-foreground);
-  border-color: var(--klc-color-axis-line);
-}
-
-.batch-close-btn svg {
-  width: 14px;
-  height: 14px;
-}
-
-.batch-body {
-  padding: 16px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
 .batch-textarea {
   width: 100%;
   min-height: 160px;
+  max-height: 100%;
   padding: 10px 12px;
   border: 1px solid var(--klc-color-border-button);
   border-radius: 6px;
@@ -172,17 +72,6 @@ function onApply() {
 .batch-textarea::placeholder {
   color: var(--klc-color-axis-text);
   opacity: 0.5;
-}
-
-.batch-footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
-  padding: 12px 20px;
-  background: var(--klc-color-background);
-  border-top: 1px solid var(--klc-color-grid-major);
-  flex-shrink: 0;
 }
 
 .batch-btn {
@@ -235,59 +124,5 @@ function onApply() {
 .batch-btn--confirm:active {
   transform: translateY(0);
   box-shadow: none;
-}
-
-.overlay-enter-active,
-.overlay-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.overlay-enter-from,
-.overlay-leave-to {
-  opacity: 0;
-}
-
-.modal-enter-active {
-  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.modal-leave-active {
-  transition: all 0.16s ease-in;
-}
-
-.modal-enter-from {
-  opacity: 0;
-  transform: scale(0.96) translateY(-10px);
-}
-
-.modal-leave-to {
-  opacity: 0;
-  transform: scale(0.98) translateY(8px);
-}
-
-@media (max-width: 480px) {
-  .batch-overlay {
-    padding: 12px;
-    align-items: flex-end;
-  }
-
-  .batch-modal {
-    min-width: 0;
-    width: 100%;
-    max-height: calc(100vh - 24px);
-    border-radius: 10px;
-  }
-
-  .batch-header,
-  .batch-body,
-  .batch-footer {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-
-  .batch-footer {
-    flex-direction: column-reverse;
-    align-items: stretch;
-  }
 }
 </style>

--- a/packages/vue/src/components/ChartSettingsDialog.vue
+++ b/packages/vue/src/components/ChartSettingsDialog.vue
@@ -1,183 +1,151 @@
 <template>
-  <Teleport :to="teleportTarget">
-    <Transition name="overlay">
-      <div v-if="show" class="settings-overlay" @click="closeSettings">
-        <Transition name="modal">
-          <div class="settings-modal" @click.stop>
-            <div class="settings-header">
-              <div class="header-left">
-                <span class="settings-title">图表设置</span>
-                <span class="settings-subtitle">个性化配置</span>
-              </div>
-              <div class="header-right">
-                <button class="settings-close" @click="closeSettings">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M18 6L6 18M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-
-            <div class="settings-body">
-              <template v-if="mainSettings.length > 0">
-                <div class="settings-section-divider">
-                  <span class="settings-section-label">主图设置</span>
-                </div>
-                <template v-for="item in mainSettings" :key="item.key">
-                  <div class="settings-item">
-                    <label class="settings-label">
-                      <span>{{ item.label }}</span>
-                      <template v-if="item.type === 'boolean'">
-                        <input
-                          type="checkbox"
-                          class="settings-checkbox"
-                          v-model="settings[item.key]"
-                        />
-                      </template>
-                      <template v-else-if="item.type === 'select' && item.options">
-                        <Dropdown
-                          :model-value="String(settings[item.key])"
-                          :options="item.options"
-                          size="sm"
-                          min-width="100px"
-                          @update:model-value="settings[item.key] = $event"
-                        />
-                      </template>
-                    </label>
-                  </div>
-                </template>
-              </template>
-
-              <div class="settings-section-divider">
-                <span class="settings-section-label">样式 / 颜色</span>
-              </div>
-              <template v-for="item in styleSettings" :key="item.key">
-                <div class="settings-item">
-                  <label class="settings-label">
-                    <span>{{ item.label }}</span>
-                    <template v-if="item.type === 'boolean'">
-                      <input
-                        type="checkbox"
-                        class="settings-checkbox"
-                        v-model="settings[item.key]"
-                      />
-                    </template>
-                    <template v-else-if="item.type === 'select' && item.options">
-                      <Dropdown
-                        :model-value="String(settings[item.key])"
-                        :options="item.options"
-                        size="sm"
-                        min-width="100px"
-                        @update:model-value="settings[item.key] = $event"
-                      />
-                    </template>
-                  </label>
-                </div>
-              </template>
-              <div class="settings-item nav-item" @click="showColorPresetModal = true">
-                <label class="settings-label">
-                  <span>颜色配置</span>
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    width="16"
-                    height="16"
-                    class="nav-arrow"
-                  >
-                    <path d="M9 18l6-6-6-6" />
-                  </svg>
-                </label>
-              </div>
-
-              <template v-if="experimentalSettings.length > 0">
-                <div class="settings-section-divider">
-                  <span class="settings-section-label">实验性 / 调试设置</span>
-                </div>
-                <template v-for="item in experimentalSettings" :key="item.key">
-                  <div class="settings-item experimental">
-                    <label class="settings-label">
-                      <span>{{ item.label }}</span>
-                      <template v-if="item.type === 'boolean'">
-                        <input
-                          type="checkbox"
-                          class="settings-checkbox"
-                          v-model="settings[item.key]"
-                        />
-                      </template>
-                      <template v-else-if="item.type === 'select' && item.options">
-                        <Dropdown
-                          :model-value="String(settings[item.key])"
-                          :options="item.options"
-                          size="sm"
-                          min-width="100px"
-                          @update:model-value="settings[item.key] = $event"
-                        />
-                      </template>
-                    </label>
-                  </div>
-                </template>
-              </template>
-            </div>
-
-            <div class="settings-footer">
-              <button class="settings-btn reset" @click="resetSettings">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                  <path d="M3 3v5h5" />
-                </svg>
-                重置
-              </button>
-              <div class="footer-right">
-                <button class="settings-btn cancel" @click="closeSettings">取消</button>
-                <button class="settings-btn confirm" @click="confirmSettings">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                    <path d="M20 6L9 17l-5-5" />
-                  </svg>
-                  确定
-                </button>
-              </div>
-            </div>
-          </div>
-        </Transition>
+  <!-- 主弹窗 -->
+  <BaseModal
+    :show="show"
+    width="min(92vw, 460px)"
+    max-height="min(720px, calc(100vh - 48px))"
+    footer-align="space-between"
+    @close="closeSettings"
+  >
+    <template #header>
+      <div class="header-left">
+        <span class="settings-title">图表设置</span>
+        <span class="settings-subtitle">个性化配置</span>
       </div>
-    </Transition>
+    </template>
 
-    <Transition name="overlay">
-      <div
-        v-if="showColorPresetModal"
-        class="settings-overlay nested-overlay"
-        @click="showColorPresetModal = false"
-      >
-        <Transition name="modal">
-          <div class="settings-modal" @click.stop>
-            <div class="settings-header">
-              <div class="header-left">
-                <span class="settings-title">颜色预设</span>
-                <span class="settings-subtitle">自定义图表颜色</span>
-              </div>
-              <div class="header-right">
-                <button class="settings-close" @click="showColorPresetModal = false">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M18 6L6 18M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-            <div class="settings-body">
-              <ColorPresetPanel
-                :color-preset-settings="settings.colorPresetSettings"
-                @update:color-preset-settings="
-                  settings = { ...settings, colorPresetSettings: $event }
-                "
+    <div class="settings-body">
+      <template v-if="mainSettings.length > 0">
+        <div class="settings-section-divider">
+          <span class="settings-section-label">主图设置</span>
+        </div>
+        <template v-for="item in mainSettings" :key="item.key">
+          <div class="settings-item">
+            <label class="settings-label">
+              <span>{{ item.label }}</span>
+              <template v-if="item.type === 'boolean'">
+                <input
+                  type="checkbox"
+                  class="settings-checkbox"
+                  v-model="settings[item.key]"
+                />
+              </template>
+              <template v-else-if="item.type === 'select' && item.options">
+                <Dropdown
+                  :model-value="String(settings[item.key])"
+                  :options="item.options"
+                  size="sm"
+                  min-width="100px"
+                  @update:model-value="settings[item.key] = $event"
+                />
+              </template>
+            </label>
+          </div>
+        </template>
+      </template>
+
+      <div class="settings-section-divider">
+        <span class="settings-section-label">样式 / 颜色</span>
+      </div>
+      <template v-for="item in styleSettings" :key="item.key">
+        <div class="settings-item">
+          <label class="settings-label">
+            <span>{{ item.label }}</span>
+            <template v-if="item.type === 'boolean'">
+              <input
+                type="checkbox"
+                class="settings-checkbox"
+                v-model="settings[item.key]"
               />
-            </div>
-          </div>
-        </Transition>
+            </template>
+            <template v-else-if="item.type === 'select' && item.options">
+              <Dropdown
+                :model-value="String(settings[item.key])"
+                :options="item.options"
+                size="sm"
+                min-width="100px"
+                @update:model-value="settings[item.key] = $event"
+              />
+            </template>
+          </label>
+        </div>
+      </template>
+      <div class="settings-item nav-item" @click="showColorPresetModal = true">
+        <label class="settings-label">
+          <span>颜色配置</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16" class="nav-arrow">
+            <path d="M9 18l6-6-6-6" />
+          </svg>
+        </label>
       </div>
-    </Transition>
-  </Teleport>
+
+      <template v-if="experimentalSettings.length > 0">
+        <div class="settings-section-divider">
+          <span class="settings-section-label">实验性 / 调试设置</span>
+        </div>
+        <template v-for="item in experimentalSettings" :key="item.key">
+          <div class="settings-item experimental">
+            <label class="settings-label">
+              <span>{{ item.label }}</span>
+              <template v-if="item.type === 'boolean'">
+                <input
+                  type="checkbox"
+                  class="settings-checkbox"
+                  v-model="settings[item.key]"
+                />
+              </template>
+              <template v-else-if="item.type === 'select' && item.options">
+                <Dropdown
+                  :model-value="String(settings[item.key])"
+                  :options="item.options"
+                  size="sm"
+                  min-width="100px"
+                  @update:model-value="settings[item.key] = $event"
+                />
+              </template>
+            </label>
+          </div>
+        </template>
+      </template>
+    </div>
+
+    <template #footer>
+      <button class="settings-btn reset" @click="resetSettings">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
+        </svg>
+        重置
+      </button>
+      <div class="footer-right">
+        <button class="settings-btn cancel" @click="closeSettings">取消</button>
+        <button class="settings-btn confirm" @click="confirmSettings">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+            <path d="M20 6L9 17l-5-5" />
+          </svg>
+          确定
+        </button>
+      </div>
+    </template>
+  </BaseModal>
+
+  <!-- 嵌套颜色预设弹窗 -->
+  <BaseModal
+    :show="showColorPresetModal"
+    title="颜色预设"
+    subtitle="自定义图表颜色"
+    width="min(92vw, 460px)"
+    max-height="min(720px, calc(100vh - 48px))"
+    :z-index="1100"
+    @close="showColorPresetModal = false"
+  >
+    <ColorPresetPanel
+      :color-preset-settings="settings.colorPresetSettings"
+      @update:color-preset-settings="
+        settings = { ...settings, colorPresetSettings: $event }
+      "
+    />
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
@@ -189,8 +157,8 @@ import {
   type SettingItem,
 } from '@363045841yyt/klinechart-core/config'
 import { normalizeColorPresetSettings } from '@363045841yyt/klinechart-core'
+import BaseModal from './BaseModal.vue'
 import ColorPresetPanel from './ColorPresetPanel.vue'
-import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
 import Dropdown from './Dropdown.vue'
 
 const props = defineProps<{
@@ -201,8 +169,6 @@ const emit = defineEmits<{
   (e: 'close'): void
   (e: 'confirm', settings: ChartSettings): void
 }>()
-
-const teleportTarget = useFullscreenTeleportTarget()
 
 const mainSettings = computed(
   () => DEFAULT_SETTINGS.filter((s) => s.group === 'main') as unknown as SettingItem[],
@@ -267,53 +233,11 @@ function confirmSettings() {
 </script>
 
 <style scoped>
-.settings-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(4px);
-  padding: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.settings-modal {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 10px;
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.15);
-  min-width: 360px;
-  max-width: 460px;
-  width: min(92vw, 460px);
-  max-height: min(720px, calc(100vh - 48px));
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.settings-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 14px 18px 14px 20px;
-  background: var(--klc-color-background);
-  border-bottom: 1px solid var(--klc-color-grid-major);
-  flex-shrink: 0;
-}
-
 .header-left {
   display: flex;
   flex-direction: column;
   gap: 2px;
   min-width: 0;
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 .settings-title {
@@ -329,52 +253,10 @@ function confirmSettings() {
   line-height: 1.3;
 }
 
-.settings-close {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 7px;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--klc-color-axis-text);
-  transition:
-    background 0.15s,
-    color 0.15s,
-    border-color 0.15s;
-  padding: 0;
-}
-
-.settings-close:hover {
-  background: var(--klc-color-tag-bg-hover);
-  color: var(--klc-color-foreground);
-  border-color: var(--klc-color-axis-line);
-}
-
-.settings-close svg {
-  width: 14px;
-  height: 14px;
-}
-
 .settings-body {
-  padding: 16px 20px 18px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-}
-
-.settings-body::-webkit-scrollbar {
-  width: 8px;
-}
-
-.settings-body::-webkit-scrollbar-thumb {
-  background: var(--klc-color-axis-line);
-  border: 2px solid var(--klc-color-tag-bg-white);
-  border-radius: 999px;
 }
 
 .settings-item {
@@ -390,7 +272,7 @@ function confirmSettings() {
 
 .settings-item:hover {
   border-color: var(--klc-color-axis-line);
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
 }
 
 .settings-label {
@@ -443,10 +325,6 @@ function confirmSettings() {
   line-height: 1;
 }
 
-.nested-overlay {
-  z-index: 1100;
-}
-
 .settings-item.nav-item {
   cursor: pointer;
 }
@@ -458,17 +336,6 @@ function confirmSettings() {
 .nav-arrow {
   color: var(--klc-color-axis-text);
   transition: color 0.15s;
-  flex-shrink: 0;
-}
-
-.settings-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 20px;
-  background: var(--klc-color-background);
-  border-top: 1px solid var(--klc-color-grid-major);
   flex-shrink: 0;
 }
 
@@ -550,54 +417,7 @@ function confirmSettings() {
   box-shadow: none;
 }
 
-.overlay-enter-active,
-.overlay-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.overlay-enter-from,
-.overlay-leave-to {
-  opacity: 0;
-}
-
-.modal-enter-active {
-  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.modal-leave-active {
-  transition: all 0.16s ease-in;
-}
-
-.modal-enter-from {
-  opacity: 0;
-  transform: scale(0.96) translateY(-10px);
-}
-
-.modal-leave-to {
-  opacity: 0;
-  transform: scale(0.98) translateY(8px);
-}
-
 @media (max-width: 480px) {
-  .settings-overlay {
-    padding: 12px;
-    align-items: flex-end;
-  }
-
-  .settings-modal {
-    min-width: 0;
-    width: 100%;
-    max-height: calc(100vh - 24px);
-    border-radius: 10px;
-  }
-
-  .settings-header,
-  .settings-body,
-  .settings-footer {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-
   .settings-label {
     align-items: flex-start;
     flex-direction: column;
@@ -607,11 +427,6 @@ function confirmSettings() {
   .settings-checkbox {
     align-self: flex-end;
     margin-top: -26px;
-  }
-
-  .settings-footer {
-    align-items: stretch;
-    flex-direction: column-reverse;
   }
 
   .footer-right {

--- a/packages/vue/src/components/ColorPresetPanel.vue
+++ b/packages/vue/src/components/ColorPresetPanel.vue
@@ -145,11 +145,11 @@ function resetCurrentThemeColors(): void {
 
 .theme-tab:not(.active):hover {
   color: var(--klc-color-foreground);
-  background: color-mix(in srgb, var(--klc-color-tag-bg-white) 60%, transparent);
+  background: color-mix(in srgb, var(--klc-color-background) 60%, transparent);
 }
 
 .theme-tab.active {
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   color: var(--klc-color-foreground);
   font-weight: 600;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
@@ -161,7 +161,7 @@ function resetCurrentThemeColors(): void {
   padding: 0 14px;
   border: 1px solid var(--klc-color-axis-line);
   border-radius: 8px;
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   color: var(--klc-color-axis-text);
   font-size: 12px;
   font-weight: 500;

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -332,7 +332,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
 }
 
 .compare-popover {
-  z-index: 20;
+  z-index: 110;
   width: min(360px, calc(100vw - 24px));
   padding: 14px;
   border: 1px solid var(--klc-color-border-button);

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -337,7 +337,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocumentClick)
   padding: 14px;
   border: 1px solid var(--klc-color-border-button);
   border-radius: 3px;
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   color: var(--klc-color-foreground);
 
   box-sizing: border-box;

--- a/packages/vue/src/components/DrawingStyleToolbar.vue
+++ b/packages/vue/src/components/DrawingStyleToolbar.vue
@@ -102,7 +102,7 @@ function onLineStyleChange(style: 'solid' | 'dashed' | 'dotted') {
   gap: 6px;
   padding: 4px 8px;
   height: 32px;
-  background: color-mix(in srgb, var(--klc-color-tag-bg-white) 88%, transparent);
+  background: color-mix(in srgb, var(--klc-color-background) 88%, transparent);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid var(--klc-color-border-button);

--- a/packages/vue/src/components/ExportProgressDialog.vue
+++ b/packages/vue/src/components/ExportProgressDialog.vue
@@ -1,42 +1,34 @@
 <template>
-  <Teleport :to="teleportTarget">
-    <Transition name="overlay">
-      <div v-if="progress" class="export-overlay">
-        <Transition name="modal">
-          <div class="export-modal" @click.stop>
-            <div class="export-header">
-              <span class="export-title">导出数据</span>
-              <button class="export-close-btn" @click="emit('close')">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M18 6L6 18M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div class="export-body">
-              <div class="export-label">{{ progress.label }}</div>
-              <div class="export-bar-track">
-                <div
-                  class="export-bar-fill"
-                  :style="{ width: pct + '%' }"
-                />
-              </div>
-              <div class="export-counter">{{ progress.current }} / {{ progress.total }}</div>
-              <button
-                v-if="progress.current === progress.total"
-                class="export-done-btn"
-                @click="emit('close')"
-              >完成</button>
-            </div>
-          </div>
-        </Transition>
+  <BaseModal
+    title="导出数据"
+    :show="!!progress"
+    :z-index="1100"
+    :close-on-overlay="false"
+    footer-align="center"
+    @close="emit('close')"
+  >
+    <div class="export-body">
+      <div class="export-label">{{ progress?.label }}</div>
+      <div class="export-bar-track">
+        <div class="export-bar-fill" :style="{ width: pct + '%' }" />
       </div>
-    </Transition>
-  </Teleport>
+      <div class="export-counter">{{ progress?.current ?? 0 }} / {{ progress?.total ?? 0 }}</div>
+    </div>
+    <template #footer>
+      <button
+        v-if="progress && progress.current === progress.total"
+        class="export-done-btn"
+        @click="emit('close')"
+      >
+        完成
+      </button>
+    </template>
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+import BaseModal from './BaseModal.vue'
 
 const props = defineProps<{
   progress: { current: number; total: number; label: string } | null
@@ -46,8 +38,6 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const teleportTarget = useFullscreenTeleportTarget()
-
 const pct = computed(() => {
   if (!props.progress || props.progress.total <= 0) return 0
   return Math.min(100, Math.round((props.progress.current / props.progress.total) * 100))
@@ -55,76 +45,7 @@ const pct = computed(() => {
 </script>
 
 <style scoped>
-.export-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(4px);
-  padding: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1100;
-}
-
-.export-modal {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 10px;
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.15);
-  min-width: 320px;
-  max-width: 380px;
-  width: min(88vw, 380px);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.export-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 14px 18px 0 20px;
-}
-
-.export-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--klc-color-foreground);
-  line-height: 1.35;
-}
-
-.export-close-btn {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 7px;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--klc-color-axis-text);
-  transition:
-    background 0.15s,
-    color 0.15s,
-    border-color 0.15s;
-  padding: 0;
-}
-
-.export-close-btn:hover {
-  background: var(--klc-color-tag-bg-hover);
-  color: var(--klc-color-foreground);
-  border-color: var(--klc-color-axis-line);
-}
-
-.export-close-btn svg {
-  width: 14px;
-  height: 14px;
-}
-
 .export-body {
-  padding: 16px 20px 24px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -175,7 +96,6 @@ const pct = computed(() => {
   background: var(--klc-color-foreground);
   border-color: var(--klc-color-foreground);
   color: var(--klc-color-background);
-  align-self: center;
   transition:
     background 0.15s,
     box-shadow 0.15s,
@@ -194,33 +114,5 @@ const pct = computed(() => {
 .export-done-btn:active {
   transform: translateY(0);
   box-shadow: none;
-}
-
-.overlay-enter-active,
-.overlay-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.overlay-enter-from,
-.overlay-leave-to {
-  opacity: 0;
-}
-
-.modal-enter-active {
-  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.modal-leave-active {
-  transition: all 0.16s ease-in;
-}
-
-.modal-enter-from {
-  opacity: 0;
-  transform: scale(0.96) translateY(-10px);
-}
-
-.modal-leave-to {
-  opacity: 0;
-  transform: scale(0.98) translateY(8px);
 }
 </style>

--- a/packages/vue/src/components/IndicatorParams.vue
+++ b/packages/vue/src/components/IndicatorParams.vue
@@ -1,123 +1,110 @@
 <template>
-  <Teleport :to="teleportTarget">
-    <Transition name="overlay">
-      <div v-if="visible" class="params-overlay" @click="$emit('close')">
-        <Transition name="modal">
-          <div class="indicator-params" @click.stop>
-            <!-- 头部 -->
-            <div class="params-header">
-              <div class="header-left">
-                <span class="params-title">{{ indicatorName }}</span>
-                <span class="params-subtitle">参数设置</span>
-              </div>
-              <div class="header-right">
-                <button
-                  class="toggle-desc-btn"
-                  :class="{ active: showDescription }"
-                  @click="showDescription = !showDescription"
-                  title="显示/隐藏说明"
-                >
-                  <svg viewBox="0 0 1024 1024">
-                    <path d="M512 97.52381c228.912762 0 414.47619 185.563429 414.47619 414.47619s-185.563429 414.47619-414.47619 414.47619S97.52381 740.912762 97.52381 512 283.087238 97.52381 512 97.52381z m0 73.142857C323.486476 170.666667 170.666667 323.486476 170.666667 512s152.81981 341.333333 341.333333 341.333333 341.333333-152.81981 341.333333-341.333333S700.513524 170.666667 512 170.666667z m36.571429 268.190476v292.571428h-73.142858V438.857143h73.142858z m0-121.904762v73.142857h-73.142858v-73.142857h73.142858z" fill="currentColor" />
-                  </svg>
-                </button>
-                <button class="params-close" @click="$emit('close')">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M18 6L6 18M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-            </div>
+  <BaseModal
+    :show="visible"
+    :title="indicatorName"
+    subtitle="参数设置"
+    width="90vw"
+    max-width="420px"
+    transition-variant="compact"
+    overlay-padding="0"
+    footer-align="space-between"
+    @close="$emit('close')"
+  >
+    <template #header-extra>
+      <button
+        class="toggle-desc-btn"
+        :class="{ active: showDescription }"
+        @click="showDescription = !showDescription"
+        title="显示/隐藏说明"
+      >
+        <svg viewBox="0 0 1024 1024">
+          <path d="M512 97.52381c228.912762 0 414.47619 185.563429 414.47619 414.47619s-185.563429 414.47619-414.47619 414.47619S97.52381 740.912762 97.52381 512 283.087238 97.52381 512 97.52381z m0 73.142857C323.486476 170.666667 170.666667 323.486476 170.666667 512s152.81981 341.333333 341.333333 341.333333 341.333333-152.81981 341.333333-341.333333S700.513524 170.666667 512 170.666667z m36.571429 268.190476v292.571428h-73.142858V438.857143h73.142858z m0-121.904762v73.142857h-73.142858v-73.142857h73.142858z" fill="currentColor" />
+        </svg>
+      </button>
+    </template>
 
-            <!-- 指标描述 -->
-            <Transition name="slide">
-              <div v-if="showDescription && indicatorDescription" class="indicator-description">
-                <p>{{ indicatorDescription }}</p>
-              </div>
-            </Transition>
+    <Transition name="slide">
+      <div v-if="showDescription && indicatorDescription" class="indicator-description">
+        <p>{{ indicatorDescription }}</p>
+      </div>
+    </Transition>
 
-            <!-- 体部 -->
-            <div class="params-body">
-              <div
-                v-for="param in params"
-                :key="param.key"
-                class="param-item"
-                :class="{ 'has-desc': showDescription && param.description }"
-              >
-                <div class="param-header">
-                  <label class="param-label">
-                    <span class="param-label-text">{{ param.label }}</span>
-                    <span
-                      v-if="param.min !== undefined || param.max !== undefined"
-                      class="param-range"
-                    >
-                      {{ param.min ?? '-∞' }} ~ {{ param.max ?? '+∞' }}
-                    </span>
-                  </label>
-                  <div class="input-wrapper">
-                    <button
-                      class="stepper-btn"
-                      :disabled="param.min !== undefined && (localValues[param.key] ?? 0) <= param.min"
-                      @click="step(param, -1)"
-                    >
-                      −
-                    </button>
-                    <input
-                      v-if="param.type === 'number'"
-                      type="number"
-                      class="param-input"
-                      :value="localValues[param.key]"
-                      :min="param.min"
-                      :max="param.max"
-                      :step="param.step || 1"
-                      @input="onInput(param.key, $event)"
-                    />
-                    <button
-                      class="stepper-btn"
-                      :disabled="param.max !== undefined && (localValues[param.key] ?? 0) >= param.max"
-                      @click="step(param, 1)"
-                    >
-                      +
-                    </button>
-                  </div>
-                </div>
-                <Transition name="slide">
-                  <div v-if="showDescription && param.description" class="param-description">
-                    {{ param.description }}
-                  </div>
-                </Transition>
-              </div>
-            </div>
-
-            <!-- 底部 -->
-            <div class="params-footer">
-              <button class="params-btn reset" @click="onReset">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                  <path d="M3 3v5h5" />
-                </svg>
-                重置
-              </button>
-              <div class="footer-right">
-                <button class="params-btn cancel" @click="$emit('close')">取消</button>
-                <button class="params-btn confirm" @click="onConfirm">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                    <path d="M20 6L9 17l-5-5" />
-                  </svg>
-                  确定
-                </button>
-              </div>
-            </div>
+    <div class="params-body">
+      <div
+        v-for="param in params"
+        :key="param.key"
+        class="param-item"
+        :class="{ 'has-desc': showDescription && param.description }"
+      >
+        <div class="param-header">
+          <label class="param-label">
+            <span class="param-label-text">{{ param.label }}</span>
+            <span
+              v-if="param.min !== undefined || param.max !== undefined"
+              class="param-range"
+            >
+              {{ param.min ?? '-∞' }} ~ {{ param.max ?? '+∞' }}
+            </span>
+          </label>
+          <div class="input-wrapper">
+            <button
+              class="stepper-btn"
+              :disabled="param.min !== undefined && (localValues[param.key] ?? 0) <= param.min"
+              @click="step(param, -1)"
+            >
+              −
+            </button>
+            <input
+              v-if="param.type === 'number'"
+              type="number"
+              class="param-input"
+              :value="localValues[param.key]"
+              :min="param.min"
+              :max="param.max"
+              :step="param.step || 1"
+              @input="onInput(param.key, $event)"
+            />
+            <button
+              class="stepper-btn"
+              :disabled="param.max !== undefined && (localValues[param.key] ?? 0) >= param.max"
+              @click="step(param, 1)"
+            >
+              +
+            </button>
+          </div>
+        </div>
+        <Transition name="slide">
+          <div v-if="showDescription && param.description" class="param-description">
+            {{ param.description }}
           </div>
         </Transition>
       </div>
-    </Transition>
-  </Teleport>
+    </div>
+
+    <template #footer>
+      <button class="params-btn reset" @click="onReset">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+          <path d="M3 3v5h5" />
+        </svg>
+        重置
+      </button>
+      <div class="footer-right">
+        <button class="params-btn cancel" @click="$emit('close')">取消</button>
+        <button class="params-btn confirm" @click="onConfirm">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+            <path d="M20 6L9 17l-5-5" />
+          </svg>
+          确定
+        </button>
+      </div>
+    </template>
+  </BaseModal>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
-import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+import { ref, watch } from 'vue'
+import BaseModal from './BaseModal.vue'
 
 export interface ParamConfig {
   key: string
@@ -147,21 +134,19 @@ const emit = defineEmits<{
 const localValues = ref<Record<string, number>>({ ...props.values })
 const showDescription = ref(true)
 
-const teleportTarget = useFullscreenTeleportTarget()
-
 watch(
   () => props.values,
   (newValues) => {
     localValues.value = { ...newValues }
   },
-  { deep: true, immediate: true }
+  { deep: true, immediate: true },
 )
 
 watch(
   () => props.visible,
   (visible) => {
     if (visible) localValues.value = { ...props.values }
-  }
+  },
 )
 
 function onInput(key: string, event: Event) {
@@ -192,122 +177,6 @@ function onConfirm() {
 </script>
 
 <style scoped>
-/* ── 遮罩 ── */
-.params-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(4px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-/* ── 弹窗 ── */
-.indicator-params {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 12px;
-  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
-  min-width: 340px;
-  max-width: 420px;
-  width: 90vw;
-  overflow: hidden;
-}
-
-/* ── 头部 ── */
-.params-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px 20px;
-  background: var(--klc-color-background);
-  border-bottom: 1px solid var(--klc-color-grid-major);
-}
-
-.header-left {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.params-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--klc-color-foreground);
-  letter-spacing: 0.2px;
-}
-
-.params-subtitle {
-  font-size: 11px;
-  color: var(--klc-color-axis-text);
-}
-
-.toggle-desc-btn {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 6px;
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--klc-color-axis-text);
-  transition: all 0.2s;
-  padding: 0;
-}
-
-.toggle-desc-btn:hover {
-  background: var(--klc-color-tag-bg-hover);
-  color: var(--klc-color-foreground);
-  border-color: var(--klc-color-axis-line);
-}
-
-.toggle-desc-btn.active {
-  background: var(--klc-color-foreground);
-  border-color: var(--klc-color-foreground);
-  color: var(--klc-color-background);
-}
-
-.toggle-desc-btn svg {
-  width: 14px;
-  height: 14px;
-}
-
-.params-close {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 6px;
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--klc-color-axis-text);
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
-  padding: 0;
-}
-
-.params-close:hover {
-  background: var(--klc-color-tag-bg-hover);
-  color: var(--klc-color-foreground);
-  border-color: var(--klc-color-axis-line);
-}
-
-.params-close svg {
-  width: 14px;
-  height: 14px;
-}
-
 /* ── 指标描述 ── */
 .indicator-description {
   padding: 12px 20px;
@@ -324,7 +193,6 @@ function onConfirm() {
 
 /* ── 体部 ── */
 .params-body {
-  padding: 16px 20px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -388,7 +256,7 @@ function onConfirm() {
   border: 1px solid var(--klc-color-axis-line);
   border-radius: 7px;
   overflow: hidden;
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   transition: border-color 0.2s;
 }
 
@@ -446,15 +314,6 @@ function onConfirm() {
 }
 
 /* ── 底部 ── */
-.params-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 20px;
-  background: var(--klc-color-background);
-  border-top: 1px solid var(--klc-color-grid-major);
-}
-
 .footer-right {
   display: flex;
   gap: 8px;
@@ -526,34 +385,6 @@ function onConfirm() {
 }
 
 /* ── 动画 ── */
-.overlay-enter-active,
-.overlay-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.overlay-enter-from,
-.overlay-leave-to {
-  opacity: 0;
-}
-
-.modal-enter-active {
-  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.modal-leave-active {
-  transition: all 0.16s ease-in;
-}
-
-.modal-enter-from {
-  opacity: 0;
-  transform: scale(0.88) translateY(-16px);
-}
-
-.modal-leave-to {
-  opacity: 0;
-  transform: scale(0.94) translateY(8px);
-}
-
 .slide-enter-active,
 .slide-leave-active {
   transition: all 0.2s ease;

--- a/packages/vue/src/components/IndicatorSelector.vue
+++ b/packages/vue/src/components/IndicatorSelector.vue
@@ -1,199 +1,159 @@
 <template>
   <div class="indicator-selector">
-
-    <!-- 添加指标弹窗 -->
-    <Teleport :to="teleportTarget">
-      <Transition name="overlay">
-        <div v-if="menuOpen" class="selector-overlay" @click="controller.closeMenu()">
-          <Transition name="modal">
-            <div v-if="menuOpen" class="selector-modal" @click.stop>
-              <!-- 弹窗头部 -->
-              <div class="modal-header">
-                <div class="header-title">
-                  <span class="title-text">添加指标</span>
-                  <span class="title-sub">{{ catalogLen }} 个可用指标</span>
-                </div>
-                <div class="header-actions">
-                  <button
-                    class="view-toggle-btn"
-                    :class="{ active: isCompactView }"
-                    @click="isCompactView = !isCompactView"
-                    title="简洁模式"
-                  >
-                    <svg
-                      v-if="!isCompactView"
-                      viewBox="0 0 24 24"
-                      width="16"
-                      height="16"
-                      fill="currentColor"
-                    >
-                      <path d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4z" />
-                    </svg>
-                    <svg v-else viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-                      <path
-                        d="M3 3h18v18H3V3zm16 16V5H5v14h14zM7 7h4v4H7V7zm0 6h4v4H7v-4zm6-6h4v4h-4V7zm0 6h4v4h-4v-4z"
-                      />
-                    </svg>
-                  </button>
-                  <button class="modal-close" @click="controller.closeMenu()" title="关闭">
-                    <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-                      <path
-                        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-
-              <!-- 搜索区域 -->
-              <div class="modal-search-area">
-                <div class="search-box">
-                  <svg
-                    class="search-icon"
-                    viewBox="0 0 24 24"
-                    width="16"
-                    height="16"
-                    fill="currentColor"
-                  >
-                    <path
-                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                    />
-                  </svg>
-                  <input
-                    :value="searchQuery" @input="controller.setSearchQuery(($event.target as HTMLInputElement).value)"
-                    type="text"
-                    class="search-input"
-                    placeholder="搜索指标名称..."
-                  />
-                </div>
-              </div>
-
-              <!-- 弹窗主体 -->
-              <div class="modal-body">
-                <!-- 主图指标区域 -->
-                <div v-if="filteredMain.length > 0" class="indicator-section">
-                  <div class="section-header">
-                    <span class="section-title">主图指标</span>
-                    <span class="section-count">{{ filteredMain.length }}</span>
-                  </div>
-                  <div class="indicator-grid" :class="{ compact: isCompactView }">
-                    <button
-                      v-for="indicator in filteredMain"
-                      :key="indicator.id"
-                      class="indicator-card"
-                      :class="{ active: isActive(indicator.id), compact: isCompactView }"
-                      @click="
-                        isActive(indicator.id)
-                          ? removeIndicator(indicator.id)
-                          : addIndicator(indicator.id)
-                      "
-                    >
-                      <template v-if="isCompactView">
-                        <span class="card-label">{{ indicator.label }}</span>
-                        <span class="card-tooltip">{{ indicator.name }}</span>
-                      </template>
-                      <template v-else>
-                        <div class="card-header">
-                          <span class="card-label">{{ indicator.label }}</span>
-                          <div class="card-header-actions">
-                            <button
-                              v-if="indicator.params?.length"
-                              class="card-settings-btn"
-                              @click.stop="showParams(indicator.id)"
-                              title="编辑参数"
-                            >
-                              <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-                                <path
-                                  d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                        <div class="card-name">{{ indicator.name }}</div>
-                      </template>
-                    </button>
-                  </div>
-                </div>
-
-                <!-- 分隔线 -->
-                <div
-                  v-if="filteredMain.length > 0 && filteredSub.length > 0"
-                  class="section-divider"
-                ></div>
-
-                <!-- 无匹配结果提示 -->
-                <div v-if="!hasSearchResults && searchQuery.trim()" class="no-results">
-                  <svg viewBox="0 0 24 24" width="48" height="48" fill="currentColor">
-                    <path
-                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                    />
-                  </svg>
-                  <p>未找到匹配的指标</p>
-                  <span class="no-results-hint">请尝试其他关键词</span>
-                </div>
-
-                <!-- 副图指标区域 -->
-                <div v-if="filteredSub.length > 0" class="indicator-section">
-                  <div class="section-header">
-                    <span class="section-title">副图指标</span>
-                    <span class="section-count">{{ filteredSub.length }}</span>
-                  </div>
-                  <div class="indicator-grid" :class="{ compact: isCompactView }">
-                    <button
-                      v-for="indicator in filteredSub"
-                      :key="indicator.id"
-                      class="indicator-card"
-                      :class="{ active: isActive(indicator.id), compact: isCompactView }"
-                      @click="
-                        isActive(indicator.id)
-                          ? removeIndicator(indicator.id)
-                          : addIndicator(indicator.id)
-                      "
-                    >
-                      <template v-if="isCompactView">
-                        <span class="card-label">{{ indicator.label }}</span>
-                        <span class="card-tooltip">{{ indicator.name }}</span>
-                      </template>
-                      <template v-else>
-                        <div class="card-header">
-                          <span class="card-label">{{ indicator.label }}</span>
-                          <div class="card-header-actions">
-                            <button
-                              v-if="indicator.params?.length"
-                              class="card-settings-btn"
-                              @click.stop="showParams(indicator.id)"
-                              title="编辑参数"
-                            >
-                              <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-                                <path
-                                  d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
-                                />
-                              </svg>
-                            </button>
-                          </div>
-                        </div>
-                        <div class="card-name">{{ indicator.name }}</div>
-                      </template>
-                    </button>
-                  </div>
-                </div>
-              </div>
-
-              <!-- 弹窗底部 -->
-              <div class="modal-footer">
-                <div class="footer-info">
-                  <span class="info-text">已激活 {{ activeCount }} 个指标</span>
-                </div>
-                <button class="btn btn-confirm" @click="controller.closeMenu()">确认</button>
-              </div>
-            </div>
-          </Transition>
+    <BaseModal
+      :show="menuOpen"
+      title="添加指标"
+      subtitle=""
+      width="90vw"
+      max-width="860px"
+      max-height="85vh"
+      transition-variant="compact"
+      footer-align="space-between"
+      @close="controller.closeMenu()"
+    >
+      <template #header>
+        <div class="header-title">
+          <span class="title-text">添加指标</span>
+          <span class="title-sub">{{ catalogLen }} 个可用指标</span>
         </div>
-      </Transition>
-    </Teleport>
+      </template>
 
-    <!-- 参数编辑弹窗 -->
+      <template #header-extra>
+        <button
+          class="view-toggle-btn"
+          :class="{ active: isCompactView }"
+          @click="isCompactView = !isCompactView"
+          title="简洁模式"
+        >
+          <svg v-if="!isCompactView" viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+            <path d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4z" />
+          </svg>
+          <svg v-else viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+            <path d="M3 3h18v18H3V3zm16 16V5H5v14h14zM7 7h4v4H7V7zm0 6h4v4H7v-4zm6-6h4v4h-4V7zm0 6h4v4h-4v-4z" />
+          </svg>
+        </button>
+      </template>
+
+      <template #subheader>
+        <div class="search-box">
+          <svg class="search-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
+            <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+          </svg>
+          <input
+            :value="searchQuery"
+            @input="controller.setSearchQuery(($event.target as HTMLInputElement).value)"
+            type="text"
+            class="search-input"
+            placeholder="搜索指标名称..."
+          />
+        </div>
+      </template>
+
+      <!-- 主图指标 -->
+      <div v-if="filteredMain.length > 0" class="indicator-section">
+        <div class="section-header">
+          <span class="section-title">主图指标</span>
+          <span class="section-count">{{ filteredMain.length }}</span>
+        </div>
+        <div class="indicator-grid" :class="{ compact: isCompactView }">
+          <button
+            v-for="indicator in filteredMain"
+            :key="indicator.id"
+            class="indicator-card"
+            :class="{ active: isActive(indicator.id), compact: isCompactView }"
+            @click="
+              isActive(indicator.id)
+                ? removeIndicator(indicator.id)
+                : addIndicator(indicator.id)
+            "
+          >
+            <template v-if="isCompactView">
+              <span class="card-label">{{ indicator.label }}</span>
+              <span class="card-tooltip">{{ indicator.name }}</span>
+            </template>
+            <template v-else>
+              <div class="card-header">
+                <span class="card-label">{{ indicator.label }}</span>
+                <div class="card-header-actions">
+                  <button
+                    v-if="indicator.params?.length"
+                    class="card-settings-btn"
+                    @click.stop="showParams(indicator.id)"
+                    title="编辑参数"
+                  >
+                    <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                      <path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div class="card-name">{{ indicator.name }}</div>
+            </template>
+          </button>
+        </div>
+      </div>
+
+      <!-- 无匹配 -->
+      <div v-if="!hasSearchResults && searchQuery.trim()" class="no-results">
+        <svg viewBox="0 0 24 24" width="48" height="48" fill="currentColor">
+          <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+        </svg>
+        <p>未找到匹配的指标</p>
+        <span class="no-results-hint">请尝试其他关键词</span>
+      </div>
+
+      <!-- 副图指标 -->
+      <div v-if="filteredSub.length > 0" class="indicator-section">
+        <div class="section-header">
+          <span class="section-title">副图指标</span>
+          <span class="section-count">{{ filteredSub.length }}</span>
+        </div>
+        <div class="indicator-grid" :class="{ compact: isCompactView }">
+          <button
+            v-for="indicator in filteredSub"
+            :key="indicator.id"
+            class="indicator-card"
+            :class="{ active: isActive(indicator.id), compact: isCompactView }"
+            @click="
+              isActive(indicator.id)
+                ? removeIndicator(indicator.id)
+                : addIndicator(indicator.id)
+            "
+          >
+            <template v-if="isCompactView">
+              <span class="card-label">{{ indicator.label }}</span>
+              <span class="card-tooltip">{{ indicator.name }}</span>
+            </template>
+            <template v-else>
+              <div class="card-header">
+                <span class="card-label">{{ indicator.label }}</span>
+                <div class="card-header-actions">
+                  <button
+                    v-if="indicator.params?.length"
+                    class="card-settings-btn"
+                    @click.stop="showParams(indicator.id)"
+                    title="编辑参数"
+                  >
+                    <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+                      <path d="M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div class="card-name">{{ indicator.name }}</div>
+            </template>
+          </button>
+        </div>
+      </div>
+
+      <template #footer>
+        <div class="footer-info">
+          <span class="info-text">已激活 {{ activeCount }} 个指标</span>
+        </div>
+        <button class="btn btn-confirm" @click="controller.closeMenu()">确认</button>
+      </template>
+    </BaseModal>
+
     <IndicatorParams
       v-if="currentIndicator"
       :visible="paramsVisible"
@@ -210,8 +170,8 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import BaseModal from './BaseModal.vue'
 import IndicatorParams from './IndicatorParams.vue'
-import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
 import { coreSignalToVueRef } from '../index'
 import {
   createIndicatorSelectorController,
@@ -234,7 +194,6 @@ const emit = defineEmits<{
   reorderSubIndicators: [orderedIndicatorIds: string[]]
 }>()
 
-// ── 将 Indicator[] 转换为 IndicatorDefinition[] ──
 function toIndicatorDefinitions(source: Indicator[]): IndicatorDefinition[] {
   return source.map((i) => ({
     id: i.id,
@@ -254,10 +213,8 @@ function toIndicatorDefinitions(source: Indicator[]): IndicatorDefinition[] {
   }))
 }
 
-// ── Controller ──
 const controller = createIndicatorSelectorController()
 
-// ── 从 Controller Signal 桥接的 Vue 响应式状态 ──
 const menuOpen = coreSignalToVueRef(controller.menuOpen)
 const searchQuery = coreSignalToVueRef(controller.searchQuery)
 const filteredMain = coreSignalToVueRef(controller.filteredMain)
@@ -277,13 +234,9 @@ onMounted(async () => {
   controller.catalog.set(toIndicatorDefinitions(allIndicators()))
 })
 
-// ── 本地 UI 状态（非 Controller 管理的纯 UI 状态） ──
 const paramsVisible = ref(false)
 const currentIndicatorId = ref<string | null>(null)
 const isCompactView = ref(false)
-
-// Teleport target for fullscreen modal visibility
-const teleportTarget = useFullscreenTeleportTarget()
 
 const currentIndicator = computed(() => {
   if (!currentIndicatorId.value) return null
@@ -298,10 +251,8 @@ function isActive(indicatorId: string): boolean {
 
 function addIndicator(indicatorId: string) {
   if (isActive(indicatorId)) return
-
   const indicator = findIndicator(indicatorId)
   if (!indicator) return
-
   emit('toggle', indicatorId, true)
 }
 
@@ -368,47 +319,7 @@ defineExpose({
   display: none;
 }
 
-/* ─────────────────────────────────────────────────────────────────
-   弹窗样式 - 与其他弹窗保持一致
-   ───────────────────────────────────────────────────────────────── */
-
-/* 遮罩层 */
-.selector-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(4px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-/* 弹窗容器 */
-.selector-modal {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-axis-line);
-  border-radius: 12px;
-  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
-  width: 90vw;
-  max-width: 860px;
-  max-height: 85vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-/* 弹窗头部 */
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px 20px;
-  background: var(--klc-color-background);
-  border-bottom: 1px solid var(--klc-color-border-chart);
-  flex-shrink: 0;
-}
-
+/* ── 头部 ── */
 .header-title {
   display: flex;
   flex-direction: column;
@@ -427,40 +338,8 @@ defineExpose({
   color: var(--klc-color-axis-text);
 }
 
-.modal-close {
-  background: var(--klc-color-tag-bg-white);
-  border: 1px solid var(--klc-color-border-button);
-  border-radius: 6px;
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: var(--klc-color-axis-text);
-  transition: all 0.15s;
-  padding: 0;
-}
-
-.modal-close:hover {
-  background: var(--klc-color-tag-bg-hover);
-  color: var(--klc-color-foreground);
-  border-color: var(--klc-color-axis-line);
-}
-
-.modal-close svg {
-  width: 14px;
-  height: 14px;
-}
-
-.header-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .view-toggle-btn {
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   border: 1px solid var(--klc-color-border-button);
   border-radius: 6px;
   width: 28px;
@@ -480,41 +359,7 @@ defineExpose({
   border-color: var(--klc-color-axis-line);
 }
 
-.view-toggle-btn.active {
-  background: var(--klc-color-tag-bg-white);
-  border-color: var(--klc-color-border-button);
-  color: var(--klc-color-foreground);
-}
-
-/* 搜索区域 */
-.modal-search-area {
-  padding: 16px 20px;
-  background: var(--klc-color-tag-bg-white);
-  border-bottom: 1px solid var(--klc-color-border-chart);
-  flex-shrink: 0;
-}
-
-/* 弹窗主体 */
-.modal-body {
-  padding: 20px;
-  overflow-y: auto;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.modal-body::-webkit-scrollbar {
-  width: 8px;
-}
-
-.modal-body::-webkit-scrollbar-thumb {
-  background: var(--klc-color-axis-line);
-  border: 2px solid var(--klc-color-tag-bg-white);
-  border-radius: 999px;
-}
-
-/* 搜索框 */
+/* ── 搜索 ── */
 .search-box {
   display: flex;
   align-items: center;
@@ -527,7 +372,7 @@ defineExpose({
 }
 
 .search-box:focus-within {
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   border-color: var(--klc-color-foreground);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--klc-color-foreground) 8%, transparent);
 }
@@ -550,7 +395,7 @@ defineExpose({
   color: var(--klc-color-axis-text);
 }
 
-/* 无结果提示 */
+/* ── 无匹配 ── */
 .no-results {
   display: flex;
   flex-direction: column;
@@ -577,11 +422,15 @@ defineExpose({
   color: var(--klc-color-axis-text);
 }
 
-/* 指标区域 */
+/* ── 指标区域 ── */
 .indicator-section {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.indicator-section + .indicator-section {
+  margin-top: 20px;
 }
 
 .section-header {
@@ -604,14 +453,12 @@ defineExpose({
   border-radius: 10px;
 }
 
-/* 自适应列数网格 */
 .indicator-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(195px, 1fr));
   gap: 10px;
 }
 
-/* 紧凑模式 - 标签形式 */
 .indicator-grid.compact {
   display: flex;
   flex-wrap: wrap;
@@ -655,7 +502,6 @@ defineExpose({
   font-weight: 500;
 }
 
-/* 指标卡片 */
 .indicator-card {
   display: flex;
   flex-direction: column;
@@ -663,7 +509,7 @@ defineExpose({
   padding: 12px 14px;
   border: 1px solid var(--klc-color-border-chart);
   border-radius: 8px;
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   cursor: pointer;
   transition: all 0.15s;
   text-align: left;
@@ -726,40 +572,12 @@ defineExpose({
   line-height: 1.4;
 }
 
-.card-params {
-  font-size: 10px;
-  color: var(--klc-color-axis-text);
-  margin-top: 2px;
-}
-
-/* 区域分隔线 */
-.section-divider {
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--klc-color-border-button), transparent);
-  margin: 4px 0;
-}
-
-/* 弹窗底部 */
-.modal-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 20px;
-  background: var(--klc-color-background);
-  border-top: 1px solid var(--klc-color-border-chart);
-  flex-shrink: 0;
-}
-
+/* ── 底部 ── */
 .footer-info {
   font-size: 12px;
   color: var(--klc-color-axis-text);
 }
 
-.info-text {
-  color: var(--klc-color-axis-text);
-}
-
-/* 按钮样式 */
 .btn {
   display: flex;
   align-items: center;
@@ -787,60 +605,10 @@ defineExpose({
   transform: translateY(-1px);
 }
 
-/* 过渡动画 */
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
-}
-
-/* 遮罩层动画 */
-.overlay-enter-active,
-.overlay-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.overlay-enter-from,
-.overlay-leave-to {
-  opacity: 0;
-}
-
-/* 弹窗动画 */
-.modal-enter-active {
-  transition: all 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-
-.modal-leave-active {
-  transition: all 0.16s ease-in;
-}
-
-.modal-enter-from {
-  opacity: 0;
-  transform: scale(0.88) translateY(-16px);
-}
-
-.modal-leave-to {
-  opacity: 0;
-  transform: scale(0.94) translateY(8px);
-}
-
-/* 响应式适配 */
+/* ── 响应式 ── */
 @media (max-width: 640px) {
-  .selector-modal {
-    width: 95vw;
-    max-height: 90vh;
-  }
-
   .indicator-grid {
     grid-template-columns: 1fr;
-  }
-
-  .modal-body {
-    padding: 16px;
   }
 }
 </style>

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -84,6 +84,7 @@
                   v-model="customEndDate"
                   :placeholder="rangeSelectionEndLabel"
                 />
+                <span class="range-selection-export__count">共 {{ rangeSelectionCount }} 条</span>
                 <button
                   type="button"
                   class="toolbar-btn"
@@ -103,10 +104,19 @@
                 <button
                   type="button"
                   class="toolbar-btn delete-btn"
-                  title="删除选区"
+                  title="取消选区"
                   @click.stop="clearRangeSelection"
                 >
-                  <svg class="delete-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <svg
+                    class="delete-icon"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
                     <path d="M3 6h18" />
                     <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
                     <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
@@ -449,6 +459,7 @@ const {
   isRangeSelectActive,
   rangeSelectionReady,
   rangeSelectionBounds,
+  rangeSelectionCount,
   rangeSelectionStartLabel,
   rangeSelectionEndLabel,
   rangeSelectionOverlayStyle,
@@ -1146,9 +1157,13 @@ watch(
   z-index: 101;
 }
 
-.range-selection-handle--left { left: -4px; }
+.range-selection-handle--left {
+  left: -4px;
+}
 
-.range-selection-handle--right { right: -4px; }
+.range-selection-handle--right {
+  right: -4px;
+}
 
 .range-selection-export {
   position: absolute;
@@ -1160,7 +1175,7 @@ watch(
   gap: 6px;
   padding: 4px 8px;
   height: 32px;
-  background: color-mix(in srgb, var(--klc-color-tag-bg-white) 88%, transparent);
+  background: color-mix(in srgb, var(--klc-color-background) 88%, transparent);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid var(--klc-color-border-button);
@@ -1232,6 +1247,13 @@ watch(
 .range-selection-export__sep {
   color: var(--klc-color-axis-text);
   font-size: 11px;
+  user-select: none;
+}
+
+.range-selection-export__count {
+  color: var(--klc-color-axis-text);
+  font-size: 12px;
+  white-space: nowrap;
   user-select: none;
 }
 

--- a/packages/vue/src/components/LeftToolbar.vue
+++ b/packages/vue/src/components/LeftToolbar.vue
@@ -418,7 +418,7 @@ onUnmounted(() => {
   gap: 4px;
   padding: 0 5px;
   height: 40px;
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   border: 1px solid var(--klc-color-border-chart);

--- a/packages/vue/src/components/SymbolSelector.vue
+++ b/packages/vue/src/components/SymbolSelector.vue
@@ -273,7 +273,7 @@ watch(() => props.symbol, () => {
   padding: 14px;
   border: 1px solid var(--klc-color-border-button);
   border-radius: 3px;
-  background: var(--klc-color-tag-bg-white);
+  background: var(--klc-color-background);
   color: var(--klc-color-foreground);
   
   box-sizing: border-box;

--- a/packages/vue/src/components/SymbolSelector.vue
+++ b/packages/vue/src/components/SymbolSelector.vue
@@ -268,7 +268,7 @@ watch(() => props.symbol, () => {
 }
 
 .symbol-popover {
-  z-index: 20;
+  z-index: 110;
   width: min(320px, calc(100vw - 24px));
   padding: 14px;
   border: 1px solid var(--klc-color-border-button);

--- a/packages/vue/src/composables/chart/useRangeSelection.ts
+++ b/packages/vue/src/composables/chart/useRangeSelection.ts
@@ -108,6 +108,12 @@ export function useRangeSelection(options: {
     return fmtDate(data[bounds.end])
   })
 
+  const rangeSelectionCount = computed(() => {
+    const bounds = rangeSelectionBounds.value
+    if (!bounds) return 0
+    return bounds.end - bounds.start + 1
+  })
+
   const rangeSelectionOverlayStyle = computed(() => {
     const bounds = rangeSelectionBounds.value
     if (!bounds) return null
@@ -399,6 +405,7 @@ export function useRangeSelection(options: {
     isRangeSelectActive,
     rangeSelectionReady,
     rangeSelectionBounds,
+    rangeSelectionCount,
     rangeSelectionStartLabel,
     rangeSelectionEndLabel,
     rangeSelectionOverlayStyle,


### PR DESCRIPTION
## Summary

Extract a reusable `BaseModal` component to eliminate duplicated overlay, teleport, transition, and layout code across all dialogs.

## Changes

### New
- **`BaseModal.vue`** — shared modal component with:
  - Overlay + spring animation transitions (two variants)
  - `header` / `subheader` / default body / `footer` / `header-extra` slots
  - Configurable z-index, width, max-height, overlay padding, body padding, footer alignment
  - Proper flex layout: `flex: 1; min-height: 0; overflow-y: auto` on body (sticky footer fix)
  - Built-in scrollbar styling that respects dark mode
  - Responsive breakpoints

### Refactored (5 dialogs migrated to BaseModal)
| Dialog | Key changes |
|--------|-------------|
| `BatchStockDialog.vue` | +195 → +15 lines template |
| `ExportProgressDialog.vue` | +170 → +60 lines CSS, done btn moved to footer slot |
| `IndicatorParams.vue` | Custom header via `header-extra` slot (info toggle) |
| `IndicatorSelector.vue` | Search area via `subheader` slot |
| `ChartSettingsDialog.vue` | Nested color preset dialog uses second BaseModal with z-index 1100 |

### Bug Fixes
- Fixed batch-textarea resize pushing footer out of dialog (`flex: 1; min-height: 0`)
- Fixed `symbol-popover` / `compare-popover` z-index (20 → 110) being below `canvas-layer` (z-index: 26)
- Fixed body scrollbar track not adapting to dark mode
- Added `rangeSelectionCount` computed for range-export toolbar

### Cleanup
- Replaced `--klc-color-tag-bg-white` (semantically wrong in dark mode) with `--klc-color-background` across 10 components
- Removed \~1300 lines of duplicated overlay/modal/transition code

## Stats
13 files changed, 774 insertions(+), 1312 deletions(-)