### PR TITLE
perf: optimize prepareCandles rendering pipeline

### DIFF
--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -2,7 +2,6 @@ import type { RendererPlugin, RenderContext } from '../../plugin'
 import { RENDERER_PRIORITY } from '../../plugin'
 import type { KLineData } from '../../types/price'
 import type { kLineTrend } from '../../types/kLine'
-import { createAlignedKLineFromPx, createVerticalLineRect } from '../draw/pixelAlign'
 import { resolveThemeColors, type VolumePriceColors } from '../../tokens'
 import { getPhysicalKLineConfig } from '../utils/klineConfig'
 import { VolumePriceRelation } from '../../types/volumePrice'
@@ -21,9 +20,20 @@ function ensureBufferCapacity(pool: Float32Array | null, requiredFloats: number)
   return new Float32Array(newLen)
 }
 
+type AlignedKLineResult = {
+    bodyRect: { x: number; y: number; width: number; height: number }
+    physBodyLeft: number
+    physBodyRight: number
+    physBodyWidth: number
+    physBodyCenter: number
+    physWickX: number
+    wickRect: { x: number; width: number }
+    isPerfectlyAligned: boolean
+}
+
 type CandleRenderData = {
     i: number
-    aligned: ReturnType<typeof createAlignedKLineFromPx>
+    aligned: AlignedKLineResult
     trend: kLineTrend
     openY: number
     closeY: number
@@ -141,6 +151,7 @@ function prepareCandles(args: {
     }
 
     const invDpr = 1 / dpr
+    const wickWidth = 1 / dpr
     const alignY = (logical: number) => Math.round(logical * dpr) * invDpr
 
     for (let i = range.start; i < range.end && i < data.length; i++) {
@@ -163,22 +174,34 @@ function prepareCandles(args: {
         const alignedRawRectH = Math.max(Math.abs(alignedOpenY - alignedCloseY), 1)
 
         const roundedLeftPx = Math.round(leftLogical * dpr)
-        const aligned = createAlignedKLineFromPx(
-            roundedLeftPx,
-            alignedRawRectY,
-            kWidthPx,
-            alignedRawRectH,
-            dpr
-        )
+
+        // Inlined createAlignedKLineFromPx — no object allocation
+        const topPx = Math.round(alignedRawRectY * dpr)
+        const bottomPx = Math.round((alignedRawRectY + alignedRawRectH) * dpr)
+        const bodyHPx = Math.max(1, bottomPx - topPx)
+
+        const bodyX = roundedLeftPx * invDpr
+        const bodyY = topPx * invDpr
+        const bodyW = kWidthPx * invDpr
+        const bodyH = bodyHPx * invDpr
+        const wickCenterX = (roundedLeftPx + (kWidthPx - 1) / 2) * invDpr
 
         const isUp = e.close >= e.open
-        const bodyRect = aligned.bodyRect
 
         if (showVolumePriceMarkers) {
             const targetKLines = isUp ? upKLines : downKLines
             targetKLines.push({
                 i,
-                aligned,
+                aligned: {
+                    bodyRect: { x: bodyX, y: bodyY, width: bodyW, height: bodyH },
+                    physBodyLeft: roundedLeftPx,
+                    physBodyRight: roundedLeftPx + kWidthPx,
+                    physBodyWidth: kWidthPx,
+                    physBodyCenter: wickCenterX,
+                    physWickX: wickCenterX,
+                    wickRect: { x: wickCenterX, width: 1 / dpr },
+                    isPerfectlyAligned: kWidthPx % 2 === 1,
+                },
                 trend: isUp ? 'up' : 'down',
                 openY,
                 closeY,
@@ -192,50 +215,53 @@ function prepareCandles(args: {
 
         if (isUp) {
             const off = upBodyCount++ * 4
-            upBodyBuf[off] = bodyRect.x
-            upBodyBuf[off + 1] = bodyRect.y
-            upBodyBuf[off + 2] = bodyRect.width
-            upBodyBuf[off + 3] = bodyRect.height
+            upBodyBuf[off] = bodyX
+            upBodyBuf[off + 1] = bodyY
+            upBodyBuf[off + 2] = bodyW
+            upBodyBuf[off + 3] = bodyH
         } else {
             const off = downBodyCount++ * 4
-            downBodyBuf[off] = bodyRect.x
-            downBodyBuf[off + 1] = bodyRect.y
-            downBodyBuf[off + 2] = bodyRect.width
-            downBodyBuf[off + 3] = bodyRect.height
+            downBodyBuf[off] = bodyX
+            downBodyBuf[off + 1] = bodyY
+            downBodyBuf[off + 2] = bodyW
+            downBodyBuf[off + 3] = bodyH
         }
 
-        const bodyTop = bodyRect.y
-        const bodyBottom = bodyRect.y + bodyRect.height
         const bodyHigh = isUp ? e.close : e.open
         const bodyLow = isUp ? e.open : e.close
 
+        // Inlined createVerticalLineRect for upper wick
         if (e.high > bodyHigh) {
-            const wick = createVerticalLineRect(aligned.wickRect.x, alignedHighY, bodyTop, dpr)
-            if (wick) {
-                const buf = isUp ? upWickBuf : downWickBuf
-                const idx = isUp ? upWickCount++ : downWickCount++
-                const off = idx * 4
-                buf[off] = wick.x
-                buf[off + 1] = wick.y
-                buf[off + 2] = wick.width
-                buf[off + 3] = wick.height
-            }
+            const top = Math.min(alignedHighY, bodyY)
+            const bottom = Math.max(alignedHighY, bodyY)
+            const physTop = Math.round(top * dpr)
+            const physBottom = Math.round(bottom * dpr)
+            const wickH = Math.max(1, physBottom - physTop) * invDpr
+            const buf = isUp ? upWickBuf : downWickBuf
+            const idx = isUp ? upWickCount++ : downWickCount++
+            const off = idx * 4
+            buf[off] = wickCenterX
+            buf[off + 1] = physTop * invDpr
+            buf[off + 2] = wickWidth
+            buf[off + 3] = wickH
         }
+        // Inlined createVerticalLineRect for lower wick
         if (e.low < bodyLow) {
-            const wick = createVerticalLineRect(aligned.wickRect.x, bodyBottom, alignedLowY, dpr)
-            if (wick) {
-                const buf = isUp ? upWickBuf : downWickBuf
-                const idx = isUp ? upWickCount++ : downWickCount++
-                const off = idx * 4
-                buf[off] = wick.x
-                buf[off + 1] = wick.y
-                buf[off + 2] = wick.width
-                buf[off + 3] = wick.height
-            }
+            const bodyBottom = bodyY + bodyH
+            const top = Math.min(bodyBottom, alignedLowY)
+            const bottom = Math.max(bodyBottom, alignedLowY)
+            const physTop = Math.round(top * dpr)
+            const physBottom = Math.round(bottom * dpr)
+            const wickH = Math.max(1, physBottom - physTop) * invDpr
+            const buf = isUp ? upWickBuf : downWickBuf
+            const idx = isUp ? upWickCount++ : downWickCount++
+            const off = idx * 4
+            buf[off] = wickCenterX
+            buf[off + 1] = physTop * invDpr
+            buf[off + 2] = wickWidth
+            buf[off + 3] = wickH
         }
     }
-
-    const wickWidth = 1 / dpr
 
     return {
         upKLines,

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -1,7 +1,7 @@
 import type { RendererPlugin, RenderContext } from '../../plugin'
 import { RENDERER_PRIORITY } from '../../plugin'
 import type { KLineData } from '../../types/price'
-import { getKLineTrend, type kLineTrend } from '../../types/kLine'
+import type { kLineTrend } from '../../types/kLine'
 import { createAlignedKLineFromPx, createVerticalLineRect } from '../draw/pixelAlign'
 import { resolveThemeColors, type VolumePriceColors } from '../../tokens'
 import { getPhysicalKLineConfig } from '../utils/klineConfig'
@@ -121,9 +121,11 @@ function prepareCandles(args: {
         const scaleB = paddingTop + viewHeight
         fastPriceToY = (price: number) => scaleB - (price - minPrice) * scaleK
     } else {
-        // 对数模式回退到标准方法
         fastPriceToY = (price: number) => pane.yAxis.priceToY(price)
     }
+
+    const invDpr = 1 / dpr
+    const alignY = (logical: number) => Math.round(logical * dpr) * invDpr
 
     for (let i = range.start; i < range.end && i < data.length; i++) {
         const e = data[i]
@@ -137,7 +139,6 @@ function prepareCandles(args: {
         const leftLogical = kLinePositions[i - range.start]
         if (leftLogical === undefined) continue
 
-        const alignY = (logical: number) => Math.round(logical * dpr) / dpr
         const alignedOpenY = alignY(openY)
         const alignedCloseY = alignY(closeY)
         const alignedHighY = alignY(highY)
@@ -154,11 +155,11 @@ function prepareCandles(args: {
             dpr
         )
 
-        const trend: kLineTrend = getKLineTrend(e)
+        const isUp = e.close >= e.open
         const renderData: CandleRenderData = {
             i,
             aligned,
-            trend,
+            trend: isUp ? 'up' : 'down',
             openY,
             closeY,
             highY,
@@ -169,8 +170,7 @@ function prepareCandles(args: {
         }
 
         const bodyRect = aligned.bodyRect
-        const targetKLines = trend === 'up' ? upKLines : downKLines
-        const isUp = trend === 'up'
+        const targetKLines = isUp ? upKLines : downKLines
 
         targetKLines.push(renderData)
 
@@ -190,8 +190,8 @@ function prepareCandles(args: {
 
         const bodyTop = bodyRect.y
         const bodyBottom = bodyRect.y + bodyRect.height
-        const bodyHigh = Math.max(e.open, e.close)
-        const bodyLow = Math.min(e.open, e.close)
+        const bodyHigh = isUp ? e.close : e.open
+        const bodyLow = isUp ? e.open : e.close
 
         if (e.high > bodyHigh) {
             const wick = createVerticalLineRect(aligned.wickRect.x, alignedHighY, bodyTop, dpr)
@@ -219,7 +219,7 @@ function prepareCandles(args: {
         }
     }
 
-    const wickWidth = upKLines[0]?.aligned.wickRect.width ?? downKLines[0]?.aligned.wickRect.width ?? 1
+    const wickWidth = 1 / dpr
 
     return {
         upKLines,

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -9,6 +9,18 @@ import { VolumePriceRelation } from '../../types/volumePrice'
 import { analyzeVolumePriceRelationBatch, DEFAULT_VOLUME_PRICE_CONFIG } from '../../utils/volumePrice'
 import type { MarkerManager } from '../marker/registry'
 
+// --- Float32Array buffer pool (reduces per-frame GC pressure) ---
+let poolUpBody: Float32Array | null = null
+let poolDownBody: Float32Array | null = null
+let poolUpWick: Float32Array | null = null
+let poolDownWick: Float32Array | null = null
+
+function ensureBufferCapacity(pool: Float32Array | null, requiredFloats: number): Float32Array {
+  if (pool && pool.length >= requiredFloats) return pool
+  const newLen = Math.max(requiredFloats, Math.ceil((pool?.length ?? 0) * 1.5))
+  return new Float32Array(newLen)
+}
+
 type CandleRenderData = {
     i: number
     aligned: ReturnType<typeof createAlignedKLineFromPx>
@@ -99,10 +111,14 @@ function prepareCandles(args: {
     const upKLines: CandleRenderData[] = []
     const downKLines: CandleRenderData[] = []
     const maxRects = Math.max(1, range.end - range.start)
-    const upBodyBuf = new Float32Array(maxRects * 4)
-    const downBodyBuf = new Float32Array(maxRects * 4)
-    const upWickBuf = new Float32Array(maxRects * 2 * 4)
-    const downWickBuf = new Float32Array(maxRects * 2 * 4)
+    const upBodyBuf = ensureBufferCapacity(poolUpBody, maxRects * 4)
+    poolUpBody = upBodyBuf
+    const downBodyBuf = ensureBufferCapacity(poolDownBody, maxRects * 4)
+    poolDownBody = downBodyBuf
+    const upWickBuf = ensureBufferCapacity(poolUpWick, maxRects * 2 * 4)
+    poolUpWick = upWickBuf
+    const downWickBuf = ensureBufferCapacity(poolDownWick, maxRects * 2 * 4)
+    poolDownWick = downWickBuf
     let upBodyCount = 0
     let downBodyCount = 0
     let upWickCount = 0

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -156,23 +156,23 @@ function prepareCandles(args: {
         )
 
         const isUp = e.close >= e.open
-        const renderData: CandleRenderData = {
-            i,
-            aligned,
-            trend: isUp ? 'up' : 'down',
-            openY,
-            closeY,
-            highY,
-            lowY,
-            alignedHighY,
-            alignedLowY,
-            e,
-        }
-
         const bodyRect = aligned.bodyRect
-        const targetKLines = isUp ? upKLines : downKLines
 
-        targetKLines.push(renderData)
+        if (showVolumePriceMarkers) {
+            const targetKLines = isUp ? upKLines : downKLines
+            targetKLines.push({
+                i,
+                aligned,
+                trend: isUp ? 'up' : 'down',
+                openY,
+                closeY,
+                highY,
+                lowY,
+                alignedHighY,
+                alignedLowY,
+                e,
+            })
+        }
 
         if (isUp) {
             const off = upBodyCount++ * 4

--- a/packages/core/src/utils/volumePrice.ts
+++ b/packages/core/src/utils/volumePrice.ts
@@ -60,6 +60,19 @@ class VolumePrefixSum {
   }
 
   /**
+   * 增量追加数据，避免全量重建
+   * @param data - K线数据数组，仅追加超出 dataLength 的部分
+   */
+  append(data: KLineData[]): void {
+    const newLen = data.length
+    if (newLen <= this.dataLength) return
+    for (let i = this.dataLength; i < newLen; i++) {
+      this.prefixSum.push(this.prefixSum[this.prefixSum.length - 1]! + (data[i]?.volume ?? 0))
+    }
+    this.dataLength = newLen
+  }
+
+  /**
    * 获取数据长度
    */
   get length(): number {
@@ -76,13 +89,13 @@ let cachedData: KLineData[] | null = null
  * 检测数据引用是否变化，自动重建前缀和
  */
 function getPrefixSum(data: KLineData[]): VolumePrefixSum {
-  if (
-    !globalPrefixSum
-    || cachedData !== data
-    || cachedData.length !== data.length
-  ) {
+  if (!globalPrefixSum || cachedData !== data || cachedData.length > data.length) {
     globalPrefixSum = new VolumePrefixSum()
     globalPrefixSum.build(data)
+    cachedData = data
+  } else if (cachedData.length < data.length) {
+    // 数据追加：增量更新，避免 O(n) 重建
+    globalPrefixSum.append(data)
     cachedData = data
   }
 

--- a/packages/core/src/utils/volumePrice.ts
+++ b/packages/core/src/utils/volumePrice.ts
@@ -76,7 +76,11 @@ let cachedData: KLineData[] | null = null
  * 检测数据引用是否变化，自动重建前缀和
  */
 function getPrefixSum(data: KLineData[]): VolumePrefixSum {
-  if (!globalPrefixSum || cachedData !== data) {
+  if (
+    !globalPrefixSum
+    || cachedData !== data
+    || cachedData.length !== data.length
+  ) {
     globalPrefixSum = new VolumePrefixSum()
     globalPrefixSum.build(data)
     cachedData = data
@@ -159,8 +163,7 @@ export function analyzeVolumePriceRelationBatch(
   endIndex: number,
   config: VolumePriceConfig = DEFAULT_VOLUME_PRICE_CONFIG
 ): VolumePriceRelation[] {
-  const prefixSum = new VolumePrefixSum()
-  prefixSum.build(data)
+  const prefixSum = getPrefixSum(data)
 
   const results: VolumePriceRelation[] = []
   const { volumeAmplifyThreshold, volumeShrinkThreshold, avgPeriod } = config


### PR DESCRIPTION
## Summary

Optimize the `prepareCandles` function in the K-line candle renderer to reduce per-frame GC pressure and CPU overhead.

### Changes

| Phase | File | Impact |
|-------|------|--------|
| 1 | `volumePrice.ts` | Reuse `VolumePrefixSum` cache across frames instead of O(n) rebuild on every call |
| 2 | `candle.ts` | Skip `CandleRenderData` object array when volume-price markers are disabled |
| 3 | `candle.ts` | Inline `getKLineTrend`, hoist `alignY` closure, eliminate redundant `Math.max/min`, precompute `wickWidth` |
| 4 | `candle.ts` | Float32Array buffer pool (1.5x grow) — 4 fewer allocations per frame |
| 5 | `candle.ts` | Inline `createAlignedKLineFromPx` and `createVerticalLineRect` to eliminate 3-5 small object allocations per K-line |
| 6 | `volumePrice.ts` | Incremental `append()` for real-time data growth — O(1) instead of O(n) per tick |

### Performance Impact

| Metric | Before | After |
|--------|--------|-------|
| Object allocations per frame (500 K-lines, markers off) | ~1500+ | ~0 |
| Float32Array allocations per frame | 4 | 0 (amortized over frames) |
| `VolumePrefixSum` rebuilds | every frame | only when data reference/length changes |
| Real-time data append | O(n) full rebuild | O(1) incremental push |

### Verification

- `pnpm build` (tsc) — clean
- `pnpm test:packages` — 963 tests, 51 files, all passed