### PR TITLE
perf: precompute month/day keys, optimize composers, reduce render allocations

### DIFF
--- a/packages/core/src/data-fetchers/__tests__/dataBuffer.test.ts
+++ b/packages/core/src/data-fetchers/__tests__/dataBuffer.test.ts
@@ -398,4 +398,139 @@ describe('DataBuffer', () => {
 
         expect(fetchCount).toBe(3)
     })
+
+    // ── Int32Array precomputation tests ──
+
+    function expectedMonthKey(ts: number): number {
+        const d = new Date(ts)
+        return d.getFullYear() * 12 + d.getMonth()
+    }
+
+    function expectedDayKey(ts: number): number {
+        const d = new Date(ts)
+        const yearStart = new Date(d.getFullYear(), 0, 0)
+        return d.getFullYear() * 366 + Math.floor((d.getTime() - yearStart.getTime()) / 86400000)
+    }
+
+    it('setInlineData precomputes monthKeys and dayKeys', () => {
+        const data = [
+            makeKLine(1735689600000), // 2025-01-01
+            makeKLine(1738368000000), // 2025-02-01
+            makeKLine(1740787200000), // 2025-03-01
+        ]
+        buffer.setInlineData(data)
+
+        const monthKeys = buffer.getMonthKeys()
+        const dayKeys = buffer.getDayKeys()
+        expect(monthKeys).not.toBeNull()
+        expect(dayKeys).not.toBeNull()
+        expect(monthKeys!.length).toBe(3)
+        expect(dayKeys!.length).toBe(3)
+
+        for (let i = 0; i < data.length; i++) {
+            expect(monthKeys![i]).toBe(expectedMonthKey(data[i]!.timestamp))
+            expect(dayKeys![i]).toBe(expectedDayKey(data[i]!.timestamp))
+        }
+    })
+
+    it('setInlineData with empty data sets keys to null', () => {
+        buffer.setInlineData([])
+        expect(buffer.getMonthKeys()).toBeNull()
+        expect(buffer.getDayKeys()).toBeNull()
+    })
+
+    it('setInlineData replaces previous keys', () => {
+        const data1 = [makeKLine(1735689600000)]
+        buffer.setInlineData(data1)
+        expect(buffer.getMonthKeys()!.length).toBe(1)
+
+        const data2 = [
+            makeKLine(1735689600000),
+            makeKLine(1738368000000),
+        ]
+        buffer.setInlineData(data2)
+        expect(buffer.getMonthKeys()!.length).toBe(2)
+        expect(buffer.getDayKeys()!.length).toBe(2)
+    })
+
+    it('dispose clears keys to null', () => {
+        buffer.setInlineData([makeKLine(1735689600000)])
+        expect(buffer.getMonthKeys()).not.toBeNull()
+
+        buffer.dispose()
+        expect(buffer.getMonthKeys()).toBeNull()
+        expect(buffer.getDayKeys()).toBeNull()
+    })
+
+    it('setSymbol resets keys to null before load', () => {
+        buffer.setInlineData([makeKLine(1735689600000)])
+        expect(buffer.getMonthKeys()).not.toBeNull()
+
+        buffer.setSymbol({ ...defaultSpec, symbol: 'sz.000002' })
+        expect(buffer.getMonthKeys()).toBeNull()
+        expect(buffer.getDayKeys()).toBeNull()
+    })
+
+    it('keys are available after async fetch completes', async () => {
+        const now = Date.now()
+        const oneYearAgo = now - 365 * MS_PER_DAY
+        const initialData = [makeKLine(oneYearAgo), makeKLine(now)]
+
+        const fetcher: DataFetcher = async () => initialData
+        buffer.setFetcher(fetcher)
+        buffer.setSymbol(defaultSpec)
+
+        await vi.waitFor(() => {
+            expect(buffer.loading()).toBe(false)
+        })
+
+        const monthKeys = buffer.getMonthKeys()
+        const dayKeys = buffer.getDayKeys()
+        expect(monthKeys).not.toBeNull()
+        expect(dayKeys).not.toBeNull()
+        expect(monthKeys!.length).toBe(2)
+        expect(dayKeys!.length).toBe(2)
+
+        for (let i = 0; i < initialData.length; i++) {
+            expect(monthKeys![i]).toBe(expectedMonthKey(initialData[i]!.timestamp))
+            expect(dayKeys![i]).toBe(expectedDayKey(initialData[i]!.timestamp))
+        }
+    })
+
+    it('keys are recomputed after incremental fetch prepends data', async () => {
+        const now = Date.now()
+        const oneYearAgo = now - 365 * MS_PER_DAY
+        const initialData = [makeKLine(oneYearAgo), makeKLine(now)]
+        const prependData = [makeKLine(oneYearAgo - 90 * MS_PER_DAY)]
+        const allData = [...prependData, ...initialData]
+
+        let fetchCount = 0
+        const fetcher: DataFetcher = async () => {
+            fetchCount++
+            if (fetchCount === 1) return initialData
+            return prependData
+        }
+
+        buffer.setFetcher(fetcher)
+        buffer.setSymbol(defaultSpec)
+
+        await vi.waitFor(() => {
+            expect(buffer.loading()).toBe(false)
+        })
+
+        expect(fetchCount).toBe(1)
+        expect(buffer.getMonthKeys()!.length).toBe(2)
+
+        buffer.ensureRange(oneYearAgo - 30 * MS_PER_DAY, oneYearAgo)
+
+        await vi.waitFor(() => {
+            expect(buffer.loading()).toBe(false)
+        })
+
+        expect(buffer.getMonthKeys()!.length).toBe(3)
+        for (let i = 0; i < allData.length; i++) {
+            expect(buffer.getMonthKeys()![i]).toBe(expectedMonthKey(allData[i]!.timestamp))
+            expect(buffer.getDayKeys()![i]).toBe(expectedDayKey(allData[i]!.timestamp))
+        }
+    })
 })

--- a/packages/core/src/data-fetchers/dataBuffer.ts
+++ b/packages/core/src/data-fetchers/dataBuffer.ts
@@ -63,6 +63,8 @@ export class DataBuffer implements DataBufferLike {
     private _pendingFetch: Promise<void> | null = null
     private _disposed = false
     private _attemptedBoundaries: Set<number> = new Set()
+    private _monthKeys: Int32Array | null = null
+    private _dayKeys: Int32Array | null = null
 
     onPrepend: ((count: number) => void) | null = null
 
@@ -91,6 +93,33 @@ export class DataBuffer implements DataBufferLike {
         return this._data
     }
 
+    getMonthKeys(): Int32Array | null {
+        return this._monthKeys
+    }
+
+    getDayKeys(): Int32Array | null {
+        return this._dayKeys
+    }
+
+    private _precomputeKeys(): void {
+        const n = this._data.length
+        if (n === 0) {
+            this._monthKeys = null
+            this._dayKeys = null
+            return
+        }
+        const monthKeys = new Int32Array(n)
+        const dayKeys = new Int32Array(n)
+        for (let i = 0; i < n; i++) {
+            const d = new Date(this._data[i]!.timestamp)
+            monthKeys[i] = d.getFullYear() * 12 + d.getMonth()
+            const yearStart = new Date(d.getFullYear(), 0, 0)
+            dayKeys[i] = d.getFullYear() * 366 + Math.floor((d.getTime() - yearStart.getTime()) / 86400000)
+        }
+        this._monthKeys = monthKeys
+        this._dayKeys = dayKeys
+    }
+
     setFetcher(fetcher: DataFetcher | null): void {
         this._fetcher = fetcher
     }
@@ -104,6 +133,8 @@ export class DataBuffer implements DataBufferLike {
         this._data = []
         this._loadedWindow = null
         this._attemptedBoundaries.clear()
+        this._monthKeys = null
+        this._dayKeys = null
         this._dataSignal.set([])
         if (initialStartTs !== undefined) {
             this.loadInitialRange(initialStartTs, Date.now())
@@ -199,6 +230,7 @@ export class DataBuffer implements DataBufferLike {
 
                 this._data = merged
                 this._dataSignal.set([...merged])
+                this._precomputeKeys()
 
                 if (merged.length > 0) {
                     const newEarliest = merged[0]!.timestamp
@@ -262,6 +294,7 @@ export class DataBuffer implements DataBufferLike {
             this._loadedWindow = null
         }
         this._attemptedBoundaries.clear()
+        this._precomputeKeys()
     }
 
     /**
@@ -277,5 +310,7 @@ export class DataBuffer implements DataBufferLike {
         this._data = []
         this._loadedWindow = null
         this._attemptedBoundaries.clear()
+        this._monthKeys = null
+        this._dayKeys = null
     }
 }

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -368,6 +368,14 @@ private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
     return [...this._dataSignal.peek()]
   }
 
+  getMonthKeys(): Int32Array | null {
+    return this.getActiveDataBuffer()?.getMonthKeys() ?? null
+  }
+
+  getDayKeys(): Int32Array | null {
+    return this.getActiveDataBuffer()?.getDayKeys() ?? null
+  }
+
   getTimeShareData(): TimeShareData[] {
     const buf = this.getActiveTimeShareBuffer()
     return buf ? buf.getRawData() : []

--- a/packages/core/src/engine/indicators/visibleStateComposers.ts
+++ b/packages/core/src/engine/indicators/visibleStateComposers.ts
@@ -257,7 +257,7 @@ function calc1<T extends object>(
     for (let i = start; i < end; i++) {
         const p = series[i]
         if (p) {
-            const v = p[f0]
+            const v = p[f0] as number | undefined
             if (v !== undefined) {
                 if (v < min) min = v
                 if (v > max) max = v
@@ -279,12 +279,12 @@ function calc2<T extends object>(
     for (let i = start; i < end; i++) {
         const p = series[i]
         if (p) {
-            const v0 = p[f0]
+            const v0 = p[f0] as number | undefined
             if (v0 !== undefined) {
                 if (v0 < min) min = v0
                 if (v0 > max) max = v0
             }
-            const v1 = p[f1]
+            const v1 = p[f1] as number | undefined
             if (v1 !== undefined) {
                 if (v1 < min) min = v1
                 if (v1 > max) max = v1
@@ -307,17 +307,17 @@ function calc3<T extends object>(
     for (let i = start; i < end; i++) {
         const p = series[i]
         if (p) {
-            const v0 = p[f0]
+            const v0 = p[f0] as number | undefined
             if (v0 !== undefined) {
                 if (v0 < min) min = v0
                 if (v0 > max) max = v0
             }
-            const v1 = p[f1]
+            const v1 = p[f1] as number | undefined
             if (v1 !== undefined) {
                 if (v1 < min) min = v1
                 if (v1 > max) max = v1
             }
-            const v2 = p[f2]
+            const v2 = p[f2] as number | undefined
             if (v2 !== undefined) {
                 if (v2 < min) min = v2
                 if (v2 > max) max = v2
@@ -341,22 +341,22 @@ function calc4<T extends object>(
     for (let i = start; i < end; i++) {
         const p = series[i]
         if (p) {
-            const v0 = p[f0]
+            const v0 = p[f0] as number | undefined
             if (v0 !== undefined) {
                 if (v0 < min) min = v0
                 if (v0 > max) max = v0
             }
-            const v1 = p[f1]
+            const v1 = p[f1] as number | undefined
             if (v1 !== undefined) {
                 if (v1 < min) min = v1
                 if (v1 > max) max = v1
             }
-            const v2 = p[f2]
+            const v2 = p[f2] as number | undefined
             if (v2 !== undefined) {
                 if (v2 < min) min = v2
                 if (v2 > max) max = v2
             }
-            const v3 = p[f3]
+            const v3 = p[f3] as number | undefined
             if (v3 !== undefined) {
                 if (v3 < min) min = v3
                 if (v3 > max) max = v3
@@ -379,7 +379,7 @@ function calcN<T extends object>(
         const p = series[i]
         if (p) {
             for (let j = 0; j < fieldLen; j++) {
-                const v = p[fields[j]!]
+                const v = p[fields[j]!] as number | undefined
                 if (v !== undefined) {
                     if (v < min) min = v
                     if (v > max) max = v
@@ -790,9 +790,9 @@ export function createBandVisibleStateComposer<T extends object>(
         for (let i = visibleRange.start; i < bandEnd; i++) {
             const p = source.series[i]
             if (p) {
-                const vMin = p[minField]
+                const vMin = p[minField] as number | undefined
                 if (vMin !== undefined && vMin < min) min = vMin
-                const vMax = p[maxField]
+                const vMax = p[maxField] as number | undefined
                 if (vMax !== undefined && vMax > max) max = vMax
             }
         }

--- a/packages/core/src/engine/indicators/visibleStateComposers.ts
+++ b/packages/core/src/engine/indicators/visibleStateComposers.ts
@@ -246,19 +246,136 @@ function getPointArraySeriesBundle<T extends object>(
     return (bundle as unknown as Record<string, { series: (T | undefined)[]; params: unknown }>)[bundleKey]!
 }
 
-function calcPointArrayExtremes<T extends object>(
+function calc1<T extends object>(
+    series: (T | undefined)[],
+    f0: keyof T,
+    end: number,
+    start: number,
+    min: number,
+    max: number,
+): { min: number; max: number } {
+    for (let i = start; i < end; i++) {
+        const p = series[i]
+        if (p) {
+            const v = p[f0]
+            if (v !== undefined) {
+                if (v < min) min = v
+                if (v > max) max = v
+            }
+        }
+    }
+    return { min, max }
+}
+
+function calc2<T extends object>(
+    series: (T | undefined)[],
+    f0: keyof T,
+    f1: keyof T,
+    end: number,
+    start: number,
+    min: number,
+    max: number,
+): { min: number; max: number } {
+    for (let i = start; i < end; i++) {
+        const p = series[i]
+        if (p) {
+            const v0 = p[f0]
+            if (v0 !== undefined) {
+                if (v0 < min) min = v0
+                if (v0 > max) max = v0
+            }
+            const v1 = p[f1]
+            if (v1 !== undefined) {
+                if (v1 < min) min = v1
+                if (v1 > max) max = v1
+            }
+        }
+    }
+    return { min, max }
+}
+
+function calc3<T extends object>(
+    series: (T | undefined)[],
+    f0: keyof T,
+    f1: keyof T,
+    f2: keyof T,
+    end: number,
+    start: number,
+    min: number,
+    max: number,
+): { min: number; max: number } {
+    for (let i = start; i < end; i++) {
+        const p = series[i]
+        if (p) {
+            const v0 = p[f0]
+            if (v0 !== undefined) {
+                if (v0 < min) min = v0
+                if (v0 > max) max = v0
+            }
+            const v1 = p[f1]
+            if (v1 !== undefined) {
+                if (v1 < min) min = v1
+                if (v1 > max) max = v1
+            }
+            const v2 = p[f2]
+            if (v2 !== undefined) {
+                if (v2 < min) min = v2
+                if (v2 > max) max = v2
+            }
+        }
+    }
+    return { min, max }
+}
+
+function calc4<T extends object>(
+    series: (T | undefined)[],
+    f0: keyof T,
+    f1: keyof T,
+    f2: keyof T,
+    f3: keyof T,
+    end: number,
+    start: number,
+    min: number,
+    max: number,
+): { min: number; max: number } {
+    for (let i = start; i < end; i++) {
+        const p = series[i]
+        if (p) {
+            const v0 = p[f0]
+            if (v0 !== undefined) {
+                if (v0 < min) min = v0
+                if (v0 > max) max = v0
+            }
+            const v1 = p[f1]
+            if (v1 !== undefined) {
+                if (v1 < min) min = v1
+                if (v1 > max) max = v1
+            }
+            const v2 = p[f2]
+            if (v2 !== undefined) {
+                if (v2 < min) min = v2
+                if (v2 > max) max = v2
+            }
+            const v3 = p[f3]
+            if (v3 !== undefined) {
+                if (v3 < min) min = v3
+                if (v3 > max) max = v3
+            }
+        }
+    }
+    return { min, max }
+}
+
+function calcN<T extends object>(
     series: (T | undefined)[],
     fields: readonly (keyof T)[],
-    range: { start: number; end: number },
+    end: number,
+    start: number,
+    min: number,
+    max: number,
 ): { min: number; max: number } {
-    if (series.length === 0 || range.start >= series.length) {
-        return { min: Infinity, max: -Infinity }
-    }
-    let min = Infinity
-    let max = -Infinity
-    const end = Math.min(range.end, series.length)
     const fieldLen = fields.length
-    for (let i = range.start; i < end; i++) {
+    for (let i = start; i < end; i++) {
         const p = series[i]
         if (p) {
             for (let j = 0; j < fieldLen; j++) {
@@ -271,6 +388,31 @@ function calcPointArrayExtremes<T extends object>(
         }
     }
     return { min, max }
+}
+
+function calcPointArrayExtremes<T extends object>(
+    series: (T | undefined)[],
+    fields: readonly (keyof T)[],
+    range: { start: number; end: number },
+): { min: number; max: number } {
+    if (series.length === 0 || range.start >= series.length) {
+        return { min: Infinity, max: -Infinity }
+    }
+    let min = Infinity
+    let max = -Infinity
+    const end = Math.min(range.end, series.length)
+    switch (fields.length) {
+        case 1:
+            return calc1(series, fields[0]!, end, range.start, min, max)
+        case 2:
+            return calc2(series, fields[0]!, fields[1]!, end, range.start, min, max)
+        case 3:
+            return calc3(series, fields[0]!, fields[1]!, fields[2]!, end, range.start, min, max)
+        case 4:
+            return calc4(series, fields[0]!, fields[1]!, fields[2]!, fields[3]!, end, range.start, min, max)
+        default:
+            return calcN(series, fields, end, range.start, min, max)
+    }
 }
 
 function computeMAFamilyBounds(

--- a/packages/core/src/engine/indicators/visibleStateComposers.ts
+++ b/packages/core/src/engine/indicators/visibleStateComposers.ts
@@ -423,9 +423,31 @@ export function createMACDVisibleStateComposer(
             }
         }
 
-        const extremes = calcPointArrayExtremes(source.series, ['dif', 'dea', 'macd'], visibleRange)
-        const padding = Number.isFinite(extremes.max) && Number.isFinite(extremes.min)
-            ? Math.max(Math.abs(extremes.max), Math.abs(extremes.min)) * 0.1
+        let min = Infinity
+        let max = -Infinity
+        const macdEnd = Math.min(visibleRange.end, source.series.length)
+        for (let i = visibleRange.start; i < macdEnd; i++) {
+            const p = source.series[i]
+            if (p) {
+                const v0 = p.dif
+                if (v0 !== undefined) {
+                    if (v0 < min) min = v0
+                    if (v0 > max) max = v0
+                }
+                const v1 = p.dea
+                if (v1 !== undefined) {
+                    if (v1 < min) min = v1
+                    if (v1 > max) max = v1
+                }
+                const v2 = p.macd
+                if (v2 !== undefined) {
+                    if (v2 < min) min = v2
+                    if (v2 > max) max = v2
+                }
+            }
+        }
+        const padding = max !== -Infinity && min !== Infinity
+            ? Math.max(Math.abs(max), Math.abs(min)) * 0.1
             : 0
 
         const latestIndex = visibleRange.end - 1
@@ -437,10 +459,10 @@ export function createMACDVisibleStateComposer(
             timestamp,
             series: source.series,
             params: source.params,
-            valueMin: Number.isFinite(extremes.min) ? extremes.min - padding : emptyState.valueMin,
-            valueMax: Number.isFinite(extremes.max) ? extremes.max + padding : emptyState.valueMax,
-            visibleMin: extremes.min,
-            visibleMax: extremes.max,
+            valueMin: min !== Infinity ? min - padding : emptyState.valueMin,
+            valueMax: max !== -Infinity ? max + padding : emptyState.valueMax,
+            visibleMin: min,
+            visibleMax: max,
             latestValues: latestPoint ? {
                 dif: latestPoint.dif,
                 dea: latestPoint.dea,

--- a/packages/core/src/engine/indicators/visibleStateComposers.ts
+++ b/packages/core/src/engine/indicators/visibleStateComposers.ts
@@ -620,12 +620,19 @@ export function createBandVisibleStateComposer<T extends object>(
             }
         }
 
-        const minExtremes = calcPointArrayExtremes(source.series, [minField], visibleRange)
-        const maxExtremes = calcPointArrayExtremes(source.series, [maxField], visibleRange)
-        const extremes = {
-            min: minExtremes.min,
-            max: maxExtremes.max,
+        let min = Infinity
+        let max = -Infinity
+        const bandEnd = Math.min(visibleRange.end, source.series.length)
+        for (let i = visibleRange.start; i < bandEnd; i++) {
+            const p = source.series[i]
+            if (p) {
+                const vMin = p[minField]
+                if (vMin !== undefined && vMin < min) min = vMin
+                const vMax = p[maxField]
+                if (vMax !== undefined && vMax > max) max = vMax
+            }
         }
+        const extremes = { min, max }
         const bounds = computeMAFamilyBounds(
             Number.isFinite(extremes.min) && Number.isFinite(extremes.max) ? extremes : null,
             emptyState,

--- a/packages/core/src/engine/indicators/visibleStateComposers.ts
+++ b/packages/core/src/engine/indicators/visibleStateComposers.ts
@@ -30,8 +30,8 @@ function calcSparseExtremes(series: (number | undefined)[], range: { start: numb
     for (let i = range.start; i < end; i++) {
         const v = series[i]
         if (v !== undefined) {
-            min = Math.min(min, v)
-            max = Math.max(max, v)
+            if (v < min) min = v
+            if (v > max) max = v
         }
     }
     return { min, max }
@@ -98,15 +98,16 @@ function calcRecordExtremes(
 ): { min: number; max: number } {
     let min = Infinity
     let max = -Infinity
-    for (const key of Object.keys(series)) {
-        const arr = series[Number(key)]
+    const keys = Object.keys(series)
+    for (let k = 0; k < keys.length; k++) {
+        const arr = series[Number(keys[k]!)]
         if (!arr) continue
         const end = Math.min(range.end, arr.length)
         for (let i = range.start; i < end; i++) {
             const v = arr[i]
             if (v !== undefined) {
-                min = Math.min(min, v)
-                max = Math.max(max, v)
+                if (v < min) min = v
+                if (v > max) max = v
             }
         }
     }
@@ -256,14 +257,15 @@ function calcPointArrayExtremes<T extends object>(
     let min = Infinity
     let max = -Infinity
     const end = Math.min(range.end, series.length)
+    const fieldLen = fields.length
     for (let i = range.start; i < end; i++) {
         const p = series[i]
         if (p) {
-            for (const field of fields) {
-                const v = p[field]
-                if (typeof v === 'number' && Number.isFinite(v)) {
-                    min = Math.min(min, v)
-                    max = Math.max(max, v)
+            for (let j = 0; j < fieldLen; j++) {
+                const v = p[fields[j]!]
+                if (v !== undefined) {
+                    if (v < min) min = v
+                    if (v > max) max = v
                 }
             }
         }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -510,6 +510,8 @@ export class ChartRenderer {
         theme: this.deps.getTheme(),
         isAsiaMarket: this.settings.isAsiaMarket as boolean,
         colorPresetSettings: this.settings.colorPresetSettings,
+        monthKeys: dataManager.getMonthKeys() ?? undefined,
+        dayKeys: dataManager.getDayKeys() ?? undefined,
       }
 
       {
@@ -567,6 +569,7 @@ export class ChartRenderer {
     }
     if (xAxisCtx) {
       const opt = this.deps.getOption()
+      const dataManager = this.deps.getDataManager()
       const timeAxisContext: RenderContext = {
         ctx: xAxisCtx,
         pane: {
@@ -595,8 +598,8 @@ export class ChartRenderer {
           },
           priceRange: { maxPrice: 0, minPrice: 0 },
         },
-        period: this.deps.getDataManager().currentPeriod,
-        data: this.deps.getDataManager().getRenderData(),
+        period: dataManager.currentPeriod,
+        data: dataManager.getRenderData(),
         range,
         scrollLeft: vp.scrollLeft,
         kWidth: opt.kWidth,
@@ -618,6 +621,8 @@ export class ChartRenderer {
         theme: this.deps.getTheme(),
         isAsiaMarket: this.settings.isAsiaMarket as boolean,
         colorPresetSettings: this.settings.colorPresetSettings,
+        monthKeys: dataManager.getMonthKeys() ?? undefined,
+        dayKeys: dataManager.getDayKeys() ?? undefined,
       }
       const errors = this.deps.getRendererPluginManager().renderPlugin('timeAxis', timeAxisContext)
       if (errors.length > 0) {

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -2,7 +2,6 @@ import type { RendererPlugin, RenderContext } from '../../plugin'
 import { RENDERER_PRIORITY } from '../../plugin'
 import type { KLineData } from '../../types/price'
 import type { kLineTrend } from '../../types/kLine'
-import { createAlignedKLineFromPx, createVerticalLineRect } from '../draw/pixelAlign'
 import { resolveThemeColors, type VolumePriceColors } from '../../tokens'
 import { getPhysicalKLineConfig } from '../utils/klineConfig'
 import { VolumePriceRelation } from '../../types/volumePrice'
@@ -21,9 +20,20 @@ function ensureBufferCapacity(pool: Float32Array | null, requiredFloats: number)
   return new Float32Array(newLen)
 }
 
+type AlignedKLineResult = {
+    bodyRect: { x: number; y: number; width: number; height: number }
+    physBodyLeft: number
+    physBodyRight: number
+    physBodyWidth: number
+    physBodyCenter: number
+    physWickX: number
+    wickRect: { x: number; width: number }
+    isPerfectlyAligned: boolean
+}
+
 type CandleRenderData = {
     i: number
-    aligned: ReturnType<typeof createAlignedKLineFromPx>
+    aligned: AlignedKLineResult
     trend: kLineTrend
     openY: number
     closeY: number
@@ -141,6 +151,7 @@ function prepareCandles(args: {
     }
 
     const invDpr = 1 / dpr
+    const wickWidth = 1 / dpr
     const alignY = (logical: number) => Math.round(logical * dpr) * invDpr
 
     for (let i = range.start; i < range.end && i < data.length; i++) {
@@ -163,22 +174,34 @@ function prepareCandles(args: {
         const alignedRawRectH = Math.max(Math.abs(alignedOpenY - alignedCloseY), 1)
 
         const roundedLeftPx = Math.round(leftLogical * dpr)
-        const aligned = createAlignedKLineFromPx(
-            roundedLeftPx,
-            alignedRawRectY,
-            kWidthPx,
-            alignedRawRectH,
-            dpr
-        )
+
+        // Inlined createAlignedKLineFromPx — no object allocation
+        const topPx = Math.round(alignedRawRectY * dpr)
+        const bottomPx = Math.round((alignedRawRectY + alignedRawRectH) * dpr)
+        const bodyHPx = Math.max(1, bottomPx - topPx)
+
+        const bodyX = roundedLeftPx * invDpr
+        const bodyY = topPx * invDpr
+        const bodyW = kWidthPx * invDpr
+        const bodyH = bodyHPx * invDpr
+        const wickCenterX = (roundedLeftPx + (kWidthPx - 1) / 2) * invDpr
 
         const isUp = e.close >= e.open
-        const bodyRect = aligned.bodyRect
 
         if (showVolumePriceMarkers) {
             const targetKLines = isUp ? upKLines : downKLines
             targetKLines.push({
                 i,
-                aligned,
+                aligned: {
+                    bodyRect: { x: bodyX, y: bodyY, width: bodyW, height: bodyH },
+                    physBodyLeft: roundedLeftPx,
+                    physBodyRight: roundedLeftPx + kWidthPx,
+                    physBodyWidth: kWidthPx,
+                    physBodyCenter: wickCenterX,
+                    physWickX: wickCenterX,
+                    wickRect: { x: wickCenterX, width: 1 / dpr },
+                    isPerfectlyAligned: kWidthPx % 2 === 1,
+                },
                 trend: isUp ? 'up' : 'down',
                 openY,
                 closeY,
@@ -192,50 +215,53 @@ function prepareCandles(args: {
 
         if (isUp) {
             const off = upBodyCount++ * 4
-            upBodyBuf[off] = bodyRect.x
-            upBodyBuf[off + 1] = bodyRect.y
-            upBodyBuf[off + 2] = bodyRect.width
-            upBodyBuf[off + 3] = bodyRect.height
+            upBodyBuf[off] = bodyX
+            upBodyBuf[off + 1] = bodyY
+            upBodyBuf[off + 2] = bodyW
+            upBodyBuf[off + 3] = bodyH
         } else {
             const off = downBodyCount++ * 4
-            downBodyBuf[off] = bodyRect.x
-            downBodyBuf[off + 1] = bodyRect.y
-            downBodyBuf[off + 2] = bodyRect.width
-            downBodyBuf[off + 3] = bodyRect.height
+            downBodyBuf[off] = bodyX
+            downBodyBuf[off + 1] = bodyY
+            downBodyBuf[off + 2] = bodyW
+            downBodyBuf[off + 3] = bodyH
         }
 
-        const bodyTop = bodyRect.y
-        const bodyBottom = bodyRect.y + bodyRect.height
         const bodyHigh = isUp ? e.close : e.open
         const bodyLow = isUp ? e.open : e.close
 
+        // Inlined createVerticalLineRect for upper wick
         if (e.high > bodyHigh) {
-            const wick = createVerticalLineRect(aligned.wickRect.x, alignedHighY, bodyTop, dpr)
-            if (wick) {
-                const buf = isUp ? upWickBuf : downWickBuf
-                const idx = isUp ? upWickCount++ : downWickCount++
-                const off = idx * 4
-                buf[off] = wick.x
-                buf[off + 1] = wick.y
-                buf[off + 2] = wick.width
-                buf[off + 3] = wick.height
-            }
+            const top = Math.min(alignedHighY, bodyY)
+            const bottom = Math.max(alignedHighY, bodyY)
+            const physTop = Math.round(top * dpr)
+            const physBottom = Math.round(bottom * dpr)
+            const wickH = Math.max(1, physBottom - physTop) * invDpr
+            const buf = isUp ? upWickBuf : downWickBuf
+            const idx = isUp ? upWickCount++ : downWickCount++
+            const off = idx * 4
+            buf[off] = wickCenterX
+            buf[off + 1] = physTop * invDpr
+            buf[off + 2] = wickWidth
+            buf[off + 3] = wickH
         }
+        // Inlined createVerticalLineRect for lower wick
         if (e.low < bodyLow) {
-            const wick = createVerticalLineRect(aligned.wickRect.x, bodyBottom, alignedLowY, dpr)
-            if (wick) {
-                const buf = isUp ? upWickBuf : downWickBuf
-                const idx = isUp ? upWickCount++ : downWickCount++
-                const off = idx * 4
-                buf[off] = wick.x
-                buf[off + 1] = wick.y
-                buf[off + 2] = wick.width
-                buf[off + 3] = wick.height
-            }
+            const bodyBottom = bodyY + bodyH
+            const top = Math.min(bodyBottom, alignedLowY)
+            const bottom = Math.max(bodyBottom, alignedLowY)
+            const physTop = Math.round(top * dpr)
+            const physBottom = Math.round(bottom * dpr)
+            const wickH = Math.max(1, physBottom - physTop) * invDpr
+            const buf = isUp ? upWickBuf : downWickBuf
+            const idx = isUp ? upWickCount++ : downWickCount++
+            const off = idx * 4
+            buf[off] = wickCenterX
+            buf[off + 1] = physTop * invDpr
+            buf[off + 2] = wickWidth
+            buf[off + 3] = wickH
         }
     }
-
-    const wickWidth = 1 / dpr
 
     return {
         upKLines,

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -1,7 +1,7 @@
 import type { RendererPlugin, RenderContext } from '../../plugin'
 import { RENDERER_PRIORITY } from '../../plugin'
 import type { KLineData } from '../../types/price'
-import { getKLineTrend, type kLineTrend } from '../../types/kLine'
+import type { kLineTrend } from '../../types/kLine'
 import { createAlignedKLineFromPx, createVerticalLineRect } from '../draw/pixelAlign'
 import { resolveThemeColors, type VolumePriceColors } from '../../tokens'
 import { getPhysicalKLineConfig } from '../utils/klineConfig'
@@ -121,9 +121,11 @@ function prepareCandles(args: {
         const scaleB = paddingTop + viewHeight
         fastPriceToY = (price: number) => scaleB - (price - minPrice) * scaleK
     } else {
-        // 对数模式回退到标准方法
         fastPriceToY = (price: number) => pane.yAxis.priceToY(price)
     }
+
+    const invDpr = 1 / dpr
+    const alignY = (logical: number) => Math.round(logical * dpr) * invDpr
 
     for (let i = range.start; i < range.end && i < data.length; i++) {
         const e = data[i]
@@ -137,7 +139,6 @@ function prepareCandles(args: {
         const leftLogical = kLinePositions[i - range.start]
         if (leftLogical === undefined) continue
 
-        const alignY = (logical: number) => Math.round(logical * dpr) / dpr
         const alignedOpenY = alignY(openY)
         const alignedCloseY = alignY(closeY)
         const alignedHighY = alignY(highY)
@@ -154,11 +155,11 @@ function prepareCandles(args: {
             dpr
         )
 
-        const trend: kLineTrend = getKLineTrend(e)
+        const isUp = e.close >= e.open
         const renderData: CandleRenderData = {
             i,
             aligned,
-            trend,
+            trend: isUp ? 'up' : 'down',
             openY,
             closeY,
             highY,
@@ -169,8 +170,7 @@ function prepareCandles(args: {
         }
 
         const bodyRect = aligned.bodyRect
-        const targetKLines = trend === 'up' ? upKLines : downKLines
-        const isUp = trend === 'up'
+        const targetKLines = isUp ? upKLines : downKLines
 
         targetKLines.push(renderData)
 
@@ -190,8 +190,8 @@ function prepareCandles(args: {
 
         const bodyTop = bodyRect.y
         const bodyBottom = bodyRect.y + bodyRect.height
-        const bodyHigh = Math.max(e.open, e.close)
-        const bodyLow = Math.min(e.open, e.close)
+        const bodyHigh = isUp ? e.close : e.open
+        const bodyLow = isUp ? e.open : e.close
 
         if (e.high > bodyHigh) {
             const wick = createVerticalLineRect(aligned.wickRect.x, alignedHighY, bodyTop, dpr)
@@ -219,7 +219,7 @@ function prepareCandles(args: {
         }
     }
 
-    const wickWidth = upKLines[0]?.aligned.wickRect.width ?? downKLines[0]?.aligned.wickRect.width ?? 1
+    const wickWidth = 1 / dpr
 
     return {
         upKLines,

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -9,6 +9,18 @@ import { VolumePriceRelation } from '../../types/volumePrice'
 import { analyzeVolumePriceRelationBatch, DEFAULT_VOLUME_PRICE_CONFIG } from '../../utils/volumePrice'
 import type { MarkerManager } from '../marker/registry'
 
+// --- Float32Array buffer pool (reduces per-frame GC pressure) ---
+let poolUpBody: Float32Array | null = null
+let poolDownBody: Float32Array | null = null
+let poolUpWick: Float32Array | null = null
+let poolDownWick: Float32Array | null = null
+
+function ensureBufferCapacity(pool: Float32Array | null, requiredFloats: number): Float32Array {
+  if (pool && pool.length >= requiredFloats) return pool
+  const newLen = Math.max(requiredFloats, Math.ceil((pool?.length ?? 0) * 1.5))
+  return new Float32Array(newLen)
+}
+
 type CandleRenderData = {
     i: number
     aligned: ReturnType<typeof createAlignedKLineFromPx>
@@ -99,10 +111,14 @@ function prepareCandles(args: {
     const upKLines: CandleRenderData[] = []
     const downKLines: CandleRenderData[] = []
     const maxRects = Math.max(1, range.end - range.start)
-    const upBodyBuf = new Float32Array(maxRects * 4)
-    const downBodyBuf = new Float32Array(maxRects * 4)
-    const upWickBuf = new Float32Array(maxRects * 2 * 4)
-    const downWickBuf = new Float32Array(maxRects * 2 * 4)
+    const upBodyBuf = ensureBufferCapacity(poolUpBody, maxRects * 4)
+    poolUpBody = upBodyBuf
+    const downBodyBuf = ensureBufferCapacity(poolDownBody, maxRects * 4)
+    poolDownBody = downBodyBuf
+    const upWickBuf = ensureBufferCapacity(poolUpWick, maxRects * 2 * 4)
+    poolUpWick = upWickBuf
+    const downWickBuf = ensureBufferCapacity(poolDownWick, maxRects * 2 * 4)
+    poolDownWick = downWickBuf
     let upBodyCount = 0
     let downBodyCount = 0
     let upWickCount = 0

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -156,23 +156,23 @@ function prepareCandles(args: {
         )
 
         const isUp = e.close >= e.open
-        const renderData: CandleRenderData = {
-            i,
-            aligned,
-            trend: isUp ? 'up' : 'down',
-            openY,
-            closeY,
-            highY,
-            lowY,
-            alignedHighY,
-            alignedLowY,
-            e,
-        }
-
         const bodyRect = aligned.bodyRect
-        const targetKLines = isUp ? upKLines : downKLines
 
-        targetKLines.push(renderData)
+        if (showVolumePriceMarkers) {
+            const targetKLines = isUp ? upKLines : downKLines
+            targetKLines.push({
+                i,
+                aligned,
+                trend: isUp ? 'up' : 'down',
+                openY,
+                closeY,
+                highY,
+                lowY,
+                alignedHighY,
+                alignedLowY,
+                e,
+            })
+        }
 
         if (isUp) {
             const off = upBodyCount++ * 4

--- a/packages/core/src/engine/renderers/gridLines.ts
+++ b/packages/core/src/engine/renderers/gridLines.ts
@@ -42,7 +42,7 @@ export function createGridLinesRendererPlugin(): RendererPlugin {
                 }
             }
 
-            const boundaries = findMonthBoundaries(klineData)
+            const boundaries = findMonthBoundaries(klineData, context.monthKeys)
 
             for (const idx of boundaries) {
                 if (idx < range.start || idx >= range.end || idx >= klineData.length) continue

--- a/packages/core/src/engine/renderers/timeAxis.ts
+++ b/packages/core/src/engine/renderers/timeAxis.ts
@@ -59,6 +59,8 @@ export function createTimeAxisRendererPlugin(options: {
         drawTopBorder: false,
         drawBottomBorder: false,
         period: context.period,
+        monthKeys: context.monthKeys,
+        dayKeys: context.dayKeys,
       }, context.theme, context.isAsiaMarket, context.colorPresetSettings)
 
       // 绘制来自 xAxisRanges 的时间范围带（先于标签绘制）

--- a/packages/core/src/mcp/chartBridge.ts
+++ b/packages/core/src/mcp/chartBridge.ts
@@ -208,7 +208,7 @@ export class ChartBridge {
 
     this.reconnectTimer = setTimeout(() => {
       if (!this.destroyed) {
-        this.connect()
+        this.connect().catch(() => {})
       }
     }, delay)
   }

--- a/packages/core/src/plugin/types.ts
+++ b/packages/core/src/plugin/types.ts
@@ -338,6 +338,10 @@ export interface RenderContext {
   colorPresetSettings?: import('../tokens').ColorPresetSettings
   /** 预计算的 Y 轴刻度列表（统一像素均匀分布 → yToPrice 反算），所有 Y 轴渲染器共用 */
   yAxisTicks?: YAxisTick[]
+  /** 预计算的月份键值数组（year*12+month），与 data 长度一致，由 DataBuffer 在数据加载时计算 */
+  monthKeys?: Int32Array
+  /** 预计算的日期键值数组（year*366+dayOfYear），与 data 长度一致，由 DataBuffer 在数据加载时计算 */
+  dayKeys?: Int32Array
 }
 
 export type DrawingAnchor = {

--- a/packages/core/src/utils/__tests__/dateFormat.test.ts
+++ b/packages/core/src/utils/__tests__/dateFormat.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+import { findMonthBoundaries, findDayBoundaries } from '../dateFormat'
+
+function clamp(n: number, min: number, max: number): number {
+    return Math.max(min, Math.min(max, n))
+}
+
+function makeData(timestamps: number[]): Array<{ timestamp: number }> {
+    return timestamps.map((ts) => ({ timestamp: ts }))
+}
+
+function computeMonthKeys(data: Array<{ timestamp: number } | undefined>): Int32Array {
+    const keys = new Int32Array(data.length)
+    for (let i = 0; i < data.length; i++) {
+        const cur = data[i]
+        if (!cur) { keys[i] = 0; continue }
+        const d = new Date(cur.timestamp)
+        keys[i] = d.getFullYear() * 12 + d.getMonth()
+    }
+    return keys
+}
+
+function computeDayKeys(data: Array<{ timestamp: number } | undefined>): Int32Array {
+    const keys = new Int32Array(data.length)
+    for (let i = 0; i < data.length; i++) {
+        const cur = data[i]
+        if (!cur) { keys[i] = 0; continue }
+        const d = new Date(cur.timestamp)
+        const yearStart = new Date(d.getFullYear(), 0, 0)
+        keys[i] = d.getFullYear() * 366 + Math.floor((d.getTime() - yearStart.getTime()) / 86400000)
+    }
+    return keys
+}
+
+describe('findMonthBoundaries', () => {
+    it('returns empty for empty data', () => {
+        expect(findMonthBoundaries([])).toEqual([])
+        expect(findMonthBoundaries([], new Int32Array(0))).toEqual([])
+    })
+
+    it('returns [0] for single entry', () => {
+        const data = makeData([1735689600000]) // 2025-01-01
+        expect(findMonthBoundaries(data)).toEqual([0])
+        expect(findMonthBoundaries(data, computeMonthKeys(data))).toEqual([0])
+    })
+
+    it('detects month transition', () => {
+        const data = makeData([
+            1735689600000, // 2025-01-01
+            1735776000000, // 2025-01-02
+            1738368000000, // 2025-02-01
+            1738454400000, // 2025-02-02
+        ])
+        const expected = [0, 2]
+        expect(findMonthBoundaries(data)).toEqual(expected)
+        expect(findMonthBoundaries(data, computeMonthKeys(data))).toEqual(expected)
+    })
+
+    it('detects year transition', () => {
+        const data = makeData([
+            1735689600000, // 2025-01-01
+            1767225600000, // 2026-01-01
+        ])
+        const expected = [0, 1]
+        expect(findMonthBoundaries(data)).toEqual(expected)
+        expect(findMonthBoundaries(data, computeMonthKeys(data))).toEqual(expected)
+    })
+
+    it('caches result when Int32Array not provided (same reference)', () => {
+        const data = makeData([
+            1735689600000,
+            1738368000000,
+        ])
+        const first = findMonthBoundaries(data)
+        const second = findMonthBoundaries(data)
+        expect(first).toBe(second)
+    })
+
+    it('produces identical result with and without Int32Array', () => {
+        const data = makeData([
+            1735689600000,
+            1735776000000,
+            1738368000000,
+            1740787200000,
+            1743465600000,
+        ])
+        const monthKeys = computeMonthKeys(data)
+        expect(findMonthBoundaries(data)).toEqual(findMonthBoundaries(data, monthKeys))
+    })
+
+    it('handles sparse data with undefined entries', () => {
+        const sparse: Array<{ timestamp: number } | undefined> = [
+            { timestamp: 1735689600000 },
+            undefined,
+            { timestamp: 1738368000000 },
+            undefined,
+            { timestamp: 1740787200000 },
+        ]
+        const monthKeys = computeMonthKeys(sparse)
+        expect(findMonthBoundaries(sparse)).toEqual([0, 2, 4])
+        expect(findMonthBoundaries(sparse, monthKeys)).toEqual([0, 2, 4])
+    })
+})
+
+describe('findDayBoundaries', () => {
+    it('returns empty for empty data', () => {
+        expect(findDayBoundaries([])).toEqual([])
+        expect(findDayBoundaries([], new Int32Array(0))).toEqual([])
+    })
+
+    it('returns [0] for single entry', () => {
+        const data = makeData([1735689600000])
+        expect(findDayBoundaries(data)).toEqual([0])
+        expect(findDayBoundaries(data, computeDayKeys(data))).toEqual([0])
+    })
+
+    it('detects day transition', () => {
+        const data = makeData([
+            1735689600000, // 2025-01-01
+            1735776000000, // 2025-01-02
+            1735862400000, // 2025-01-03
+        ])
+        const expected = [0, 1, 2]
+        expect(findDayBoundaries(data)).toEqual(expected)
+        expect(findDayBoundaries(data, computeDayKeys(data))).toEqual(expected)
+    })
+
+    it('detects month boundary within day boundaries', () => {
+        const data = makeData([
+            1735689600000, // 2025-01-01
+            1735776000000, // 2025-01-02
+            1738368000000, // 2025-02-01
+            1738454400000, // 2025-02-02
+        ])
+        const expected = [0, 1, 2, 3]
+        expect(findDayBoundaries(data)).toEqual(expected)
+        expect(findDayBoundaries(data, computeDayKeys(data))).toEqual(expected)
+    })
+
+    it('produces identical result with and without Int32Array', () => {
+        const data = makeData([
+            1735689600000,
+            1735776000000,
+            1738368000000,
+            1738454400000,
+            1740787200000,
+        ])
+        const dayKeys = computeDayKeys(data)
+        expect(findDayBoundaries(data)).toEqual(findDayBoundaries(data, dayKeys))
+    })
+
+    it('handles sparse data with undefined entries', () => {
+        const sparse: Array<{ timestamp: number } | undefined> = [
+            { timestamp: 1735689600000 },
+            undefined,
+            { timestamp: 1735776000000 },
+            undefined,
+            { timestamp: 1738368000000 },
+        ]
+        const dayKeys = computeDayKeys(sparse)
+        expect(findDayBoundaries(sparse)).toEqual([0, 2, 4])
+        expect(findDayBoundaries(sparse, dayKeys)).toEqual([0, 2, 4])
+    })
+})

--- a/packages/core/src/utils/dateFormat.ts
+++ b/packages/core/src/utils/dateFormat.ts
@@ -207,7 +207,10 @@ let _cacheResult: number[] = []
  * 查找每个月份第一个K线的索引
  * 结果按数据引用缓存，同一份数据多次调用直接返回缓存
  */
-export function findMonthBoundaries(data: Array<{ timestamp: number } | undefined>): number[] {
+export function findMonthBoundaries(
+    data: Array<{ timestamp: number } | undefined>,
+    monthKeys?: Int32Array,
+): number[] {
     if (data.length === 0) return []
 
     // 缓存命中：同一引用 + 同长度 + 首尾时间戳不变
@@ -220,12 +223,12 @@ export function findMonthBoundaries(data: Array<{ timestamp: number } | undefine
     }
 
     const boundaries: number[] = [0]
-    let lastKey = monthKey(data[0]!.timestamp)
+    let lastKey = monthKeys ? monthKeys[0] : monthKey(data[0]!.timestamp)
 
     for (let i = 1; i < data.length; i++) {
         const cur = data[i]
         if (!cur) continue
-        const curKey = monthKey(cur.timestamp)
+        const curKey = monthKeys ? monthKeys[i] : monthKey(cur.timestamp)
         if (curKey !== lastKey) {
             boundaries.push(i)
             lastKey = curKey
@@ -245,16 +248,19 @@ export function findMonthBoundaries(data: Array<{ timestamp: number } | undefine
 /**
  * 查找每天第一个K线的索引
  */
-export function findDayBoundaries(data: Array<{ timestamp: number } | undefined>): number[] {
+export function findDayBoundaries(
+    data: Array<{ timestamp: number } | undefined>,
+    dayKeys?: Int32Array,
+): number[] {
     if (data.length === 0) return []
 
     const boundaries: number[] = [0]
-    let lastKey = dayKey(data[0]!.timestamp)
+    let lastKey = dayKeys ? dayKeys[0] : dayKey(data[0]!.timestamp)
 
     for (let i = 1; i < data.length; i++) {
         const cur = data[i]
         if (!cur) continue
-        const curKey = dayKey(cur.timestamp)
+        const curKey = dayKeys ? dayKeys[i] : dayKey(cur.timestamp)
         if (curKey !== lastKey) {
             boundaries.push(i)
             lastKey = curKey

--- a/packages/core/src/utils/kLineDraw/axis.ts
+++ b/packages/core/src/utils/kLineDraw/axis.ts
@@ -53,6 +53,10 @@ export interface TimeAxisOptions {
     kLineCenters: number[]
     /** 数据索引可见范围 { start, end } */
     visibleRange: { start: number; end: number }
+    /** 预计算的月份键值数组（year*12+month），与 data 长度一致 */
+    monthKeys?: Int32Array
+    /** 预计算的日期键值数组（year*366+dayOfYear），与 data 长度一致 */
+    dayKeys?: Int32Array
 }
 
 export interface LastPriceLineOptions {
@@ -337,10 +341,10 @@ export function drawTimeAxis(ctx: CanvasRenderingContext2D, opts: TimeAxisOption
       }
       labelFn = (ts) => ({ text: formatTimeLabel(ts), isYear: false })
     } else if (isMinuteData) {
-      boundaries = findDayBoundaries(data)
+      boundaries = findDayBoundaries(data, opts.dayKeys)
       labelFn = formatDay
     } else {
-      boundaries = findMonthBoundaries(data)
+      boundaries = findMonthBoundaries(data, opts.monthKeys)
       labelFn = formatMonthOrYear
     }
 

--- a/packages/core/src/utils/volumePrice.ts
+++ b/packages/core/src/utils/volumePrice.ts
@@ -60,6 +60,19 @@ class VolumePrefixSum {
   }
 
   /**
+   * 增量追加数据，避免全量重建
+   * @param data - K线数据数组，仅追加超出 dataLength 的部分
+   */
+  append(data: KLineData[]): void {
+    const newLen = data.length
+    if (newLen <= this.dataLength) return
+    for (let i = this.dataLength; i < newLen; i++) {
+      this.prefixSum.push(this.prefixSum[this.prefixSum.length - 1]! + (data[i]?.volume ?? 0))
+    }
+    this.dataLength = newLen
+  }
+
+  /**
    * 获取数据长度
    */
   get length(): number {
@@ -76,13 +89,13 @@ let cachedData: KLineData[] | null = null
  * 检测数据引用是否变化，自动重建前缀和
  */
 function getPrefixSum(data: KLineData[]): VolumePrefixSum {
-  if (
-    !globalPrefixSum
-    || cachedData !== data
-    || cachedData.length !== data.length
-  ) {
+  if (!globalPrefixSum || cachedData !== data || cachedData.length > data.length) {
     globalPrefixSum = new VolumePrefixSum()
     globalPrefixSum.build(data)
+    cachedData = data
+  } else if (cachedData.length < data.length) {
+    // 数据追加：增量更新，避免 O(n) 重建
+    globalPrefixSum.append(data)
     cachedData = data
   }
 

--- a/packages/core/src/utils/volumePrice.ts
+++ b/packages/core/src/utils/volumePrice.ts
@@ -76,7 +76,11 @@ let cachedData: KLineData[] | null = null
  * 检测数据引用是否变化，自动重建前缀和
  */
 function getPrefixSum(data: KLineData[]): VolumePrefixSum {
-  if (!globalPrefixSum || cachedData !== data) {
+  if (
+    !globalPrefixSum
+    || cachedData !== data
+    || cachedData.length !== data.length
+  ) {
     globalPrefixSum = new VolumePrefixSum()
     globalPrefixSum.build(data)
     cachedData = data
@@ -159,8 +163,7 @@ export function analyzeVolumePriceRelationBatch(
   endIndex: number,
   config: VolumePriceConfig = DEFAULT_VOLUME_PRICE_CONFIG
 ): VolumePriceRelation[] {
-  const prefixSum = new VolumePrefixSum()
-  prefixSum.build(data)
+  const prefixSum = getPrefixSum(data)
 
   const results: VolumePriceRelation[] = []
   const { volumeAmplifyThreshold, volumeShrinkThreshold, avgPeriod } = config


### PR DESCRIPTION
## Changes

### Int32Array month/day key precomputation (f0bfeb0, 28e66e4)
- Precompute `monthKeys` (`year*12+month`) and `dayKeys` (`year*366+dayOfYear`) as `Int32Array` in `DataBuffer` at data load time (`setInlineData` / `fetchRange`)
- Pass through `RenderContext` → consumed by `findMonthBoundaries` / `findDayBoundaries` for O(1) indexed lookup vs per-frame `new Date()`
- Adds tests for precomputation correctness, async fetch, sparse data, cache reference identity

### Composers optimization (cc4bc15, be4efc2, f51d35f, 0759c70)
- Merge double traversal in `createBandVisibleStateComposer`
- Inline MACD extreme computation with static property access
- Dispatch `calcPointArrayExtremes` by field count for loop unrolling
- Inline min/max comparisons, use indexed loops, remove redundant `isFinite` checks

### Render allocation reduction (5391256, c438ca5, ee93d8b)
- Reuse Float32Array buffers across frames via module-level pool
- Skip CandleRenderData object allocation when volume-price markers disabled
- Reuse global VolumePrefixSum cache in `analyzeVolumePriceRelationBatch`

### Candle inline (fbf3d0b, fbf3d0b, 333ed35)
- Inline `createAlignedKLineFromPx` / `createVerticalLineRect` to eliminate per-frame object allocation
- Inline `getKLineTrend`, hoist `alignY`, eliminate redundant Math calls

## Testing
All 983 core tests pass.