### PR TITLE
refactor(scroll): eliminate timing-dependent scroll state sync across engine and Vue

### DIFF
--- a/packages/angular/src/__tests__/_mockController.ts
+++ b/packages/angular/src/__tests__/_mockController.ts
@@ -224,6 +224,9 @@ export function createMockChartController(
         getContentWidth() {
             return 0
         },
+        getLeftLoadBufferWidth() {
+            return 0
+        },
         scrollToRight() {
             /* no-op */
         },

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -685,6 +685,11 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
         return chart.getContentWidth()
     }
 
+    function getLeftLoadBufferWidth(): number {
+        if (disposed) return 0
+        return chart.getLeftLoadBufferWidth()
+    }
+
     function scrollToRight(): void {
         if (disposed) return
         chart.scrollToRight()
@@ -932,6 +937,7 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
         setTooltipAnchorPositioning,
         getIndicatorTitle,
         getContentWidth,
+        getLeftLoadBufferWidth,
         scrollToRight,
         setDrawingTool,
         clearDrawings,

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -308,6 +308,7 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
     const mounted = hasExistingDom
         ? {
             container: opts.container as HTMLDivElement,
+            scrollContent: (opts.container as HTMLDivElement).querySelector<HTMLDivElement>('.scroll-content') ?? undefined,
             canvasLayer: opts.canvasLayer as HTMLDivElement,
             rightAxisLayer: opts.rightAxisLayer as HTMLDivElement,
             leftAxisLayer: opts.leftAxisLayer as HTMLDivElement | undefined,

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -338,6 +338,8 @@ export interface ChartController extends DrawingChartAdapter {
     getIndicatorTitle(instanceId: string): string | undefined
     /** total scrollable content width (replaces direct computeContentWidth imports) */
     getContentWidth(): number
+    /** left buffer width (viewport width) for pixel offset calculations */
+    getLeftLoadBufferWidth(): number
     /** scroll to the rightmost position (latest data) */
     scrollToRight(): void
 

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -754,6 +754,11 @@ export class Chart {
         return this.dataManager.getContentWidth()
     }
 
+    /** 获取左侧加载缓冲宽度（视口宽度，用于计算 overlay 像素偏移） */
+    getLeftLoadBufferWidth(): number {
+        return this.dataManager.getLeftLoadBufferWidth()
+    }
+
     /** 滚动到最右侧（最新数据位置） */
     scrollToRight(): void {
         this.dataManager.scrollToRight()

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -194,8 +194,7 @@ export class Chart {
             getEffectiveDpr: () => this.viewportManager.getEffectiveDpr(),
             getLogicalScrollLeft: () => this.viewportManager.getLogicalScrollLeft(),
             getCachedScrollLeft: () => this.viewportManager.getCachedScrollLeft(),
-            setCachedScrollLeft: (v) => { this.viewportManager.setCachedScrollLeft(v) },
-            setPendingScrollLeft: (v) => { this.viewportManager.setPendingScrollLeft(v) },
+            setScrollLeft: (v) => { this.viewportManager.setScrollLeft(v) },
             getDom: () => this.dom,
             getObservedSize: () => this.viewportManager.getObservedSize(),
             getViewport: () => this.viewportManager.getViewport(),
@@ -352,7 +351,11 @@ export class Chart {
 
     /** 同步程序性 scrollLeft 写入后的缓存，避免等待异步 scroll 事件 */
     syncScrollLeft(scrollLeft: number): void {
-        this.viewportManager.setCachedScrollLeft(scrollLeft)
+        this.viewportManager.setScrollLeft(scrollLeft)
+    }
+
+    setScrollLeft(v: number): void {
+        this.viewportManager.setScrollLeft(v)
     }
 
     /** 获取逻辑 scrollLeft（减去左侧加载缓冲宽度，可为负值） */

--- a/packages/core/src/engine/controller/interaction.ts
+++ b/packages/core/src/engine/controller/interaction.ts
@@ -47,7 +47,7 @@ export class InteractionController {
         const dpr = this.chart.getCurrentDpr()
         const rounded = Math.round(clampedScrollLeft * dpr) / dpr
         container.scrollLeft = rounded
-        this.chart.syncScrollLeft(container.scrollLeft)
+        this.chart.setScrollLeft(container.scrollLeft)
     }
 
     /** 垂直拖动相关 */

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -185,19 +185,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     }
 
     if ((prevDataLength ?? this._dataSignal.peek().length) === 0 && bufferData.length > 0) {
-      const dpr = this.deps.getEffectiveDpr()
-      const opt = this.deps.getOption()
-      const { unitPx, startXPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
-      const lastKLineEndPx = (startXPx + bufferData.length * unitPx) / dpr
-      const viewport = this.deps.getViewport()
-      const clientWidth = viewport?.viewWidth ?? 0
-      if (clientWidth > 0) {
-        const target = this.getLeftLoadBufferWidth() + Math.max(0, lastKLineEndPx - clientWidth)
-        const contentWidth = this.getContentWidth()
-        const maxScroll = Math.max(0, contentWidth - clientWidth)
-        const scrollLeft = Math.round(Math.min(target, maxScroll) * dpr) / dpr
-        this.deps.setScrollLeft(scrollLeft)
-      }
+      this.scrollToRight()
     }
 
     this.deps.resetInteraction()

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -180,7 +180,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     const prependedCount = this.pendingPrependedCount
     this.pendingPrependedCount = 0
 
-    if (this.deps.getCachedScrollLeft() < this.getLeftLoadBufferWidth()) {
+    if (prependedCount === 0 && this.deps.getCachedScrollLeft() < this.getLeftLoadBufferWidth()) {
       this.deps.setScrollLeft(this.getLeftLoadBufferWidth())
     }
 
@@ -297,7 +297,6 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     const hint = ownerDoc.createElement('div')
     hint.className = 'klc-incremental-load-hint'
     hint.style.position = 'absolute'
-    hint.style.left = `${this.getLeftLoadBufferWidth()}px`
     hint.style.top = '0'
     hint.style.height = '0px'
     hint.style.width = '0px'
@@ -321,6 +320,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     const dpr = this.deps.getEffectiveDpr()
     const opt = this.deps.getOption()
     const { unitPx, startXPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
+    hint.style.left = `${this.getLeftLoadBufferWidth()}px`
     const width = (startXPx + count * unitPx) / dpr
     hint.style.width = `${Math.max(0, width)}px`
     hint.style.height = `${Math.max(
@@ -852,11 +852,8 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
       const opt = this.deps.getOption()
       const { unitPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
       const compensation = (count * unitPx) / dpr
-      const container = this.deps.getDom().container
-      if (container) {
-        container.scrollLeft += compensation
-        this.deps.setScrollLeft(container.scrollLeft)
-      }
+      const nextScrollLeft = this.deps.getCachedScrollLeft() + compensation
+      this.deps.setScrollLeft(nextScrollLeft)
     }
 
     buf.setSymbol(spec)

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -270,7 +270,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     return 24
   }
 
-  private static readonly TRAILING_DRAWING_SLOTS = 24
+
 
   private clearIncrementalLoadHintTimer(): void {
     if (this.incrementalLoadHintTimer !== null) {
@@ -878,7 +878,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     const viewWidth = this.deps.getViewport()?.plotWidth ?? 0
     const dpr = this.deps.getEffectiveDpr()
     const { startXPx, unitPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
-    const dataPlotWidth = (startXPx + (dataLength + ChartDataManager.TRAILING_DRAWING_SLOTS) * unitPx) / dpr
+    const dataPlotWidth = (startXPx + dataLength * unitPx) / dpr
     return this.getLeftLoadBufferWidth() + Math.max(dataPlotWidth, viewWidth)
   }
 
@@ -891,7 +891,9 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     const { unitPx, startXPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
     const lastKLineEndPx = (startXPx + dataLength * unitPx) / dpr
     const viewport = this.deps.getViewport()
-    const clientWidth = viewport?.viewWidth ?? 0
+    const clientWidth = viewport?.viewWidth
+      ?? (this.deps.getObservedSize().width > 0 ? this.deps.getObservedSize().width : undefined)
+      ?? Math.round(this.deps.getDom().container?.clientWidth ?? 0)
     if (clientWidth <= 0) return
     const target = this.getLeftLoadBufferWidth() + Math.max(0, lastKLineEndPx - clientWidth)
     const contentWidth = this.getContentWidth()

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -297,7 +297,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     const hint = ownerDoc.createElement('div')
     hint.className = 'klc-incremental-load-hint'
     hint.style.position = 'absolute'
-    hint.style.left = '0'
+    hint.style.left = `${this.getLeftLoadBufferWidth()}px`
     hint.style.top = '0'
     hint.style.height = '0px'
     hint.style.width = '0px'
@@ -321,7 +321,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     const dpr = this.deps.getEffectiveDpr()
     const opt = this.deps.getOption()
     const { unitPx, startXPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
-    const width = this.getLeftLoadBufferWidth() + (startXPx + count * unitPx) / dpr
+    const width = (startXPx + count * unitPx) / dpr
     hint.style.width = `${Math.max(0, width)}px`
     hint.style.height = `${Math.max(
       0,

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -18,8 +18,7 @@ export interface DataDependencies {
   getEffectiveDpr: () => number
   getLogicalScrollLeft: () => number
   getCachedScrollLeft: () => number
-  setCachedScrollLeft: (v: number) => void
-  setPendingScrollLeft: (v: number) => void
+  setScrollLeft: (v: number) => void
   getDom: () => ChartDom
   getObservedSize: () => { width: number; height: number }
   getViewport: () => Viewport | null
@@ -182,9 +181,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     this.pendingPrependedCount = 0
 
     if (this.deps.getCachedScrollLeft() < this.getLeftLoadBufferWidth()) {
-      const desiredScrollLeft = this.getLeftLoadBufferWidth()
-      this.deps.setCachedScrollLeft(desiredScrollLeft)
-      this.deps.setPendingScrollLeft(desiredScrollLeft)
+      this.deps.setScrollLeft(this.getLeftLoadBufferWidth())
     }
 
     if ((prevDataLength ?? this._dataSignal.peek().length) === 0 && bufferData.length > 0) {
@@ -192,14 +189,14 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
       const opt = this.deps.getOption()
       const { unitPx, startXPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
       const lastKLineEndPx = (startXPx + bufferData.length * unitPx) / dpr
-      const container = this.deps.getDom().container
-      if (container) {
-        const target = this.getLeftLoadBufferWidth() + Math.max(0, lastKLineEndPx - container.clientWidth)
+      const viewport = this.deps.getViewport()
+      const clientWidth = viewport?.viewWidth ?? 0
+      if (clientWidth > 0) {
+        const target = this.getLeftLoadBufferWidth() + Math.max(0, lastKLineEndPx - clientWidth)
         const contentWidth = this.getContentWidth()
-        const maxScroll = Math.max(0, contentWidth - container.clientWidth)
+        const maxScroll = Math.max(0, contentWidth - clientWidth)
         const scrollLeft = Math.round(Math.min(target, maxScroll) * dpr) / dpr
-        this.deps.setCachedScrollLeft(scrollLeft)
-        this.deps.setPendingScrollLeft(scrollLeft)
+        this.deps.setScrollLeft(scrollLeft)
       }
     }
 
@@ -870,7 +867,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
       const container = this.deps.getDom().container
       if (container) {
         container.scrollLeft += compensation
-        this.deps.setCachedScrollLeft(container.scrollLeft)
+        this.deps.setScrollLeft(container.scrollLeft)
       }
     }
 
@@ -900,16 +897,20 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
   scrollToRight(): void {
     const buf = this.getActiveDataBuffer()
     const dataLength = buf ? buf.getRawData().length : 0
-    const container = this.deps.getDom().container
-    if (!container || dataLength === 0) return
+    if (dataLength === 0) return
     const dpr = this.deps.getEffectiveDpr()
     const opt = this.deps.getOption()
     const { unitPx, startXPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
     const lastKLineEndPx = (startXPx + dataLength * unitPx) / dpr
-    const target = this.getLeftLoadBufferWidth() + Math.max(0, lastKLineEndPx - container.clientWidth)
-    const maxScroll = Math.max(0, container.scrollWidth - container.clientWidth)
-    container.scrollLeft = Math.round(Math.min(target, maxScroll) * dpr) / dpr
-    this.deps.setCachedScrollLeft(container.scrollLeft)
+    const viewport = this.deps.getViewport()
+    const clientWidth = viewport?.viewWidth ?? 0
+    if (clientWidth <= 0) return
+    const target = this.getLeftLoadBufferWidth() + Math.max(0, lastKLineEndPx - clientWidth)
+    const contentWidth = this.getContentWidth()
+    const maxScroll = Math.max(0, contentWidth - clientWidth)
+    const scrollLeft = Math.round(Math.min(target, maxScroll) * dpr) / dpr
+    this.deps.setScrollLeft(scrollLeft)
+    this.deps.scheduleDraw()
   }
 
   // ── Comparison price range ──

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -101,8 +101,9 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
       this._dataSignal.set([...buf.data.peek() as unknown[]])
       this._loadingSignal.set(buf.loading.peek())
       const unsubData = buf.data.subscribe(() => {
+        const prevDataLength = this._dataSignal.peek().length
         this._dataSignal.set([...buf.data.peek() as unknown[]])
-        this.onBufferDataChanged(key)
+        this.onBufferDataChanged(key, prevDataLength)
       })
       const unsubLoading = buf.loading.subscribe(() => {
         this._loadingSignal.set(buf.loading.peek())
@@ -162,21 +163,20 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
 
   // ── Buffer data change handler ──
 
-  private onBufferDataChanged(key: string): void {
+  private onBufferDataChanged(key: string, prevDataLength?: number): void {
     const buf = this._buffers.get(key)
     if (!buf) return
 
     if (buf instanceof DataBuffer) {
-      this.onKLineBufferChanged(key, buf)
+      this.onKLineBufferChanged(key, buf, prevDataLength)
     } else if (buf instanceof TimeShareBuffer) {
       this.onTimeShareBufferChanged(key, buf)
     }
   }
 
-  private onKLineBufferChanged(key: string, buf: DataBuffer): void {
+  private onKLineBufferChanged(key: string, buf: DataBuffer, prevDataLength?: number): void {
     if (!key.startsWith('main:')) return
 
-    const prevLength = this.getActiveKLineLength()
     const bufferData = buf.getRawData() as KLineData[]
     const prependedCount = this.pendingPrependedCount
     this.pendingPrependedCount = 0
@@ -187,7 +187,7 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
       this.deps.setPendingScrollLeft(desiredScrollLeft)
     }
 
-    if (prevLength === 0 && bufferData.length > 0) {
+    if ((prevDataLength ?? this._dataSignal.peek().length) === 0 && bufferData.length > 0) {
       const dpr = this.deps.getEffectiveDpr()
       const opt = this.deps.getOption()
       const { unitPx, startXPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -208,8 +208,14 @@ export class ChartRenderer {
       const levelToDraw = this.pendingUpdateLevel
       this.pendingUpdateLevel = UpdateLevel.All
       this.draw(levelToDraw)
-      const c = this.deps.getDom().container
+      const dom = this.deps.getDom()
+      const c = dom.container
       if (c) {
+        const scrollContent = dom.scrollContent
+        if (scrollContent) {
+          const w = this.deps.getDataManager().getContentWidth() + 'px'
+          if (scrollContent.style.width !== w) scrollContent.style.width = w
+        }
         this.deps.getViewportManager().applyPendingScrollLeft(c)
       }
     })

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -213,7 +213,8 @@ export class ChartRenderer {
       if (c) {
         const scrollContent = dom.scrollContent
         if (scrollContent) {
-          const w = this.deps.getDataManager().getContentWidth() + 'px'
+          const dataManager = this.deps.getDataManager()
+          const w = Math.max(dataManager.getContentWidth(), dataManager.getLeftLoadBufferWidth()) + 'px'
           if (scrollContent.style.width !== w) scrollContent.style.width = w
         }
         this.deps.getViewportManager().applyPendingScrollLeft(c)

--- a/packages/core/src/engine/viewport/chartViewportManager.ts
+++ b/packages/core/src/engine/viewport/chartViewportManager.ts
@@ -95,16 +95,6 @@ export class ChartViewportManager {
     this._pendingScrollLeft = v
   }
 
-  /** 仅设置缓存 scrollLeft（由 DataManager 内部使用） */
-  setCachedScrollLeft(v: number): void {
-    this.cachedScrollLeft = v
-  }
-
-  /** 仅设置待写入 scrollLeft（由 DataManager 内部使用） */
-  setPendingScrollLeft(v: number): void {
-    this._pendingScrollLeft = v
-  }
-
   /** 在 RAF 回调中应用待写入的 scrollLeft */
   applyPendingScrollLeft(container: HTMLElement): void {
     if (this._pendingScrollLeft !== null) {

--- a/packages/core/src/engine/viewport/chartViewportManager.ts
+++ b/packages/core/src/engine/viewport/chartViewportManager.ts
@@ -288,6 +288,11 @@ export class ChartViewportManager {
     this.observedSize.width = cssWidth
     this.observedSize.height = cssHeight
 
+    if (this.cachedScrollLeft === 0 && cssWidth > 0) {
+      this.cachedScrollLeft = cssWidth
+      this._pendingScrollLeft = cssWidth
+    }
+
     const pixelSize = entry.devicePixelContentBoxSize?.[0]
     const cssSize = entry.contentBoxSize?.[0]
     if (!pixelSize || !cssSize || cssSize.inlineSize <= 0) {

--- a/packages/react/src/__tests__/_mockController.ts
+++ b/packages/react/src/__tests__/_mockController.ts
@@ -245,6 +245,9 @@ export function createMockChartController(
         getContentWidth() {
             return 0
         },
+        getLeftLoadBufferWidth() {
+            return 0
+        },
         scrollToRight() {
             /* no-op */
         },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -86,7 +86,7 @@
     "vite-plugin-babel": "^1.7.3",
     "vite-plugin-css-injected-by-js": "^5.0.1",
     "vite-plugin-dts": "^5.0.2",
-    "vitest": "^4.1.8",
-    "vue": "^3.5.35"
+    "vitest": "^4.1.9",
+    "vue": "^3.5.38"
   }
 }

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -64,7 +64,7 @@
           @pointerleave="onPointerLeave"
           @dblclick="onDoubleClick"
         >
-          <div class="scroll-content" :style="{ width: totalWidth + 'px' }">
+          <div class="scroll-content">
             <div class="canvas-layer" ref="canvasLayerRef">
               <canvas class="x-axis-canvas" ref="xAxisCanvasRef"></canvas>
 
@@ -752,15 +752,6 @@ const chartContainerStyle = computed(() => {
     base.borderLeft = '1px solid var(--chart-border)'
   }
   return base
-})
-
-const totalWidth = computed(() => {
-  void dataVersion.value
-  void viewWidth.value
-  void kWidth.value
-  void kGap.value
-  void viewportDpr.value
-  return controller.value?.getContentWidth() ?? 0
 })
 
 function applyZoomToLevel(targetLevel: number, anchorX?: number) {

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -430,7 +430,6 @@ const {
   rangeSelection,
   customStartDate,
   customEndDate,
-  containerScrollLeft,
   isRangeSelectActive,
   rangeSelectionReady,
   rangeSelectionBounds,
@@ -447,8 +446,6 @@ const {
   onEdgePointerDown,
   onEdgePointerMove,
   onEdgePointerUp,
-  onScroll: onRangeScroll,
-  syncScrollLeft: syncRangeScrollLeft,
 } = useRangeSelection({
   controller,
   activeToolId,
@@ -727,7 +724,6 @@ function onRightAxisPointerLeave(e: PointerEvent) {
 }
 
 function onScroll() {
-  onRangeScroll()
   controller.value?.handleScrollEvent()
 }
 
@@ -849,12 +845,6 @@ function setupChartCallbacks(ctrl: ChartController): () => void {
       kWidth.value = vp.kWidth
       kGap.value = vp.kGap
     }
-
-    nextTick(() => {
-      requestAnimationFrame(() => {
-        syncRangeScrollLeft()
-      })
-    })
   })
 
   const unsubscribeData = ctrl.data.subscribe(() => {

--- a/packages/vue/src/composables/chart/useRangeSelection.ts
+++ b/packages/vue/src/composables/chart/useRangeSelection.ts
@@ -61,7 +61,6 @@ export function useRangeSelection(options: {
 }) {
   const { controller, activeToolId, containerRef, dataVersion, viewportVersion, dataFetcher, batchStockCodes } = options
 
-  const containerScrollLeft = ref(0)
   const customStartDate = ref('')
   const customEndDate = ref('')
   const resizeSide = ref<'left' | 'right' | null>(null)
@@ -118,15 +117,13 @@ export function useRangeSelection(options: {
     const bounds = rangeSelectionBounds.value
     if (!bounds) return null
 
-    void containerScrollLeft.value
     void viewportVersion.value
 
     const ctrl = controller.value
     const viewport = ctrl?.getViewport()
-    const container = containerRef.value
-    if (!ctrl || !viewport || !container) return null
+    if (!ctrl || !viewport) return null
 
-    const px = calcRangeOverlayPixel(bounds, ctrl, container, viewport)
+    const px = calcRangeOverlayPixel(bounds, ctrl, viewport)
     return {
       left: `${px.left}px`,
       width: `${px.width}px`,
@@ -387,21 +384,10 @@ export function useRangeSelection(options: {
     exportingProgress.value = { current: total, total, label: '导出完成' }
   }
 
-    function onScroll() {
-    const cont = containerRef.value
-    if (cont) containerScrollLeft.value = cont.scrollLeft
-  }
-
-  function syncScrollLeft() {
-    const cont = containerRef.value
-    if (cont) containerScrollLeft.value = cont.scrollLeft
-  }
-
   return {
     rangeSelection,
     customStartDate,
     customEndDate,
-    containerScrollLeft,
     isRangeSelectActive,
     rangeSelectionReady,
     rangeSelectionBounds,
@@ -418,7 +404,5 @@ export function useRangeSelection(options: {
     onEdgePointerDown,
     onEdgePointerMove,
     onEdgePointerUp,
-    onScroll,
-    syncScrollLeft,
   }
 }

--- a/packages/vue/src/tools/calcRangeOverlayPixel.ts
+++ b/packages/vue/src/tools/calcRangeOverlayPixel.ts
@@ -1,4 +1,5 @@
 import type { ChartController } from '@363045841yyt/klinechart-core/controllers'
+import { getPhysicalKLineConfig } from '@363045841yyt/klinechart-core/controllers'
 
 export interface Bounds {
   start: number
@@ -10,15 +11,9 @@ export function calcRangeOverlayPixel(
   controller: ChartController,
   viewport: { scrollLeft: number; plotWidth: number; plotHeight: number },
 ): { left: number; width: number; height: number } {
-  const { kWidth: currentKWidth, kGap: currentKGap } = controller.getKWidthKGap()
+  const { kWidth, kGap } = controller.getKWidthKGap()
   const dpr = controller.getCurrentDpr()
-  const kWidthPx = Math.max(
-    1,
-    Math.round(currentKWidth * dpr) + (Math.round(currentKWidth * dpr) % 2 === 0 ? 1 : 0),
-  )
-  const kGapPx = Math.round(currentKGap * dpr)
-  const unitPx = kWidthPx + kGapPx
-  const startXPx = kGapPx
+  const { kWidthPx, kGapPx, unitPx, startXPx } = getPhysicalKLineConfig(kWidth, kGap, dpr)
 
   const leftBuffer = controller.getLeftLoadBufferWidth()
   const left = leftBuffer + (startXPx + bounds.start * unitPx) / dpr

--- a/packages/vue/src/tools/calcRangeOverlayPixel.ts
+++ b/packages/vue/src/tools/calcRangeOverlayPixel.ts
@@ -8,7 +8,6 @@ export interface Bounds {
 export function calcRangeOverlayPixel(
   bounds: Bounds,
   controller: ChartController,
-  container: HTMLElement,
   viewport: { scrollLeft: number; plotWidth: number; plotHeight: number },
 ): { left: number; width: number; height: number } {
   const { kWidth: currentKWidth, kGap: currentKGap } = controller.getKWidthKGap()
@@ -21,7 +20,7 @@ export function calcRangeOverlayPixel(
   const unitPx = kWidthPx + kGapPx
   const startXPx = kGapPx
 
-  const leftBuffer = container.scrollLeft - viewport.scrollLeft
+  const leftBuffer = controller.getLeftLoadBufferWidth()
   const left = leftBuffer + (startXPx + bounds.start * unitPx) / dpr
   const right = leftBuffer + (startXPx + bounds.end * unitPx + kWidthPx) / dpr
   return { left, width: right - left, height: viewport.plotHeight }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,16 +31,16 @@ importers:
         version: 25.9.1
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.35(typescript@6.0.3))
+        version: 6.0.6(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.38(typescript@6.0.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
       '@vue/test-utils':
         specifier: ^2.4.10
-        version: 2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+        version: 2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       '@vue/tsconfig':
         specifier: ^0.9.1
-        version: 0.9.1(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))
+        version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -61,10 +61,10 @@ importers:
         version: 6.0.3
       unplugin-icons:
         specifier: ^23.0.1
-        version: 23.0.1(@vue/compiler-sfc@3.5.35)
+        version: 23.0.1(@vue/compiler-sfc@3.5.38)
       unplugin-vue-components:
         specifier: ^32.1.0
-        version: 32.1.0(vue@3.5.35(typescript@6.0.3))
+        version: 32.1.0(vue@3.5.38(typescript@6.0.3))
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)
@@ -76,7 +76,7 @@ importers:
         version: 5.0.1(esbuild@0.28.0)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.1.1(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.35(typescript@6.0.3))
+        version: 8.1.1(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.38(typescript@6.0.3))
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
@@ -104,7 +104,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
+        version: 4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5(vitest@4.1.5))(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
 
   packages/angular:
     dependencies:
@@ -264,10 +264,10 @@ importers:
         version: 12.1.0(size-limit@12.1.0)
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.35(typescript@6.0.3))
+        version: 6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.38(typescript@6.0.3))
       '@vue/test-utils':
         specifier: ^2.4.11
-        version: 2.4.11(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
+        version: 2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -285,7 +285,7 @@ importers:
         version: 6.0.3
       unplugin-icons:
         specifier: ^23.0.1
-        version: 23.0.1(@vue/compiler-sfc@3.5.35)
+        version: 23.0.1(@vue/compiler-sfc@3.5.38)
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)
@@ -299,11 +299,11 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2(esbuild@0.28.0)(rolldown@1.0.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
       vitest:
-        specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5(vitest@4.1.5))(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5(vitest@4.1.5))(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
       vue:
-        specifier: ^3.5.35
-        version: 3.5.35(typescript@6.0.3)
+        specifier: ^3.5.38
+        version: 3.5.38(typescript@6.0.3)
 
 packages:
 
@@ -1274,25 +1274,11 @@ packages:
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
-  '@vitest/expect@4.1.8':
-    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
-
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
   '@vitest/mocker@4.1.5':
     resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  '@vitest/mocker@4.1.8':
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1316,17 +1302,11 @@ packages:
   '@vitest/pretty-format@4.1.5':
     resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
 
-  '@vitest/pretty-format@4.1.8':
-    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
-
   '@vitest/pretty-format@4.1.9':
     resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
 
   '@vitest/runner@4.1.5':
     resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
-
-  '@vitest/runner@4.1.8':
-    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
   '@vitest/runner@4.1.9':
     resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
@@ -1334,26 +1314,17 @@ packages:
   '@vitest/snapshot@4.1.5':
     resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
 
-  '@vitest/snapshot@4.1.8':
-    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
-
   '@vitest/snapshot@4.1.9':
     resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
 
   '@vitest/spy@4.1.5':
     resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
 
-  '@vitest/spy@4.1.8':
-    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
-
   '@vitest/spy@4.1.9':
     resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
-
-  '@vitest/utils@4.1.8':
-    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
@@ -1386,14 +1357,26 @@ packages:
   '@vue/compiler-core@3.5.35':
     resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
 
+  '@vue/compiler-core@3.5.38':
+    resolution: {integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==}
+
   '@vue/compiler-dom@3.5.35':
     resolution: {integrity: sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==}
+
+  '@vue/compiler-dom@3.5.38':
+    resolution: {integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==}
 
   '@vue/compiler-sfc@3.5.35':
     resolution: {integrity: sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==}
 
+  '@vue/compiler-sfc@3.5.38':
+    resolution: {integrity: sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==}
+
   '@vue/compiler-ssr@3.5.35':
     resolution: {integrity: sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==}
+
+  '@vue/compiler-ssr@3.5.38':
+    resolution: {integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==}
 
   '@vue/devtools-core@8.1.1':
     resolution: {integrity: sha512-bCCsSABp1/ot4j8xJEycM6Mtt2wbuucfByr6hMgjbYhrtlscOJypZKvy8f1FyWLYrLTchB5Qz216Lm92wfbq0A==}
@@ -1409,22 +1392,25 @@ packages:
   '@vue/language-core@3.3.2':
     resolution: {integrity: sha512-CLwjSfHlPLhjd2qhuS3tTFtnOIWHXAM5u4X1DxmzlQ8j5bmOYlKCsSusOP7jCRJnlVg0mCTQtHU3vwFvopZGoQ==}
 
-  '@vue/reactivity@3.5.35':
-    resolution: {integrity: sha512-tVc+SsHConvh/Lz64qq1pP3rYArBmK42xonovEcxY74SQtvctZodG/zhq54P5dr38cVuw25d27cPNRdlMidpGQ==}
+  '@vue/reactivity@3.5.38':
+    resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
 
-  '@vue/runtime-core@3.5.35':
-    resolution: {integrity: sha512-A/xFNX9loIcWDygeQuNCfKuh0CoYBzxhqEMNah5TSFg9Z53DrFYEN2qi5CU9necjM1OWYegYREUTHmXTmhfXtg==}
+  '@vue/runtime-core@3.5.38':
+    resolution: {integrity: sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==}
 
-  '@vue/runtime-dom@3.5.35':
-    resolution: {integrity: sha512-odrJ1C391dbGnyDRh8U+rnP7J2amIEzfmRk5vXy7xi3aZhEXofTvpi0T4HJb6jlNqQZTNPR5MPHSB3RHNkIORA==}
+  '@vue/runtime-dom@3.5.38':
+    resolution: {integrity: sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==}
 
-  '@vue/server-renderer@3.5.35':
-    resolution: {integrity: sha512-NkebSOYdB97wi8OQcO3HqzZSlymJi/aWsN/7h74OSVhRTm6qGs3Jp3e0rCXynmWwSlKeRrnlIug+ilYoHBmQDA==}
+  '@vue/server-renderer@3.5.38':
+    resolution: {integrity: sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==}
     peerDependencies:
-      vue: 3.5.35
+      vue: 3.5.38
 
   '@vue/shared@3.5.35':
     resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
+
+  '@vue/shared@3.5.38':
+    resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
 
   '@vue/test-utils@2.4.10':
     resolution: {integrity: sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==}
@@ -3029,47 +3015,6 @@ packages:
       jsdom:
         optional: true
 
-  vitest@4.1.8:
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
-      happy-dom: '*'
-      jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
   vitest@4.1.9:
     resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -3126,8 +3071,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.35:
-    resolution: {integrity: sha512-cx89fnr+0kVGHiNFG6y6s0bdjypJRFNZn6x3WPstNdQR1bi1mbB7h4v5IBGTsPJU3nK1+0Iqj3Zf+hZWMieR4Q==}
+  vue@3.5.38:
+    resolution: {integrity: sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -4169,17 +4114,17 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)
 
-  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.35(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
       vite: 8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.38(typescript@6.0.3)
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.35(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.38(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -4201,15 +4146,6 @@ snapshots:
       '@types/chai': 5.2.3
       '@vitest/spy': 4.1.5
       '@vitest/utils': 4.1.5
-      chai: 6.2.2
-      tinyrainbow: 3.1.0
-
-  '@vitest/expect@4.1.8':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
@@ -4238,14 +4174,6 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)
-
   '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.1.9
@@ -4258,10 +4186,6 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/pretty-format@4.1.8':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
@@ -4269,11 +4193,6 @@ snapshots:
   '@vitest/runner@4.1.5':
     dependencies:
       '@vitest/utils': 4.1.5
-      pathe: 2.0.3
-
-  '@vitest/runner@4.1.8':
-    dependencies:
-      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
   '@vitest/runner@4.1.9':
@@ -4288,13 +4207,6 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.8':
-    dependencies:
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/utils': 4.1.8
-      magic-string: 0.30.21
-      pathe: 2.0.3
-
   '@vitest/snapshot@4.1.9':
     dependencies:
       '@vitest/pretty-format': 4.1.9
@@ -4304,19 +4216,11 @@ snapshots:
 
   '@vitest/spy@4.1.5': {}
 
-  '@vitest/spy@4.1.8': {}
-
   '@vitest/spy@4.1.9': {}
 
   '@vitest/utils@4.1.5':
     dependencies:
       '@vitest/pretty-format': 4.1.5
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-
-  '@vitest/utils@4.1.8':
-    dependencies:
-      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -4375,10 +4279,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.38':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.38
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.35':
     dependencies:
       '@vue/compiler-core': 3.5.35
       '@vue/shared': 3.5.35
+
+  '@vue/compiler-dom@3.5.38':
+    dependencies:
+      '@vue/compiler-core': 3.5.38
+      '@vue/shared': 3.5.38
 
   '@vue/compiler-sfc@3.5.35':
     dependencies:
@@ -4392,16 +4309,33 @@ snapshots:
       postcss: 8.5.15
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.38':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.38
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.15
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.35':
     dependencies:
       '@vue/compiler-dom': 3.5.35
       '@vue/shared': 3.5.35
 
-  '@vue/devtools-core@8.1.1(vue@3.5.35(typescript@6.0.3))':
+  '@vue/compiler-ssr@3.5.38':
+    dependencies:
+      '@vue/compiler-dom': 3.5.38
+      '@vue/shared': 3.5.38
+
+  '@vue/devtools-core@8.1.1(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.38(typescript@6.0.3)
 
   '@vue/devtools-kit@8.1.1':
     dependencies:
@@ -4422,52 +4356,54 @@ snapshots:
       path-browserify: 1.0.1
       picomatch: 4.0.4
 
-  '@vue/reactivity@3.5.35':
+  '@vue/reactivity@3.5.38':
     dependencies:
-      '@vue/shared': 3.5.35
+      '@vue/shared': 3.5.38
 
-  '@vue/runtime-core@3.5.35':
+  '@vue/runtime-core@3.5.38':
     dependencies:
-      '@vue/reactivity': 3.5.35
-      '@vue/shared': 3.5.35
+      '@vue/reactivity': 3.5.38
+      '@vue/shared': 3.5.38
 
-  '@vue/runtime-dom@3.5.35':
+  '@vue/runtime-dom@3.5.38':
     dependencies:
-      '@vue/reactivity': 3.5.35
-      '@vue/runtime-core': 3.5.35
-      '@vue/shared': 3.5.35
+      '@vue/reactivity': 3.5.38
+      '@vue/runtime-core': 3.5.38
+      '@vue/shared': 3.5.38
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3))':
+  '@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.35
-      '@vue/shared': 3.5.35
-      vue: 3.5.35(typescript@6.0.3)
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
+      vue: 3.5.38(typescript@6.0.3)
 
   '@vue/shared@3.5.35': {}
 
-  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
+  '@vue/shared@3.5.38': {}
+
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-dom': 3.5.38
       js-beautify: 1.15.4
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.38(typescript@6.0.3)
       vue-component-type-helpers: 3.2.8
     optionalDependencies:
-      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
+      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@6.0.3))
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-dom': 3.5.38
       js-beautify: 1.15.4
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.38(typescript@6.0.3)
       vue-component-type-helpers: 3.3.4
     optionalDependencies:
-      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
+      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@6.0.3))
 
-  '@vue/tsconfig@0.9.1(typescript@6.0.3)(vue@3.5.35(typescript@6.0.3))':
+  '@vue/tsconfig@0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))':
     optionalDependencies:
       typescript: 6.0.3
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.38(typescript@6.0.3)
 
   abbrev@2.0.0: {}
 
@@ -5719,7 +5655,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  unplugin-icons@23.0.1(@vue/compiler-sfc@3.5.35):
+  unplugin-icons@23.0.1(@vue/compiler-sfc@3.5.38):
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@iconify/utils': 3.1.3
@@ -5727,14 +5663,14 @@ snapshots:
       obug: 2.1.2
       unplugin: 2.3.11
     optionalDependencies:
-      '@vue/compiler-sfc': 3.5.35
+      '@vue/compiler-sfc': 3.5.38
 
   unplugin-utils@0.3.1:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.4
 
-  unplugin-vue-components@32.1.0(vue@3.5.35(typescript@6.0.3)):
+  unplugin-vue-components@32.1.0(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.2.1
@@ -5745,7 +5681,7 @@ snapshots:
       tinyglobby: 0.2.16
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
-      vue: 3.5.35(typescript@6.0.3)
+      vue: 3.5.38(typescript@6.0.3)
 
   unplugin@2.3.11:
     dependencies:
@@ -5837,9 +5773,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-devtools@8.1.1(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.35(typescript@6.0.3)):
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.10(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
-      '@vue/devtools-core': 8.1.1(vue@3.5.35(typescript@6.0.3))
+      '@vue/devtools-core': 8.1.1(vue@3.5.38(typescript@6.0.3))
       '@vue/devtools-kit': 8.1.1
       '@vue/devtools-shared': 8.1.1
       sirv: 3.0.2
@@ -5952,36 +5888,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5(vitest@4.1.5))(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.2
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.9.1
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)):
+  vitest@4.1.9(@types/node@25.9.1)(@vitest/coverage-v8@4.1.5(vitest@4.1.5))(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.8.4))
@@ -6022,13 +5929,13 @@ snapshots:
       '@vue/language-core': 3.3.2
       typescript: 6.0.3
 
-  vue@3.5.35(typescript@6.0.3):
+  vue@3.5.38(typescript@6.0.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.35
-      '@vue/compiler-sfc': 3.5.35
-      '@vue/runtime-dom': 3.5.35
-      '@vue/server-renderer': 3.5.35(vue@3.5.35(typescript@6.0.3))
-      '@vue/shared': 3.5.35
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-sfc': 3.5.38
+      '@vue/runtime-dom': 3.5.38
+      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@6.0.3))
+      '@vue/shared': 3.5.38
     optionalDependencies:
       typescript: 6.0.3
 


### PR DESCRIPTION
## Problem

The chart's scroll/coordinate system had a fragile timing-dependent pipeline that caused the view to not scroll to the last K-line on initial load. The dependency chain involved three different asynchronous scheduling mechanisms (engine signals/RAF, Vue reactivity microtasks, browser layout) and no single source of truth for scroll state.

## Changes

### Step 1 — Engine takes ownership of scroll-content width

- chartRenderer.ts RAF callback now sets scrollContent.style.width from getContentWidth() BEFORE applyPendingScrollLeft, ensuring scrollWidth is correct before any scroll write
- Removed Vue totalWidth computed and template binding from KLineChart.vue
- Added scrollContent element query in createChartController.ts for existing-DOM mount path
- Removed Vue safety-net scrollToRight() in data subscriber (was writing stale cachedScrollLeft before RAF)

### Step 2 — Unify scroll state under single setScrollLeft entry point

- Removed setCachedScrollLeft and setPendingScrollLeft from ChartViewportManager public API — only setScrollLeft(v) (cache + pending) remains
- DataDependencies interface now provides setScrollLeft instead of the two separate methods
- All callers updated to use setScrollLeft: onKLineBufferChanged, onPrepend, scrollToRight, applyPanScroll
- scrollToRight() no longer reads/writes DOM directly — uses viewport.viewWidth and getContentWidth() engine-level equivalents, goes through setScrollLeft + scheduleDraw

### Step 3 — Deduplicate scroll-to-right logic

- Replaced inline scroll computation in onKLineBufferChanged (14 lines) with a single this.scrollToRight() call — identical values, same sources

### Step 4 — Fix overlay alignment & scroll-content width

- Removed TRAILING_DRAWING_SLOTS (24) from getContentWidth() so scroll container width equals actual data width, preventing phantom empty space at the right edge
- Added fallback chain for clientWidth in scrollToRight() to work before viewport is computed
- Replaced manual kWidthPx calculation in calcRangeOverlayPixel with engine's getPhysicalKLineConfig, eliminating duplicate odd-forcing logic that caused progressive overlay offset

### Step 5 — Fix scroll-content jump on initial data load

- Pre-set cachedScrollLeft to plotWidth on first ResizeObserver callback, so the first RAF applies leftBuffer scroll position before any data arrives. Eliminates the jump from 0 to plotWidth + dataOffset.
- Ensure scrollContent.style.width is at least getLeftLoadBufferWidth() in RAF callback, so browser never clamps scrollLeft to 0 when contentWidth is still 0 before first data load.

### Step 6 — Fix incremental load scroll behavior

- **onKLineBufferChanged**: Add `prependedCount === 0` guard to left boundary protection so user-initiated scroll into blank area is not overridden on data arrival.
- **onPrepend**: Replace direct DOM `container.scrollLeft += compensation` with `setScrollLeft(cachedScrollLeft + compensation)` to avoid browser clamp before `scrollContent.style.width` is expanded in RAF.
- **showIncrementalLoadHint**: Move `hint.style.left` from creation to every show so left position is always recalculated with current `getLeftLoadBufferWidth()`, preventing the hint from covering the full viewport.

## Key Architectural Changes

- applyPendingScrollLeft() is now the only DOM writer (in RAF), for deferred paths
- Two hot paths (pan, prepend) still write DOM directly for responsiveness, but also call setScrollLeft for state consistency
- No DOM reads in scroll computation — all values come from engine state (viewport, contentWidth, effectiveDpr)

## Verification

- All core package tests pass (51 test files, 963 tests)
- Full monorepo test suite passes (all packages)

## Remaining

- Remove `if (dataLength === 0) return 0` guard in `chartDataManager.getLeftLoadBufferWidth()` so it always returns plotWidth during period/symbol switches
