### PR TITLE
feat(core+vue): add applyCustomData unified entry and customData prop for user data injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,38 @@ const config: SemanticChartConfig = {
 </template>
 ```
 
-### 4. (Optional) Enable MCP / AI Agent Control
+### 4. Inject Custom Data Directly (Without Fetcher)
+
+Bypass the data fetcher entirely by passing your own K-line data and comparison products through the `customData` prop:
+
+```vue
+<script setup lang="ts">
+import KLineChart from '@363045841yyt/klinechart'
+import type { CustomDataSource, KLineData } from '@363045841yyt/klinechart'
+
+const myData: KLineData[] = [
+  { timestamp: 1748736000000, date: '2025-06-01', open: 30, high: 32, low: 30, close: 31.5, volume: 1500000 },
+  { timestamp: 1748822400000, date: '2025-06-02', open: 31.5, high: 33.2, low: 31.2, close: 33, volume: 2100000 },
+  // ... more candles
+]
+
+const customDataSource: CustomDataSource = {
+  symbol: 'MY.STOCK',
+  period: 'daily',
+  data: myData,
+  comparisons: {
+    'COMP.A': [ /* comparison KLineData[] */ ],
+    'COMP.B': [ /* comparison KLineData[] */ ],
+  },
+}
+</script>
+
+<template>
+  <KLineChart :customData="customDataSource" />
+</template>
+```
+
+### 5. (Optional) Enable MCP / AI Agent Control
 
 ```bash
 npm install @363045841yyt/klinechart-ai-runtime
@@ -167,6 +198,7 @@ Connect via MCP Inspector and call `chart.zoomToLevel`, `indicators.add`, etc.
 | zoomLevels | `number` | 20 | Total number of zoom levels |
 | initialZoomLevel | `number` | 3 | Initial zoom level (1 ~ zoomLevels) |
 | mcp | `McpConfig` | — | MCP bridge config: `{ wsUrl?, autoReconnect?, onToolCall? }`. See [@363045841yyt/klinechart-ai-runtime](packages/ai-runtime/README.md) |
+| customData | `CustomDataSource` | — | Inline data bundle: `{ symbol?, period?, data, comparisons? }`. Bypasses the fetcher pipeline entirely. See example above |
 
 ## 🗺️ Roadmap
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -110,7 +110,38 @@ const config: SemanticChartConfig = {
 </template>
 ```
 
-### 4.（可选）启用 MCP / AI Agent 控制
+### 4. 直接注入自定义数据（无需后端）
+
+通过 `customData` prop 传入自己的 K 线数据和对比商品，完全绕过数据请求器：
+
+```vue
+<script setup lang="ts">
+import KLineChart from '@363045841yyt/klinechart'
+import type { CustomDataSource, KLineData } from '@363045841yyt/klinechart'
+
+const myData: KLineData[] = [
+  { timestamp: 1748736000000, date: '2025-06-01', open: 30, high: 32, low: 30, close: 31.5, volume: 1500000 },
+  { timestamp: 1748822400000, date: '2025-06-02', open: 31.5, high: 33.2, low: 31.2, close: 33, volume: 2100000 },
+  // ... 更多 K 线
+]
+
+const customDataSource: CustomDataSource = {
+  symbol: 'MY.STOCK',
+  period: 'daily',
+  data: myData,
+  comparisons: {
+    'COMP.A': [ /* 对比商品 KLineData[] */ ],
+    'COMP.B': [ /* 对比商品 KLineData[] */ ],
+  },
+}
+</script>
+
+<template>
+  <KLineChart :customData="customDataSource" />
+</template>
+```
+
+### 5.（可选）启用 MCP / AI Agent 控制
 
 ```bash
 npm install @363045841yyt/klinechart-ai-runtime
@@ -168,6 +199,7 @@ pnpm inspect
 | zoomLevels | `number` | 20 | 缩放级别总数 |
 | initialZoomLevel | `number` | 3 | 初始缩放级别（1 ~ zoomLevels） |
 | mcp | `McpConfig` | — | MCP 桥接配置：`{ wsUrl?, autoReconnect?, onToolCall? }`。详见 [@363045841yyt/klinechart-ai-runtime](packages/ai-runtime/README.md) |
+| customData | `CustomDataSource` | — | 内联数据包：`{ symbol?, period?, data, comparisons? }`。完全绕过数据请求器，直接使用传入的数据渲染 |
 
 ## 🗺️ Roadmap
 

--- a/packages/ai-runtime/package.json
+++ b/packages/ai-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@363045841yyt/klinechart-ai-runtime",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AI Native runtime for @363045841yyt/klinechart — MCP tool schemas, controller describe() output, chart state serialization.",
   "keywords": [
     "kline",

--- a/packages/ai-runtime/src/__tests__/executeTool.test.ts
+++ b/packages/ai-runtime/src/__tests__/executeTool.test.ts
@@ -446,7 +446,11 @@ describe('executeTool', () => {
         name: 'markers.update',
         input: { markers },
       })
-      expect(chart.updateCustomMarkers).toHaveBeenCalledWith(markers)
+      const expectedMarkers = markers.map((m) => ({
+        ...m,
+        timestamp: new Date(m.date).getTime(),
+      }))
+      expect(chart.updateCustomMarkers).toHaveBeenCalledWith(expectedMarkers)
       expect(result.success).toBe(true)
     })
   })

--- a/packages/ai-runtime/src/__tests__/toolSchemas.test.ts
+++ b/packages/ai-runtime/src/__tests__/toolSchemas.test.ts
@@ -204,16 +204,18 @@ describe('inputSchema correctness — spot checks', () => {
     }
   })
 
-  it('drawing.setTool uses an enum for tool types', () => {
+  it('drawing.setTool uses oneOf for tool types (string + null)', () => {
     const t = findTool('drawing.setTool')!
     if (t.inputSchema.type === 'object') {
       const tool = t.inputSchema.properties.tool
-      expect(tool?.type).toBe('string')
-      if (tool?.type === 'string') {
-        expect(tool.enum).toContain('trendline')
-        expect(tool.enum).toContain('fib')
-        expect(tool.enum).toContain(null)
-      }
+      expect(tool?.oneOf).toBeDefined()
+      const stringOption = tool.oneOf.find((o: Record<string, unknown>) => o.type === 'string')
+      expect(stringOption).toBeDefined()
+      expect(stringOption!.enum).toContain('trendline')
+      expect(stringOption!.enum).toContain('fib')
+
+      const nullOption = tool.oneOf.find((o: Record<string, unknown>) => o.type === 'null')
+      expect(nullOption).toBeDefined()
     }
   })
 

--- a/packages/ai-runtime/src/executeTool.ts
+++ b/packages/ai-runtime/src/executeTool.ts
@@ -1,4 +1,4 @@
-import type { ChartController, ToolCall, ToolResult } from '@363045841yyt/klinechart-core'
+import type { ChartController, DrawingToolType, KLineData, ToolCall, ToolResult } from '@363045841yyt/klinechart-core'
 import { findTool } from './toolSchemas'
 
 export type { ToolCall, ToolResult }
@@ -110,7 +110,7 @@ export function executeTool(
       const { bars } = call.input as {
         bars: Array<{ timestamp?: number; open: number; high: number; low: number; close: number; volume?: number }>
       }
-      chart.appendData(bars)
+      chart.appendData(bars as KLineData[])
       return { success: true }
     }
 
@@ -118,7 +118,7 @@ export function executeTool(
       const { bars } = call.input as {
         bars: Array<{ timestamp?: number; open: number; high: number; low: number; close: number; volume?: number }>
       }
-      chart.updateData(bars)
+      chart.updateData(bars as KLineData[])
       return { success: true }
     }
 
@@ -140,7 +140,7 @@ export function executeTool(
 
     case 'drawing.setTool': {
       const { tool } = call.input as { tool: string | null }
-      chart.setDrawingTool(tool)
+      chart.setDrawingTool(tool as DrawingToolType | null)
       return { success: true }
     }
 
@@ -180,8 +180,22 @@ export function executeTool(
     }
 
     case 'markers.update': {
-      const { markers } = call.input as { markers: Array<{ id: string; date: string; shape: string; groupKey?: string; style?: Record<string, unknown>; label?: { text: string; position?: string } }> }
-      chart.updateCustomMarkers(markers)
+      const { markers } = call.input as {
+        markers: Array<{
+          id: string
+          date: string
+          shape: string
+          groupKey?: string
+          style?: Record<string, unknown>
+          label?: { text: string; position?: string }
+        }>
+      }
+      chart.updateCustomMarkers(
+        markers.map((m) => ({
+          ...m,
+          timestamp: new Date(m.date).getTime(),
+        })) as Parameters<typeof chart.updateCustomMarkers>[0],
+      )
       return { success: true }
     }
 

--- a/packages/ai-runtime/src/toolSchemas.ts
+++ b/packages/ai-runtime/src/toolSchemas.ts
@@ -282,8 +282,10 @@ export const DRAWING_TOOLS: McpToolSchema[] = [
       type: 'object',
       properties: {
         tool: {
-          type: 'string',
-          enum: ['trendline', 'horizontal', 'fib', 'rectangle', 'arrow', null],
+          oneOf: [
+            { type: 'string', enum: ['trendline', 'horizontal', 'fib', 'rectangle', 'arrow'], description: 'Drawing tool type.' },
+            { type: 'null', description: 'Deactivate drawing tool.' },
+          ],
           description:
             'Drawing tool type, or null to deactivate. ' +
             'trendline=trend line, horizontal=horizontal line, fib=Fibo retracement, ' +
@@ -416,6 +418,7 @@ export const MARKER_TOOLS: McpToolSchema[] = [
               groupKey: { type: 'string', description: 'Optional grouping key.' },
               style: {
                 type: 'object',
+                properties: {},
                 additionalProperties: true,
                 description: 'Optional style overrides (fillColor, strokeColor, size, etc.).',
               },
@@ -460,11 +463,13 @@ export const SETTINGS_TOOLS: McpToolSchema[] = [
       properties: {
         settings: {
           type: 'object',
+          properties: {},
           additionalProperties: true,
           description: 'Chart settings key-value pairs (behaviour).',
         },
         options: {
           type: 'object',
+          properties: {},
           additionalProperties: true,
           description: 'Chart options key-value pairs (appearance).',
         },

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -29,6 +29,7 @@ import type {
     PaneSpec,
     SymbolSpec,
     DataFetcher,
+    CustomDataSource,
 } from './types'
 import type { CustomMarkerEntity } from '../engine/marker/registry'
 import { Chart, type InteractionSnapshot as LegacyInteractionSnapshot } from '../engine/chart'
@@ -545,6 +546,11 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
         chart.setCurrentPeriod(period)
     }
 
+    function applyCustomData(source: CustomDataSource): void {
+        if (disposed) return
+        chart.applyCustomData(source)
+    }
+
     function setDataFetcher(fetcher: DataFetcher | null): void {
         if (disposed) return
         chart.setDataFetcher(fetcher)
@@ -882,6 +888,7 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
         setComparisonData,
         setCurrentSymbol,
         setCurrentPeriod,
+        applyCustomData,
         setDataFetcher,
         ensureDataRange,
         setData,

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -530,6 +530,21 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
         chart.removeComparisonSymbol(symbol)
     }
 
+    function setComparisonData(symbol: string, data: ReadonlyArray<KLineData>): void {
+        if (disposed) return
+        chart.setComparisonData(symbol, [...data])
+    }
+
+    function setCurrentSymbol(symbol: string): void {
+        if (disposed) return
+        chart.setCurrentSymbol(symbol)
+    }
+
+    function setCurrentPeriod(period: string): void {
+        if (disposed) return
+        chart.setCurrentPeriod(period)
+    }
+
     function setDataFetcher(fetcher: DataFetcher | null): void {
         if (disposed) return
         chart.setDataFetcher(fetcher)
@@ -864,6 +879,9 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
         setSymbols,
         addComparisonSymbol,
         removeComparisonSymbol,
+        setComparisonData,
+        setCurrentSymbol,
+        setCurrentPeriod,
         setDataFetcher,
         ensureDataRange,
         setData,

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -102,6 +102,17 @@ export type DataFetcher = (
     },
 ) => Promise<ReadonlyArray<KLineData>>
 
+/** User-provided K-line data bundle — bypasses the fetcher pipeline entirely */
+export interface CustomDataSource {
+    symbol?: string
+    period?: string
+    adjust?: string
+    /** Main chart K-line data (required) */
+    data: ReadonlyArray<KLineData>
+    /** Comparison products keyed by symbol */
+    comparisons?: Record<string, ReadonlyArray<KLineData>>
+}
+
 // ---------------------------------------------------------------------------
 // Indicator metadata
 // ---------------------------------------------------------------------------
@@ -270,6 +281,8 @@ export interface ChartController extends DrawingChartAdapter {
     setCurrentSymbol(symbol: string): void
     /** Update the K-line period without triggering a fetch */
     setCurrentPeriod(period: string): void
+    /** Inject a complete custom data bundle (bypasses fetcher pipeline) */
+    applyCustomData(source: CustomDataSource): void
     setDataFetcher(fetcher: DataFetcher | null): void
     setData(next: ReadonlyArray<KLineData>): void
     appendData(next: ReadonlyArray<KLineData>): void

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -264,6 +264,12 @@ export interface ChartController extends DrawingChartAdapter {
     setSymbols(next: ReadonlyArray<SymbolSpec>): void
     addComparisonSymbol(spec: SymbolSpec): void
     removeComparisonSymbol(symbol: string): void
+    /** Inject comparison product data directly (bypasses fetcher) */
+    setComparisonData(symbol: string, data: ReadonlyArray<KLineData>): void
+    /** Update the main symbol code without triggering a fetch */
+    setCurrentSymbol(symbol: string): void
+    /** Update the K-line period without triggering a fetch */
+    setCurrentPeriod(period: string): void
     setDataFetcher(fetcher: DataFetcher | null): void
     setData(next: ReadonlyArray<KLineData>): void
     appendData(next: ReadonlyArray<KLineData>): void

--- a/packages/core/src/data-fetchers/dataBuffer.ts
+++ b/packages/core/src/data-fetchers/dataBuffer.ts
@@ -222,6 +222,32 @@ export class DataBuffer {
         })
     }
 
+    /**
+     * Put the buffer in inline mode — use the provided data directly
+     * instead of fetching. Sets data signal and tracks loadedWindow.
+     */
+    setInlineData(data: KLineData[]): void {
+        if (this._disposed) return
+        this._data = [...data]
+        this._dataSignal.set([...data])
+        if (data.length > 0) {
+            this._loadedWindow = {
+                earliestTs: data[0]!.timestamp,
+                latestTs: data[data.length - 1]!.timestamp,
+            }
+        } else {
+            this._loadedWindow = null
+        }
+        this._attemptedBoundaries.clear()
+    }
+
+    /**
+     * Update just the spec metadata without triggering any fetch.
+     */
+    setCurrentSpec(spec: SymbolSpec): void {
+        this._currentSpec = spec
+    }
+
     dispose(): void {
         this._disposed = true
         this._pendingFetch = null

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -1,7 +1,7 @@
 import type { KLineData } from '../types/price'
 import type { ChartSettings } from '../config/chartSettings'
 import { createSignal, type Signal, type Computed } from '../reactivity/signal'
-import type { SymbolSpec } from '../controllers/types'
+import type { SymbolSpec, CustomDataSource } from '../controllers/types'
 import { ChartDataManager } from './data/chartDataManager'
 import { ChartPaneLayout } from './layout/chartPaneLayout'
 import { UpdateLevel } from './layout/pane'
@@ -839,6 +839,10 @@ export class Chart {
 
     setCurrentPeriod(period: string): void {
         this.dataManager.setCurrentPeriod(period)
+    }
+
+    applyCustomData(source: CustomDataSource): void {
+        this.dataManager.applyCustomData(source)
     }
 
     // ---------- Theme ----------

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -829,6 +829,18 @@ export class Chart {
         this.dataManager.removeComparisonSymbol(symbol)
     }
 
+    setComparisonData(symbol: string, data: KLineData[]): void {
+        this.dataManager.setComparisonData(symbol, data)
+    }
+
+    setCurrentSymbol(symbol: string): void {
+        this.dataManager.setCurrentSymbol(symbol)
+    }
+
+    setCurrentPeriod(period: string): void {
+        this.dataManager.setCurrentPeriod(period)
+    }
+
     // ---------- Theme ----------
 
     /**

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -1,5 +1,5 @@
 import type { KLineData } from '../../types/price'
-import type { SymbolSpec, DataFetcher } from '../../controllers/types'
+import type { SymbolSpec, DataFetcher, CustomDataSource } from '../../controllers/types'
 import { createSignal, type Signal } from '../../reactivity/signal'
 import { DataBuffer } from '../../data-fetchers/dataBuffer'
 import type { ChartDom, Viewport } from '../chartTypes'
@@ -478,9 +478,10 @@ export class ChartDataManager {
       this._comparisonSpecs.push(spec)
       const mainSpec = this._symbolsSignal.peek()[0]
       this._symbolsSignal.set(mainSpec ? [mainSpec, ...this._comparisonSpecs] : [...this._comparisonSpecs])
-    }
 
-    existing ??= this._comparisonBuffers.get(key)!
+      buffer.setInlineData(data)
+      return
+    }
     existing.setInlineData(data)
   }
 
@@ -509,6 +510,20 @@ export class ChartDataManager {
     if (specs.length > 0) {
       const updated = [{ ...specs[0], period }, ...specs.slice(1)] as SymbolSpec[]
       this._symbolsSignal.set(updated)
+    }
+  }
+
+  applyCustomData(source: CustomDataSource): void {
+    if (source.symbol) this.setCurrentSymbol(source.symbol)
+    if (source.period) this.setCurrentPeriod(source.period)
+    this.setData([...source.data])
+    if (source.comparisons) {
+      for (const key of this._comparisonBuffers.keys()) {
+        if (!source.comparisons[key]) this.removeComparisonSymbol(key)
+      }
+      for (const [symbol, data] of Object.entries(source.comparisons)) {
+        this.setComparisonData(symbol, [...data])
+      }
     }
   }
 

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -516,13 +516,17 @@ export class ChartDataManager {
   applyCustomData(source: CustomDataSource): void {
     if (source.symbol) this.setCurrentSymbol(source.symbol)
     if (source.period) this.setCurrentPeriod(source.period)
-    this.setData([...source.data])
+    // 浅克隆每个 KLineData 对象，剥离外部框架响应性代理（Vue reactive Proxy 等）
+    // 避免 structuredClone（Web Worker postMessage 底层使用）因 Proxy 陷阱中
+    // 的函数引用而抛出 DataCloneError
+    const plainData = source.data.map((d) => ({ ...d }))
+    this.setData(plainData)
     if (source.comparisons) {
       for (const key of this._comparisonBuffers.keys()) {
         if (!source.comparisons[key]) this.removeComparisonSymbol(key)
       }
       for (const [symbol, data] of Object.entries(source.comparisons)) {
-        this.setComparisonData(symbol, [...data])
+        this.setComparisonData(symbol, data.map((d) => ({ ...d })))
       }
     }
   }

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -451,6 +451,67 @@ export class ChartDataManager {
     this._symbolsSignal.set([this._symbolsSignal.peek()[0]!, ...this._comparisonSpecs])
   }
 
+  setComparisonData(symbol: string, data: KLineData[]): void {
+    const key = symbol
+    const existing = this._comparisonBuffers.get(key)
+
+    if (!existing) {
+      const buffer = new DataBuffer()
+      this._comparisonBuffers.set(key, buffer)
+
+      const unsub = buffer.data.subscribe(() => {
+        this._comparisonData.set(key, [...buffer.data.peek()])
+        this.deps.scheduleDraw()
+      })
+      this._comparisonBufferUnsubs.set(key, unsub)
+
+      const unsubLoading = buffer.loading.subscribe(() => this.recomputeComparisonLoading())
+      this._comparisonLoadingUnsubs.set(key, unsubLoading)
+
+      const color =
+        COMPARISON_PALETTE[this._comparisonColors.size % COMPARISON_PALETTE.length] ??
+        DEFAULT_COMPARISON_COLOR
+      this._comparisonColors.set(key, color)
+      this._comparisonColorsSignal.set(new Map(this._comparisonColors))
+
+      const spec: SymbolSpec = { symbol, period: this.currentPeriod }
+      this._comparisonSpecs.push(spec)
+      const mainSpec = this._symbolsSignal.peek()[0]
+      this._symbolsSignal.set(mainSpec ? [mainSpec, ...this._comparisonSpecs] : [...this._comparisonSpecs])
+    }
+
+    existing ??= this._comparisonBuffers.get(key)!
+    existing.setInlineData(data)
+  }
+
+  setCurrentSymbol(symbol: string): void {
+    const currentSpec = this._dataBuffer.currentSpec
+    if (currentSpec) {
+      this._dataBuffer.setCurrentSpec({ ...currentSpec, symbol })
+    } else {
+      this._dataBuffer.setCurrentSpec({ symbol })
+    }
+    const specs = this._symbolsSignal.peek()
+    if (specs.length > 0) {
+      const updated = [{ ...specs[0], symbol }, ...specs.slice(1)] as SymbolSpec[]
+      this._symbolsSignal.set(updated)
+    }
+  }
+
+  setCurrentPeriod(period: string): void {
+    const currentSpec = this._dataBuffer.currentSpec
+    if (currentSpec) {
+      this._dataBuffer.setCurrentSpec({ ...currentSpec, period })
+    } else {
+      this._dataBuffer.setCurrentSpec({ symbol: '', period })
+    }
+    const specs = this._symbolsSignal.peek()
+    if (specs.length > 0) {
+      const updated = [{ ...specs[0], period }, ...specs.slice(1)] as SymbolSpec[]
+      this._symbolsSignal.set(updated)
+    }
+  }
+
   removeComparisonSymbol(symbol: string): void {
     const key = symbol
     if (!this._comparisonBuffers.has(key)) return

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -516,9 +516,18 @@ export class ChartDataManager {
   applyCustomData(source: CustomDataSource): void {
     if (source.symbol) this.setCurrentSymbol(source.symbol)
     if (source.period) this.setCurrentPeriod(source.period)
-    // 浅克隆每个 KLineData 对象，剥离外部框架响应性代理（Vue reactive Proxy 等）
-    // 避免 structuredClone（Web Worker postMessage 底层使用）因 Proxy 陷阱中
-    // 的函数引用而抛出 DataCloneError
+
+    // 确保主品种在 _symbolsSignal 中有条目，避免后续 setComparisonData
+    // 因取不到 mainSpec 而把第一个对比商品误当做主品种
+    const specs = this._symbolsSignal.peek()
+    if (specs.length === 0 && source.symbol) {
+      const mainSpec: SymbolSpec = {
+        symbol: source.symbol,
+        period: source.period ?? 'daily',
+      }
+      this._symbolsSignal.set([mainSpec])
+    }
+
     const plainData = source.data.map((d) => ({ ...d }))
     this.setData(plainData)
     if (source.comparisons) {

--- a/packages/core/src/engine/renderers/lastPrice.ts
+++ b/packages/core/src/engine/renderers/lastPrice.ts
@@ -68,7 +68,7 @@ export function createLastPriceLineRendererPlugin(): RendererPlugin {
         priority: RENDERER_PRIORITY.LAST_PRICE_LABEL,
 
         draw(context: RenderContext) {
-            const { ctx, scrollLeft, dpr, kLinePositions, paneWidth } = context
+            const { ctx, scrollLeft, dpr, paneWidth } = context
             const colors = resolveThemeColors(context.theme, context.isAsiaMarket, context.colorPresetSettings)
             const info = getLastPriceInfo(context)
             if (!info) return
@@ -78,7 +78,8 @@ export function createLastPriceLineRendererPlugin(): RendererPlugin {
             ctx.save()
             ctx.translate(-scrollLeft, 0)
 
-            const startX = kLinePositions[0] ?? 0
+            // 最新价水平线横贯整个视口（从左边缘到右边缘）
+            const startX = scrollLeft
             const endX = paneWidth + scrollLeft
 
             ctx.strokeStyle = colors.price.lastPrice

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -108,6 +108,34 @@ const config: SemanticChartConfig = {
 </template>
 ```
 
+### Inject Custom Data Directly (Without Fetcher)
+
+```vue
+<script setup lang="ts">
+import KLineChart from '@363045841yyt/klinechart'
+import type { CustomDataSource, KLineData } from '@363045841yyt/klinechart'
+
+const myData: KLineData[] = [
+  { timestamp: 1748736000000, date: '2025-06-01', open: 30, high: 32, low: 30, close: 31.5, volume: 1500000 },
+  { timestamp: 1748822400000, date: '2025-06-02', open: 31.5, high: 33.2, low: 31.2, close: 33, volume: 2100000 },
+]
+
+const customDataSource: CustomDataSource = {
+  symbol: 'MY.STOCK',
+  period: 'daily',
+  data: myData,
+  comparisons: {
+    'COMP.A': [ /* comparison KLineData[] */ ],
+    'COMP.B': [ /* comparison KLineData[] */ ],
+  },
+}
+</script>
+
+<template>
+  <KLineChart :customData="customDataSource" />
+</template>
+```
+
 ## 📖 More Documentation
 
 - [Rendering Engine Architecture](./docs/rendering-engine-architecture.md) - Core rendering pipeline and physical pixel alignment mechanism
@@ -127,6 +155,7 @@ const config: SemanticChartConfig = {
 | priceLabelWidth | `number` | 60 | Price label extra width for showing change percentage |
 | zoomLevels | `number` | 20 | Total number of zoom levels |
 | initialZoomLevel | `number` | 3 | Initial zoom level (1 ~ zoomLevels) |
+| customData | `CustomDataSource` | — | Inline data bundle: `{ symbol?, period?, data, comparisons? }`. Bypasses the fetcher pipeline entirely |
 
 ## 🗺️ Roadmap
 

--- a/packages/vue/README_CN.md
+++ b/packages/vue/README_CN.md
@@ -107,6 +107,34 @@ const config: SemanticChartConfig = {
 </template>
 ```
 
+### 直接注入自定义数据（无需后端）
+
+```vue
+<script setup lang="ts">
+import KLineChart from '@363045841yyt/klinechart'
+import type { CustomDataSource, KLineData } from '@363045841yyt/klinechart'
+
+const myData: KLineData[] = [
+  { timestamp: 1748736000000, date: '2025-06-01', open: 30, high: 32, low: 30, close: 31.5, volume: 1500000 },
+  { timestamp: 1748822400000, date: '2025-06-02', open: 31.5, high: 33.2, low: 31.2, close: 33, volume: 2100000 },
+]
+
+const customDataSource: CustomDataSource = {
+  symbol: 'MY.STOCK',
+  period: 'daily',
+  data: myData,
+  comparisons: {
+    'COMP.A': [ /* 对比商品 KLineData[] */ ],
+    'COMP.B': [ /* 对比商品 KLineData[] */ ],
+  },
+}
+</script>
+
+<template>
+  <KLineChart :customData="customDataSource" />
+</template>
+```
+
 ## 📖 更多文档
 
 - [渲染引擎架构](./docs/rendering-engine-architecture.md) —— 核心渲染管线与物理像素对齐机制
@@ -126,6 +154,7 @@ const config: SemanticChartConfig = {
 | priceLabelWidth | `number` | 60 | 价格标签的额外宽度，用于显示涨跌幅 |
 | zoomLevels | `number` | 20 | 缩放等级总数 |
 | initialZoomLevel | `number` | 3 | 初始缩放等级（1 ~ zoomLevels） |
+| customData | `CustomDataSource` | — | 内联数据包：`{ symbol?, period?, data, comparisons? }`。完全绕过数据请求器，直接使用传入的数据渲染 |
 
 ## 🗺️ 路线图
 

--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -35,19 +35,13 @@
             <path d="M3 16v3a2 2 0 0 0 2 2h3" />
           </svg>
         </button>
-        <button @click="onDemoInjectComparison" title="注入比较商品（演示 setComparisonData）">
+        <button
+          :class="{ 'is-active': useCustomData }"
+          @click="onToggleCustomData"
+          :title="useCustomData ? '切换到 Fetcher 数据源' : '切换到自定义数据源'"
+        >
           <svg class="debug-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-          </svg>
-        </button>
-        <button @click="onDemoChangeSymbol" title="切换商品代码（演示 setCurrentSymbol）">
-          <svg class="debug-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="2" /><path d="M12 2v4m0 12v4m10-10h-4M6 12H2" />
-          </svg>
-        </button>
-        <button @click="onDemoTogglePeriod" title="切换周期（演示 setCurrentPeriod）">
-          <svg class="debug-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <rect x="3" y="4" width="18" height="18" rx="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+            <ellipse cx="12" cy="5" rx="9" ry="3" /><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" /><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
           </svg>
         </button>
       </div>
@@ -96,6 +90,7 @@
         ref="chartRef"
         :mcp="mcpConfig"
         :dataFetcher="dataFetcher"
+        :custom-data="customData"
         :is-fullscreen="isFullscreen"
         @toggle-fullscreen="toggleFullscreen"
         @theme-change="onThemeChange"
@@ -125,18 +120,19 @@
 import { ref, computed, provide, inject, type Ref, type InjectionKey } from 'vue'
 import KLineChart from '../src/components/KLineChart.vue'
 import { VERSION, CORE_VERSION } from '../src/version'
-import { routerDataFetcher, type KLineData, type ChartController } from '@363045841yyt/klinechart-core/controllers'
+import { routerDataFetcher, type KLineData, type ChartController, type CustomDataSource } from '@363045841yyt/klinechart-core/controllers'
 import { executeTool } from '@363045841yyt/klinechart-ai-runtime'
 
 function generateMockKLineData(
   basePrice: number,
   days: number,
-  startTs: number,
+  startDate: string,
   seed: number,
 ): KLineData[] {
   const data: KLineData[] = []
   let price = basePrice
   let r = seed
+  const start = new Date(startDate).getTime()
   for (let i = 0; i < days; i++) {
     r = (r * 16807 + 0) % 2147483647
     const change = ((r % 200) - 100) / 1000
@@ -144,14 +140,16 @@ function generateMockKLineData(
     const close = +(price * (1 + change)).toFixed(2)
     const high = +(Math.max(open, close) * (1 + Math.abs(change) * 0.5)).toFixed(2)
     const low = +(Math.min(open, close) * (1 - Math.abs(change) * 0.5)).toFixed(2)
-    const volume = Math.round(1000000 + (r % 5000000))
+    const d = new Date(start + i * 86400000)
+    const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
     data.push({
-      timestamp: startTs + i * 86400000,
+      timestamp: start + i * 86400000,
+      date: dateStr,
       open,
       high,
       low,
       close,
-      volume,
+      volume: Math.round(1000000 + (r % 5000000)),
     })
     price = close
   }
@@ -240,39 +238,25 @@ if (typeof document !== 'undefined') {
   document.addEventListener('fullscreenchange', handleFullscreenChange)
 }
 
-// ── Demo: Controller Data Injection API ──
-const demoInjectedSymbols = ref<string[]>([])
+// ── 自定义数据源 Demo ──
+const useCustomData = ref(false)
+const customData = ref<CustomDataSource | null>(null)
 
-function getCtrl(): ChartController | null {
-  return chartRef.value?.getController?.() ?? null
-}
-
-function onDemoInjectComparison() {
-  const ctrl = getCtrl()
-  if (!ctrl) return
-  const now = Date.now()
-  const startTs = now - 365 * 86400000
-  const mockSymbol = `MOCK.${String.fromCharCode(65 + demoInjectedSymbols.value.length)}`
-  const mockData = generateMockKLineData(50 + demoInjectedSymbols.value.length * 10, 365, startTs, demoInjectedSymbols.value.length + 42)
-  ctrl.setComparisonData(mockSymbol, mockData)
-  demoInjectedSymbols.value = [...demoInjectedSymbols.value, mockSymbol]
-}
-
-function onDemoChangeSymbol() {
-  const ctrl = getCtrl()
-  if (!ctrl) return
-  const symbols = ['000001.SZ', '600519.SH', '300750.SZ']
-  const current = ctrl.symbols.peek()[0]?.symbol ?? ''
-  const next = symbols.find((s) => s !== current) ?? symbols[0]!
-  ctrl.setCurrentSymbol(next)
-}
-
-function onDemoTogglePeriod() {
-  const ctrl = getCtrl()
-  if (!ctrl) return
-  const current = ctrl.symbols.peek()[0]?.period ?? 'daily'
-  const next = current === 'daily' ? 'weekly' : 'daily'
-  ctrl.setCurrentPeriod(next)
+function onToggleCustomData() {
+  useCustomData.value = !useCustomData.value
+  if (useCustomData.value) {
+    customData.value = {
+      symbol: 'CUSTOM.DEMO',
+      period: 'daily',
+      data: generateMockKLineData(30, 500, '2025-06-01', 42),
+      comparisons: {
+        'COMP.A': generateMockKLineData(28, 500, '2025-06-01', 100),
+        'COMP.B': generateMockKLineData(35, 500, '2025-06-01', 200),
+      },
+    }
+  } else {
+    customData.value = null
+  }
 }
 </script>
 

--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -35,6 +35,21 @@
             <path d="M3 16v3a2 2 0 0 0 2 2h3" />
           </svg>
         </button>
+        <button @click="onDemoInjectComparison" title="注入比较商品（演示 setComparisonData）">
+          <svg class="debug-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+          </svg>
+        </button>
+        <button @click="onDemoChangeSymbol" title="切换商品代码（演示 setCurrentSymbol）">
+          <svg class="debug-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="2" /><path d="M12 2v4m0 12v4m10-10h-4M6 12H2" />
+          </svg>
+        </button>
+        <button @click="onDemoTogglePeriod" title="切换周期（演示 setCurrentPeriod）">
+          <svg class="debug-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="4" width="18" height="18" rx="2" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
+          </svg>
+        </button>
       </div>
       <div class="debug-right">
         <span class="version-badge">{{ displayVersion }}</span>
@@ -110,8 +125,38 @@
 import { ref, computed, provide, inject, type Ref, type InjectionKey } from 'vue'
 import KLineChart from '../src/components/KLineChart.vue'
 import { VERSION, CORE_VERSION } from '../src/version'
-import { routerDataFetcher } from '@363045841yyt/klinechart-core/controllers'
+import { routerDataFetcher, type KLineData, type ChartController } from '@363045841yyt/klinechart-core/controllers'
 import { executeTool } from '@363045841yyt/klinechart-ai-runtime'
+
+function generateMockKLineData(
+  basePrice: number,
+  days: number,
+  startTs: number,
+  seed: number,
+): KLineData[] {
+  const data: KLineData[] = []
+  let price = basePrice
+  let r = seed
+  for (let i = 0; i < days; i++) {
+    r = (r * 16807 + 0) % 2147483647
+    const change = ((r % 200) - 100) / 1000
+    const open = price
+    const close = +(price * (1 + change)).toFixed(2)
+    const high = +(Math.max(open, close) * (1 + Math.abs(change) * 0.5)).toFixed(2)
+    const low = +(Math.min(open, close) * (1 - Math.abs(change) * 0.5)).toFixed(2)
+    const volume = Math.round(1000000 + (r % 5000000))
+    data.push({
+      timestamp: startTs + i * 86400000,
+      open,
+      high,
+      low,
+      close,
+      volume,
+    })
+    price = close
+  }
+  return data
+}
 
 const FULLSCREEN_TARGET_KEY: InjectionKey<Ref<HTMLElement | null>> = Symbol(
   'fullscreen-teleport-target',
@@ -193,6 +238,41 @@ function handleFullscreenChange() {
 
 if (typeof document !== 'undefined') {
   document.addEventListener('fullscreenchange', handleFullscreenChange)
+}
+
+// ── Demo: Controller Data Injection API ──
+const demoInjectedSymbols = ref<string[]>([])
+
+function getCtrl(): ChartController | null {
+  return chartRef.value?.getController?.() ?? null
+}
+
+function onDemoInjectComparison() {
+  const ctrl = getCtrl()
+  if (!ctrl) return
+  const now = Date.now()
+  const startTs = now - 365 * 86400000
+  const mockSymbol = `MOCK.${String.fromCharCode(65 + demoInjectedSymbols.value.length)}`
+  const mockData = generateMockKLineData(50 + demoInjectedSymbols.value.length * 10, 365, startTs, demoInjectedSymbols.value.length + 42)
+  ctrl.setComparisonData(mockSymbol, mockData)
+  demoInjectedSymbols.value = [...demoInjectedSymbols.value, mockSymbol]
+}
+
+function onDemoChangeSymbol() {
+  const ctrl = getCtrl()
+  if (!ctrl) return
+  const symbols = ['000001.SZ', '600519.SH', '300750.SZ']
+  const current = ctrl.symbols.peek()[0]?.symbol ?? ''
+  const next = symbols.find((s) => s !== current) ?? symbols[0]!
+  ctrl.setCurrentSymbol(next)
+}
+
+function onDemoTogglePeriod() {
+  const ctrl = getCtrl()
+  if (!ctrl) return
+  const current = ctrl.symbols.peek()[0]?.period ?? 'daily'
+  const next = current === 'daily' ? 'weekly' : 'daily'
+  ctrl.setCurrentPeriod(next)
 }
 </script>
 

--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -120,41 +120,65 @@
 import { ref, computed, provide, inject, type Ref, type InjectionKey } from 'vue'
 import KLineChart from '../src/components/KLineChart.vue'
 import { VERSION, CORE_VERSION } from '../src/version'
-import { routerDataFetcher, type KLineData, type ChartController, type CustomDataSource } from '@363045841yyt/klinechart-core/controllers'
+import { routerDataFetcher, type KLineData, type CustomDataSource } from '@363045841yyt/klinechart-core/controllers'
 import { executeTool } from '@363045841yyt/klinechart-ai-runtime'
 
-function generateMockKLineData(
-  basePrice: number,
-  days: number,
-  startDate: string,
-  seed: number,
-): KLineData[] {
-  const data: KLineData[] = []
-  let price = basePrice
-  let r = seed
-  const start = new Date(startDate).getTime()
-  for (let i = 0; i < days; i++) {
-    r = (r * 16807 + 0) % 2147483647
-    const change = ((r % 200) - 100) / 1000
-    const open = price
-    const close = +(price * (1 + change)).toFixed(2)
-    const high = +(Math.max(open, close) * (1 + Math.abs(change) * 0.5)).toFixed(2)
-    const low = +(Math.min(open, close) * (1 - Math.abs(change) * 0.5)).toFixed(2)
-    const d = new Date(start + i * 86400000)
-    const dateStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-    data.push({
-      timestamp: start + i * 86400000,
-      date: dateStr,
-      open,
-      high,
-      low,
-      close,
-      volume: Math.round(1000000 + (r % 5000000)),
-    })
-    price = close
-  }
-  return data
-}
+/** 硬编码演示数据：主品种 CUSTOM.DEMO（15 根日 K） */
+const DEMO_MAIN_DATA: KLineData[] = [
+  { timestamp: 1748736000000, date: '2025-06-01', open: 30.00, high: 32.00, low: 30.00, close: 31.50, volume: 1500000 },
+  { timestamp: 1748822400000, date: '2025-06-02', open: 31.50, high: 33.20, low: 31.20, close: 33.00, volume: 2100000 },
+  { timestamp: 1748908800000, date: '2025-06-03', open: 33.00, high: 33.50, low: 31.80, close: 32.10, volume: 1800000 },
+  { timestamp: 1748995200000, date: '2025-06-04', open: 32.10, high: 32.80, low: 31.00, close: 31.20, volume: 1200000 },
+  { timestamp: 1749081600000, date: '2025-06-05', open: 31.20, high: 31.50, low: 29.80, close: 30.00, volume: 900000 },
+  { timestamp: 1749168000000, date: '2025-06-06', open: 30.00, high: 31.00, low: 29.50, close: 30.80, volume: 1350000 },
+  { timestamp: 1749254400000, date: '2025-06-07', open: 30.80, high: 32.40, low: 30.60, close: 32.20, volume: 1700000 },
+  { timestamp: 1749340800000, date: '2025-06-08', open: 32.20, high: 34.00, low: 32.00, close: 33.80, volume: 2200000 },
+  { timestamp: 1749427200000, date: '2025-06-09', open: 33.80, high: 35.50, low: 33.50, close: 35.00, volume: 2600000 },
+  { timestamp: 1749513600000, date: '2025-06-10', open: 35.00, high: 35.20, low: 33.60, close: 33.80, volume: 1900000 },
+  { timestamp: 1749600000000, date: '2025-06-11', open: 33.80, high: 34.50, low: 33.00, close: 34.20, volume: 1550000 },
+  { timestamp: 1749686400000, date: '2025-06-12', open: 34.20, high: 36.00, low: 34.00, close: 35.60, volume: 2400000 },
+  { timestamp: 1749772800000, date: '2025-06-13', open: 35.60, high: 36.50, low: 35.00, close: 36.20, volume: 2800000 },
+  { timestamp: 1749859200000, date: '2025-06-14', open: 36.20, high: 36.80, low: 35.20, close: 35.50, volume: 2000000 },
+  { timestamp: 1749945600000, date: '2025-06-15', open: 35.50, high: 36.00, low: 34.50, close: 35.80, volume: 1600000 },
+]
+
+/** 硬编码演示数据：对比商品 COMP.A（15 根日 K，偏弱走势） */
+const DEMO_COMP_A_DATA: KLineData[] = [
+  { timestamp: 1748736000000, date: '2025-06-01', open: 28.00, high: 29.50, low: 27.80, close: 29.00, volume: 800000 },
+  { timestamp: 1748822400000, date: '2025-06-02', open: 29.00, high: 29.20, low: 27.50, close: 27.80, volume: 950000 },
+  { timestamp: 1748908800000, date: '2025-06-03', open: 27.80, high: 28.50, low: 26.80, close: 27.00, volume: 720000 },
+  { timestamp: 1748995200000, date: '2025-06-04', open: 27.00, high: 27.20, low: 25.50, close: 25.80, volume: 1100000 },
+  { timestamp: 1749081600000, date: '2025-06-05', open: 25.80, high: 26.50, low: 25.00, close: 25.20, volume: 680000 },
+  { timestamp: 1749168000000, date: '2025-06-06', open: 25.20, high: 26.00, low: 24.80, close: 25.60, volume: 840000 },
+  { timestamp: 1749254400000, date: '2025-06-07', open: 25.60, high: 26.80, low: 25.40, close: 26.50, volume: 920000 },
+  { timestamp: 1749340800000, date: '2025-06-08', open: 26.50, high: 27.50, low: 26.20, close: 27.30, volume: 1050000 },
+  { timestamp: 1749427200000, date: '2025-06-09', open: 27.30, high: 28.00, low: 26.80, close: 27.00, volume: 780000 },
+  { timestamp: 1749513600000, date: '2025-06-10', open: 27.00, high: 27.20, low: 25.80, close: 26.10, volume: 890000 },
+  { timestamp: 1749600000000, date: '2025-06-11', open: 26.10, high: 26.50, low: 25.00, close: 25.20, volume: 760000 },
+  { timestamp: 1749686400000, date: '2025-06-12', open: 25.20, high: 25.80, low: 24.00, close: 24.50, volume: 1300000 },
+  { timestamp: 1749772800000, date: '2025-06-13', open: 24.50, high: 25.60, low: 24.20, close: 25.40, volume: 960000 },
+  { timestamp: 1749859200000, date: '2025-06-14', open: 25.40, high: 26.50, low: 25.00, close: 26.20, volume: 1120000 },
+  { timestamp: 1749945600000, date: '2025-06-15', open: 26.20, high: 27.00, low: 25.80, close: 26.80, volume: 840000 },
+]
+
+/** 硬编码演示数据：对比商品 COMP.B（15 根日 K，偏强走势） */
+const DEMO_COMP_B_DATA: KLineData[] = [
+  { timestamp: 1748736000000, date: '2025-06-01', open: 35.00, high: 36.50, low: 34.80, close: 36.00, volume: 1800000 },
+  { timestamp: 1748822400000, date: '2025-06-02', open: 36.00, high: 37.20, low: 35.50, close: 37.00, volume: 2200000 },
+  { timestamp: 1748908800000, date: '2025-06-03', open: 37.00, high: 38.00, low: 36.20, close: 36.50, volume: 1950000 },
+  { timestamp: 1748995200000, date: '2025-06-04', open: 36.50, high: 37.50, low: 35.80, close: 37.20, volume: 1650000 },
+  { timestamp: 1749081600000, date: '2025-06-05', open: 37.20, high: 39.00, low: 37.00, close: 38.50, volume: 2500000 },
+  { timestamp: 1749168000000, date: '2025-06-06', open: 38.50, high: 40.00, low: 38.20, close: 39.80, volume: 2800000 },
+  { timestamp: 1749254400000, date: '2025-06-07', open: 39.80, high: 41.50, low: 39.50, close: 41.00, volume: 3100000 },
+  { timestamp: 1749340800000, date: '2025-06-08', open: 41.00, high: 41.20, low: 39.00, close: 39.50, volume: 2400000 },
+  { timestamp: 1749427200000, date: '2025-06-09', open: 39.50, high: 40.00, low: 38.00, close: 38.50, volume: 2100000 },
+  { timestamp: 1749513600000, date: '2025-06-10', open: 38.50, high: 39.50, low: 37.50, close: 39.00, volume: 1750000 },
+  { timestamp: 1749600000000, date: '2025-06-11', open: 39.00, high: 40.80, low: 38.50, close: 40.50, volume: 2300000 },
+  { timestamp: 1749686400000, date: '2025-06-12', open: 40.50, high: 42.00, low: 40.00, close: 41.50, volume: 2900000 },
+  { timestamp: 1749772800000, date: '2025-06-13', open: 41.50, high: 43.50, low: 41.00, close: 43.00, volume: 3400000 },
+  { timestamp: 1749859200000, date: '2025-06-14', open: 43.00, high: 43.50, low: 41.50, close: 42.00, volume: 2600000 },
+  { timestamp: 1749945600000, date: '2025-06-15', open: 42.00, high: 42.50, low: 40.50, close: 41.20, volume: 1900000 },
+]
 
 const FULLSCREEN_TARGET_KEY: InjectionKey<Ref<HTMLElement | null>> = Symbol(
   'fullscreen-teleport-target',
@@ -248,10 +272,10 @@ function onToggleCustomData() {
     customData.value = {
       symbol: 'CUSTOM.DEMO',
       period: 'daily',
-      data: generateMockKLineData(30, 500, '2025-06-01', 42),
+      data: DEMO_MAIN_DATA,
       comparisons: {
-        'COMP.A': generateMockKLineData(28, 500, '2025-06-01', 100),
-        'COMP.B': generateMockKLineData(35, 500, '2025-06-01', 200),
+        'COMP.A': DEMO_COMP_A_DATA,
+        'COMP.B': DEMO_COMP_B_DATA,
       },
     }
   } else {

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -70,7 +70,7 @@
           </div>
           <div class="compare-selected__list">
             <div
-              v-for="item in selectedItems"
+              v-for="item in displayItems"
               :key="item.code"
               class="compare-selected__item"
             >
@@ -156,10 +156,12 @@ import { useFullscreenTeleportTarget } from '../composables/useFullscreenTelepor
 const props = withDefaults(defineProps<{
   symbols: SymbolItem[]
   selected?: string[]
+  selectedItems?: SymbolItem[]
   comparisonColors?: Map<string, string>
   comparisonLoading?: boolean
 }>(), {
   selected: () => [],
+  selectedItems: () => [],
 })
 
 const emit = defineEmits<{
@@ -183,7 +185,8 @@ const { popupStyle, startPositionSync, stopPositionSync } = useTeleportedPopup(
 
 const selectedSet = computed(() => new Set(props.selected ?? []))
 
-const selectedItems = computed<SymbolItem[]>(() => {
+const displayItems = computed<SymbolItem[]>(() => {
+  if (props.selectedItems.length > 0) return props.selectedItems
   const set = selectedSet.value
   return props.symbols.filter((s) => set.has(s.code))
 })

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -7,6 +7,7 @@
       :symbol-loading="symbolLoading"
       :symbol-error="symbolError"
       :overlay-symbols="overlaySymbols"
+      :overlay-symbol-items="overlaySymbolItems"
       :comparison-colors="comparisonColorsMap"
       :comparison-loading="comparisonLoading"
       @add-overlay-symbol="onAddOverlaySymbol"

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -188,6 +188,7 @@ import {
   type ChartController,
   type InteractionSnapshot,
   type SymbolSpec,
+  type CustomDataSource,
   zoomLevelToKWidth,
   kGapFromKWidth,
 } from '@363045841yyt/klinechart-core/controllers'
@@ -228,6 +229,9 @@ const props = withDefaults(
     isFullscreen?: boolean
     /** 时区，默认 Asia/Shanghai */
     timezone?: string
+
+    /** 用户自定义数据源（传入后 bypass fetcher，使用此数据） */
+    customData?: CustomDataSource
 
     /** MCP / AI runtime bridge 配置。传入后自动连接 MCP WebSocket server */
     mcp?: {
@@ -885,6 +889,12 @@ function setupInteractionCallbacks(ctrl: ChartController): void {
 }
 
 function setupSemanticController(ctrl: ChartController): void {
+  // 如果传入了 customData，跳过 fetcher 配置，使用自定义数据
+  if (props.customData) {
+    ctrl.applyCustomData(props.customData)
+    return
+  }
+
   ctrl.setDataFetcher(props.dataFetcher)
   semanticController.value = new SemanticChartController(ctrl)
 
@@ -976,6 +986,14 @@ watch(
         console.error('Semantic config apply failed:', result.errors)
       }
     }
+  },
+  { deep: true },
+)
+
+watch(
+  () => props.customData,
+  (newVal) => {
+    if (newVal) controller.value?.applyCustomData(newVal)
   },
   { deep: true },
 )

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -18,6 +18,7 @@
     <CompareSymbolSelector
       :symbols="symbolPool"
       :selected="overlaySymbols"
+      :selected-items="overlaySymbolItems"
       :comparison-colors="comparisonColors"
       :comparison-loading="comparisonLoading"
       @add="emit('addOverlaySymbol', $event)"
@@ -97,6 +98,7 @@ const props = defineProps<{
   symbolLoading?: boolean
   symbolError?: boolean
   overlaySymbols?: string[]
+  overlaySymbolItems?: SymbolItem[]
   comparisonColors?: Map<string, string>
   comparisonLoading?: boolean
 }>()

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -42,6 +42,8 @@ export type {
     ChartController,
     ChartMountOptions,
     ChartViewport,
+    CustomDataSource,
+    KLineData,
 } from '@363045841yyt/klinechart-core'
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a unified **Custom Data Injection** API that allows users to bypass the fetcher pipeline and inject their own K-line data + comparison products directly through a single entry point.

## Changes

### Core (packages/core/)

- **CustomDataSource interface** — bundles symbol, period, adjust, main data, and comparison products into one object
- **ChartController.applyCustomData(source)** — unified entry that dispatches internally to setData/setComparisonData/setCurrentSymbol/setCurrentPeriod
- **DataBuffer.setInlineData()** — static mode that wraps pre-loaded data with the same signal/render pipeline as fetched data
- **ChartDataManager.applyCustomData()** — orchestrates the full flow including seeding _symbolsSignal with main symbol
- Shallow-clone each KLineData object to strip Vue reactive proxies (fixes DataCloneError in Web Worker postMessage)

### Vue (packages/vue/)

- **KLineChart.vue**: new customData prop + deep watcher; setupSemanticController early-returns when customData is provided
- **TopToolbar + CompareSymbolSelector**: fixed comparison list to use authoritative overlaySymbolItems prop

### Demo Preview

- Single toggle button switches between Fetcher mode and Custom Data mode
- Hardcoded demo data (15 candles each) with distinct price trends

## Usage

```vue
<KLineChart
  :custom-data="{
    symbol: 'CUSTOM.DEMO',
    period: 'daily',
    data: myKLineData,
    comparisons: {
      'COMP.A': myCompDataA,
      'COMP.B': myCompDataB,
    },
  }"
/>
```

## Tests

- Core: 949 passed
- Vue: 6 passed
- React: 7 passed
- Angular: 12 passed
