### PR TITLE
feat(vue): internalize dataFetcher default, theme prop & fullscreen into KLineChart SFC

### DIFF
--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -89,11 +89,10 @@
       <KLineChart
         ref="chartRef"
         :mcp="mcpConfig"
-        :dataFetcher="dataFetcher"
         :left-axis-width="60"
         :custom-data="customData"
-        :is-fullscreen="isFullscreen"
-        @toggle-fullscreen="toggleFullscreen"
+        :theme="currentTheme"
+        @update:is-fullscreen="isFullscreen = $event"
         @theme-change="onThemeChange"
       />
     </div>
@@ -108,7 +107,7 @@
               <button class="close-btn" @click="showModal = false">×</button>
             </header>
             <div class="modal-body">
-              <KLineChart :dataFetcher="dataFetcher" @theme-change="onThemeChange" />
+              <KLineChart @theme-change="onThemeChange" />
             </div>
           </div>
         </div>
@@ -121,7 +120,7 @@
 import { ref, computed, provide, inject, type Ref, type InjectionKey } from 'vue'
 import KLineChart from '../src/components/KLineChart.vue'
 import { VERSION, CORE_VERSION } from '../src/version'
-import { routerDataFetcher, type KLineData, type CustomDataSource } from '@363045841yyt/klinechart-core/controllers'
+import { type KLineData, type CustomDataSource } from '@363045841yyt/klinechart-core/controllers'
 import { executeTool } from '@363045841yyt/klinechart-ai-runtime'
 
 /** 硬编码演示数据：主品种 CUSTOM.DEMO（15 根日 K） */
@@ -196,8 +195,6 @@ function useFullscreenTeleportTarget() {
   })
 }
 
-const dataFetcher = routerDataFetcher
-
 const chartRef = ref<InstanceType<typeof KLineChart> | null>(null)
 const mcpConfig = {
   wsUrl: 'ws://localhost:8081',
@@ -239,29 +236,6 @@ function onThemeChange(theme: 'light' | 'dark') {
 provideFullscreenTeleportTarget(embedContainerRef)
 
 const teleportTarget = computed<HTMLElement | string>(() => embedContainerRef.value ?? 'body')
-
-async function toggleFullscreen() {
-  if (!embedContainerRef.value) return
-  try {
-    if (!document.fullscreenElement) {
-      await embedContainerRef.value.requestFullscreen()
-      isFullscreen.value = true
-    } else {
-      await document.exitFullscreen()
-      isFullscreen.value = false
-    }
-  } catch (err) {
-    console.error('Fullscreen error:', err)
-  }
-}
-
-function handleFullscreenChange() {
-  isFullscreen.value = !!document.fullscreenElement
-}
-
-if (typeof document !== 'undefined') {
-  document.addEventListener('fullscreenchange', handleFullscreenChange)
-}
 
 // ── 自定义数据源 Demo ──
 const useCustomData = ref(false)

--- a/packages/vue/src/__tests__/_mockController.ts
+++ b/packages/vue/src/__tests__/_mockController.ts
@@ -14,6 +14,7 @@ import type {
     ChartController,
     ChartMountOptions,
     ChartViewport,
+    DataFetcher,
     DrawingObject,
     DrawingToolType,
     IndicatorDefinition,
@@ -52,15 +53,23 @@ function createSignal<T>(initial: T): Signal<T> {
 export interface MockChartController extends ChartController {
     /** spy: how many times `dispose` was called */
     disposeCalls: () => number
+    /** spy: data fetchers passed to `setDataFetcher` */
+    setDataFetcherCalls: () => ReadonlyArray<DataFetcher | null>
+    /** spy: themes passed to `setTheme` */
+    setThemeCalls: () => ReadonlyArray<'light' | 'dark'>
     /** test-only signal mutators */
     _setViewport: (vp: ChartViewport) => void
     _setData: (data: ReadonlyArray<KLineData>) => void
+    /** test-only: emit a theme change as the controller would */
+    _emitTheme: (next: 'light' | 'dark') => void
 }
 
 export function createMockChartController(
     opts: Partial<ChartMountOptions> = {},
 ): MockChartController {
     let disposeCalls = 0
+    const setDataFetcherCalls: Array<DataFetcher | null> = []
+    const setThemeCalls: Array<'light' | 'dark'> = []
 
     const viewport = createSignal<ChartViewport>({
         zoomLevel: opts.initialZoomLevel ?? 3,
@@ -121,9 +130,14 @@ export function createMockChartController(
         setCurrentPeriod: () => {},
         switchToTimeShareForDate: () => {},
         applyCustomData: () => {},
-        setDataFetcher: () => {},
+        setDataFetcher: (fetcher) => {
+            setDataFetcherCalls.push(fetcher)
+        },
         ensureDataRange: () => {},
-        setTheme: (next) => theme.set(next),
+        setTheme: (next) => {
+            setThemeCalls.push(next)
+            theme.set(next)
+        },
         zoomToLevel: (level) =>
             viewport.set({ ...viewport.peek(), zoomLevel: level }),
         zoomIn: () =>
@@ -177,8 +191,11 @@ export function createMockChartController(
             disposeCalls += 1
         },
         disposeCalls: () => disposeCalls,
+        setDataFetcherCalls: () => setDataFetcherCalls,
+        setThemeCalls: () => setThemeCalls,
         _setViewport: (vp) => viewport.set(vp),
         _setData: (next) => data.set(next),
+        _emitTheme: (next) => theme.set(next),
     }
 }
 

--- a/packages/vue/src/__tests__/internalize.test.ts
+++ b/packages/vue/src/__tests__/internalize.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the 3-part internalization of the Vue KLineChart SFC:
+ *   1. dataFetcher default (routerDataFetcher) + override
+ *   2. theme prop (controlled) applied on mount + on change, themeChange still emits
+ *   3. fullscreen internalization (uncontrolled toggles DOM, controlled does not)
+ *
+ * Strategy: mock `@363045841yyt/klinechart-core/controllers` so the heavy real
+ * `createChartController` (canvas engine) is swapped for the shape-compatible
+ * mock, while `routerDataFetcher` and all other named exports stay real.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createMockChartController, type MockChartController } from './_mockController'
+
+// ── Shared mock controller (one per mount, reset in beforeEach) ──
+let mockController: MockChartController
+
+vi.mock('@363045841yyt/klinechart-core/controllers', async () => {
+    const actual = await vi.importActual<
+        typeof import('@363045841yyt/klinechart-core/controllers')
+    >('@363045841yyt/klinechart-core/controllers')
+    return {
+        ...actual,
+        createChartController: () => Promise.resolve(mockController),
+    }
+})
+
+import KLineChart from '../components/KLineChart.vue'
+import { routerDataFetcher } from '@363045841yyt/klinechart-core/controllers'
+
+// ── jsdom environment shims ──
+function installMatchMedia(): void {
+    if (typeof window.matchMedia !== 'function') {
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            configurable: true,
+            value: (query: string) => ({
+                matches: false,
+                media: query,
+                onchange: null,
+                addEventListener: () => {},
+                removeEventListener: () => {},
+                addListener: () => {},
+                removeListener: () => {},
+                dispatchEvent: () => false,
+            }),
+        })
+    }
+}
+
+interface FullscreenSpies {
+    requestFullscreen: ReturnType<typeof vi.fn>
+    exitFullscreen: ReturnType<typeof vi.fn>
+    setElement: (el: Element | null) => void
+}
+
+function installFullscreenApi(): FullscreenSpies {
+    let fullscreenElement: Element | null = null
+    const requestFullscreen = vi.fn(function (this: Element) {
+        fullscreenElement = this
+        return Promise.resolve()
+    })
+    const exitFullscreen = vi.fn(() => {
+        fullscreenElement = null
+        return Promise.resolve()
+    })
+
+    Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true,
+        get: () => fullscreenElement,
+    })
+    Object.defineProperty(document, 'exitFullscreen', {
+        configurable: true,
+        writable: true,
+        value: exitFullscreen,
+    })
+    // jsdom does not implement requestFullscreen on elements
+    ;(HTMLElement.prototype as unknown as Record<string, unknown>).requestFullscreen =
+        requestFullscreen
+
+    return {
+        requestFullscreen,
+        exitFullscreen,
+        setElement: (el) => {
+            fullscreenElement = el
+        },
+    }
+}
+
+let fullscreenSpies: FullscreenSpies
+
+beforeEach(() => {
+    mockController = createMockChartController({ data: [] })
+    installMatchMedia()
+    fullscreenSpies = installFullscreenApi()
+})
+
+afterEach(() => {
+    vi.clearAllMocks()
+})
+
+async function flushMount() {
+    // onMounted is async (awaits createChartController), give microtasks a beat
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+}
+
+describe('KLineChart internalization — dataFetcher default', () => {
+    it('applies the built-in routerDataFetcher when no prop is bound', async () => {
+        const wrapper = mount(KLineChart, { attachTo: document.body })
+        await flushMount()
+
+        const calls = mockController.setDataFetcherCalls()
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toBe(routerDataFetcher)
+
+        wrapper.unmount()
+    })
+
+    it('uses the caller-provided dataFetcher when the prop is bound', async () => {
+        const customFetcher = vi.fn(async () => [])
+        const wrapper = mount(KLineChart, {
+            attachTo: document.body,
+            props: { dataFetcher: customFetcher },
+        })
+        await flushMount()
+
+        const calls = mockController.setDataFetcherCalls()
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toBe(customFetcher)
+        expect(calls[0]).not.toBe(routerDataFetcher)
+
+        wrapper.unmount()
+    })
+})
+
+describe('KLineChart internalization — theme prop', () => {
+    it('applies a controlled theme on mount instead of settings', async () => {
+        const wrapper = mount(KLineChart, {
+            attachTo: document.body,
+            props: { theme: 'dark' },
+        })
+        await flushMount()
+
+        expect(mockController.setThemeCalls()).toContain('dark')
+
+        wrapper.unmount()
+    })
+
+    it('applies theme changes via watcher', async () => {
+        const wrapper = mount(KLineChart, {
+            attachTo: document.body,
+            props: { theme: 'light' },
+        })
+        await flushMount()
+
+        await wrapper.setProps({ theme: 'dark' })
+        await nextTick()
+
+        expect(mockController.setThemeCalls()).toContain('dark')
+
+        wrapper.unmount()
+    })
+
+    it('still emits themeChange when the controller theme changes', async () => {
+        const wrapper = mount(KLineChart, { attachTo: document.body })
+        await flushMount()
+
+        mockController._emitTheme('dark')
+        await nextTick()
+
+        const emitted = wrapper.emitted('themeChange')
+        expect(emitted).toBeTruthy()
+        expect(emitted?.at(-1)).toEqual(['dark'])
+
+        wrapper.unmount()
+    })
+})
+
+describe('KLineChart internalization — fullscreen (uncontrolled)', () => {
+    it('requests fullscreen on the wrapper when toggled with no isFullscreen prop', async () => {
+        const wrapper = mount(KLineChart, { attachTo: document.body })
+        await flushMount()
+
+        wrapper.findComponent({ name: 'LeftToolbar' }).vm.$emit('toggleFullscreen')
+        await nextTick()
+
+        expect(fullscreenSpies.requestFullscreen).toHaveBeenCalledTimes(1)
+        // the element that received requestFullscreen is the chart wrapper
+        const calledOn = fullscreenSpies.requestFullscreen.mock.instances[0] as HTMLElement
+        expect(calledOn.classList.contains('chart-wrapper')).toBe(true)
+        // notification emit still fires
+        expect(wrapper.emitted('toggleFullscreen')).toBeTruthy()
+
+        wrapper.unmount()
+    })
+
+    it('fullscreenchange updates internal state, emits update:isFullscreen, flips icon', async () => {
+        const wrapper = mount(KLineChart, { attachTo: document.body })
+        await flushMount()
+
+        // simulate entering fullscreen
+        fullscreenSpies.setElement(wrapper.element)
+        document.dispatchEvent(new Event('fullscreenchange'))
+        await nextTick()
+
+        const emitted = wrapper.emitted('update:isFullscreen')
+        expect(emitted).toBeTruthy()
+        expect(emitted?.at(-1)).toEqual([true])
+
+        // LeftToolbar receives the effective fullscreen flag → minimize icon
+        const toolbar = wrapper.findComponent({ name: 'LeftToolbar' })
+        expect(toolbar.props('isFullscreen')).toBe(true)
+
+        wrapper.unmount()
+    })
+
+    it('removes the fullscreenchange listener on unmount', async () => {
+        const removeSpy = vi.spyOn(document, 'removeEventListener')
+        const wrapper = mount(KLineChart, { attachTo: document.body })
+        await flushMount()
+
+        wrapper.unmount()
+        await nextTick()
+
+        expect(removeSpy).toHaveBeenCalledWith('fullscreenchange', expect.any(Function))
+        removeSpy.mockRestore()
+    })
+})
+
+describe('KLineChart internalization — fullscreen (controlled)', () => {
+    it('does NOT touch the Fullscreen DOM API when isFullscreen prop is set', async () => {
+        const wrapper = mount(KLineChart, {
+            attachTo: document.body,
+            props: { isFullscreen: false },
+        })
+        await flushMount()
+
+        wrapper.findComponent({ name: 'LeftToolbar' }).vm.$emit('toggleFullscreen')
+        await nextTick()
+
+        expect(fullscreenSpies.requestFullscreen).not.toHaveBeenCalled()
+        expect(fullscreenSpies.exitFullscreen).not.toHaveBeenCalled()
+        // controlled consumers still get the notification emit (legacy behavior)
+        expect(wrapper.emitted('toggleFullscreen')).toBeTruthy()
+
+        wrapper.unmount()
+    })
+})
+
+describe('KLineChart internalization — SSR import safety', () => {
+    it('module import does not throw and exposes the component', async () => {
+        const mod = await import('../components/KLineChart.vue')
+        expect(mod.default).toBeDefined()
+    })
+})

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -31,9 +31,9 @@
     >
       <LeftToolbar
         ref="toolbarRef"
-        :is-fullscreen="isFullscreen"
+        :is-fullscreen="effectiveIsFullscreen"
         @select-tool="handleSelectTool"
-        @toggle-fullscreen="$emit('toggleFullscreen')"
+        @toggle-fullscreen="handleToggleFullscreen"
         @zoom-in="applyZoomToLevel(zoomLevel + 1)"
         @zoom-out="applyZoomToLevel(zoomLevel - 1)"
         @settings-change="handleSettingsChange"
@@ -196,6 +196,7 @@ import CanvasToolbarStack from './common/CanvasToolbarStack.vue'
 import { provideFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
 import {
   createChartController,
+  routerDataFetcher,
   type ChartController,
   type InteractionSnapshot,
   type SymbolSpec,
@@ -218,8 +219,8 @@ const props = withDefaults(
     /** 语义化配置（可选，唯一控制源） */
     semanticConfig?: SemanticChartConfig
 
-    /** 数据获取函数（必需）。框架不绑定数据源，由使用者注入。 */
-    dataFetcher: DataFetcher
+    /** 数据获取函数（可选）。默认使用内置 routerDataFetcher，亦可由使用者注入覆盖。 */
+    dataFetcher?: DataFetcher
 
     yPaddingPx?: number
     minKWidth?: number
@@ -237,8 +238,10 @@ const props = withDefaults(
     zoomLevels?: number
     /** 初始缩放级别（1 ~ zoomLevels，默认居中） */
     initialZoomLevel?: number
-    /** 是否全屏 */
+    /** 是否全屏（受控）。不绑定时为非受控模式，组件内部接管全屏 DOM 操作 */
     isFullscreen?: boolean
+    /** 主题（受控）。不传时由设置项决定 */
+    theme?: 'light' | 'dark'
     /** 时区，默认 Asia/Shanghai */
     timezone?: string
 
@@ -258,6 +261,7 @@ const props = withDefaults(
     }
   }>(),
   {
+    dataFetcher: () => routerDataFetcher,
     yPaddingPx: 20,
     minKWidth: 1,
     maxKWidth: 50,
@@ -266,7 +270,9 @@ const props = withDefaults(
     priceLabelWidth: 60,
     zoomLevels: 20,
     initialZoomLevel: 3,
-    isFullscreen: false,
+    // 显式 undefined：覆盖 Vue 对 Boolean 缺省值的强制转换（默认会变成 false），
+    // 保证未绑定 isFullscreen 时为非受控模式（props.isFullscreen === undefined）
+    isFullscreen: undefined,
     timezone: 'Asia/Shanghai',
   },
 )
@@ -274,6 +280,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: 'zoomLevelChange', level: number, kWidth: number): void
   (e: 'toggleFullscreen'): void
+  (e: 'update:isFullscreen', value: boolean): void
   (e: 'themeChange', theme: 'light' | 'dark'): void
   (e: 'kLineLevelChange', level: string): void
   (e: 'kLineAdjustChange', adjust: 'qfq' | 'hfq' | 'splits' | 'none'): void
@@ -373,6 +380,36 @@ const toolbarRef = ref<InstanceType<typeof LeftToolbar> | null>(null)
 const indicatorSelectorRef = ref<InstanceType<typeof IndicatorSelector> | null>(null)
 const leftAxisLayerRef = ref<HTMLDivElement | null>(null)
 provideFullscreenTeleportTarget(chartWrapperRef)
+
+// ── Fullscreen (controlled / uncontrolled) ──
+const internalIsFullscreen = ref(false)
+const effectiveIsFullscreen = computed(() => props.isFullscreen ?? internalIsFullscreen.value)
+let onFullscreenChange: (() => void) | null = null
+
+function handleToggleFullscreen() {
+  // 受控模式：保持旧行为，仅通知，不操作 DOM
+  if (props.isFullscreen !== undefined) {
+    emit('toggleFullscreen')
+    return
+  }
+
+  // 非受控模式：组件内部接管全屏 DOM 操作
+  if (typeof document !== 'undefined') {
+    const el = chartWrapperRef.value
+    if (!document.fullscreenElement) {
+      if (el && typeof el.requestFullscreen === 'function') {
+        el.requestFullscreen().catch(() => {
+          /* 用户拒绝或浏览器不支持，忽略 */
+        })
+      }
+    } else if (typeof document.exitFullscreen === 'function') {
+      document.exitFullscreen().catch(() => {
+        /* 忽略 */
+      })
+    }
+  }
+  emit('toggleFullscreen')
+}
 
 // ── Controller & Composable Wiring ──
 const controller = shallowRef<ChartController | null>(null)
@@ -929,7 +966,12 @@ function setupChartCallbacks(ctrl: ChartController): () => void {
 function applyInitialSettings(ctrl: ChartController): void {
   const initialSettings = toolbarRef.value?.getSettings() ?? { showVolumePriceMarkers: true }
   chartSettings.value = initialSettings
-  applyThemeFromSettings(initialSettings.theme as string)
+  // 受控主题优先，否则交由设置项决定
+  if (props.theme) {
+    ctrl.setTheme(props.theme)
+  } else {
+    applyThemeFromSettings(initialSettings.theme as string)
+  }
   ctrl.updateSettingsFacade(initialSettings)
 }
 
@@ -973,6 +1015,15 @@ function setupSemanticController(ctrl: ChartController): void {
 // ── onMounted ──
 onMounted(async () => {
   useAnchorPositioning.value = false
+
+  // 全屏状态监听（非受控模式下驱动内部状态与 update:isFullscreen）
+  if (typeof document !== 'undefined') {
+    onFullscreenChange = () => {
+      internalIsFullscreen.value = !!document.fullscreenElement
+      emit('update:isFullscreen', internalIsFullscreen.value)
+    }
+    document.addEventListener('fullscreenchange', onFullscreenChange)
+  }
 
   const container = containerRef.value
   const chartMain = chartMainRef.value
@@ -1020,6 +1071,10 @@ onMounted(async () => {
 
 // ── onUnmounted & Watchers ──
 onUnmounted(() => {
+  if (typeof document !== 'undefined' && onFullscreenChange) {
+    document.removeEventListener('fullscreenchange', onFullscreenChange)
+  }
+  onFullscreenChange = null
   cleanupChartCallbacks?.()
   cleanupChartCallbacks = null
   const ctrl = controller.value
@@ -1060,6 +1115,14 @@ watch(
     if (newVal) controller.value?.applyCustomData(newVal)
   },
   { deep: true },
+)
+
+// 受控主题：外部 theme 变化时同步到控制器
+watch(
+  () => props.theme,
+  (t) => {
+    if (t) controller.value?.setTheme(t)
+  },
 )
 </script>
 

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -261,7 +261,6 @@ const props = withDefaults(
     }
   }>(),
   {
-    dataFetcher: () => routerDataFetcher,
     yPaddingPx: 20,
     minKWidth: 1,
     maxKWidth: 50,
@@ -380,6 +379,11 @@ const toolbarRef = ref<InstanceType<typeof LeftToolbar> | null>(null)
 const indicatorSelectorRef = ref<InstanceType<typeof IndicatorSelector> | null>(null)
 const leftAxisLayerRef = ref<HTMLDivElement | null>(null)
 provideFullscreenTeleportTarget(chartWrapperRef)
+
+// ── DataFetcher 默认值（未绑定时回退到内置 routerDataFetcher）──
+// 用 computed 解析默认值，避免依赖 Vue 对「函数类型 prop 默认值」的特殊语义
+// （函数类型 prop 的 withDefaults 默认值会被原样使用而非作为工厂调用，跨编译条件不稳定）
+const effectiveDataFetcher = computed(() => props.dataFetcher ?? routerDataFetcher)
 
 // ── Fullscreen (controlled / uncontrolled) ──
 const internalIsFullscreen = ref(false)
@@ -506,7 +510,7 @@ const {
   containerRef,
   dataVersion,
   viewportVersion,
-  dataFetcher: computed(() => props.dataFetcher),
+  dataFetcher: effectiveDataFetcher,
   batchStockCodes,
 })
 
@@ -992,7 +996,7 @@ function setupSemanticController(ctrl: ChartController): void {
     return
   }
 
-  ctrl.setDataFetcher(props.dataFetcher)
+  ctrl.setDataFetcher(effectiveDataFetcher.value)
   semanticController.value = new SemanticChartController(ctrl)
 
   semanticController.value.on('config:error', (error) => {

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -10,12 +10,19 @@ const coreSrc = fileURLToPath(new URL('../core/src', import.meta.url))
 const repoSrc = fileURLToPath(new URL('../../src', import.meta.url))
 
 const corePkg = JSON.parse(readFileSync(new URL('../core/package.json', import.meta.url), 'utf-8'))
-const coreAliases: Array<{ find: string; replacement: string }> = []
+const coreAliases: Array<{ find: string | RegExp; replacement: string }> = []
 for (const [key, value] of Object.entries(corePkg.exports)) {
-    if (key === '.') continue
-    const subpath = `@363045841yyt/klinechart-core${key.slice(1)}`
     const importPath = (value as any).import as string
     const sourcePath = importPath.replace('./dist/', '').replace(/\.js$/, '.ts')
+    if (key === '.') {
+        // Exact-match the bare root specifier so it does not clobber sub-paths.
+        coreAliases.push({
+            find: /^@363045841yyt\/klinechart-core$/,
+            replacement: `${coreSrc}/${sourcePath}`,
+        })
+        continue
+    }
+    const subpath = `@363045841yyt/klinechart-core${key.slice(1)}`
     coreAliases.push({ find: subpath, replacement: `${coreSrc}/${sourcePath}` })
 }
 


### PR DESCRIPTION
## Summary
Internalizes three things the Vue `KLineChart` SFC was pushing onto consumers (visible in `packages/vue/preview/App.vue`, which shrinks ~26 lines). Branches off current `main`, so the diff is just the 5 vue-package files.

### Changes
1. **dataFetcher default** — `dataFetcher` is now optional and defaults to the built-in `routerDataFetcher`; explicit override unchanged. Consumers no longer import/pass it.
2. **theme prop** — new controlled `theme?: 'light' | 'dark'` applied on mount (precedence over settings) and on change; the existing `themeChange` emit is preserved → `:theme` + `@theme-change` two-way use.
3. **fullscreen internalization** — the SFC owns fullscreen on its own `.chart-wrapper`. **Backward-safe dual mode:** when `:is-fullscreen` is bound it stays *controlled* (emit-only, no DOM — identical legacy behavior); when unbound it manages `requestFullscreen`/`exitFullscreen` itself and emits `update:isFullscreen` (v-model). SSR/jsdom-guarded; `fullscreenchange` listener removed on unmount.

### Consumer impact (`preview/App.vue`)
Dropped the `routerDataFetcher` import + both `:dataFetcher` bindings, the `toggleFullscreen()`/`handleFullscreenChange()` functions, and the manual `fullscreenchange` listener — replaced by `@update:is-fullscreen` + `:theme`. ~26 fewer lines.

### Backward compatibility
- `dataFetcher` / `isFullscreen` / `toggleFullscreen` / `themeChange` all still work exactly as before for existing consumers. The only behavioral change is *additive* (defaults + uncontrolled fullscreen when previously the consumer had to do it).
- `isFullscreen` default changed from `false` to `undefined` so the SFC can distinguish controlled (bound) from uncontrolled (unbound). A consumer reading the prop without binding it now sees `undefined` instead of `false` — use `effectiveIsFullscreen` semantics via `update:isFullscreen`.

### Tests
`packages/vue/src/__tests__/internalize.test.ts` — 10 new cases (dataFetcher default+override; theme mount/change + `themeChange` still emits; fullscreen uncontrolled→`requestFullscreen` on wrapper, `fullscreenchange`→`update:isFullscreen`+icon, listener cleanup; controlled mode→no DOM; SSR import). **16/16 pass** with the existing contract suite. `vitest.config.ts` gains an exact-match root alias so the new test's `vi.importActual` resolves core from source (mirrors existing sub-path aliases).

## Test plan
- [x] `pnpm --filter @363045841yyt/klinechart-core build && (cd packages/vue && pnpm exec vitest run)` → 16/16
- [x] `vue-tsc --noEmit` → 0 errors (after core build)
- [ ] TODO: manual fullscreen smoke test in a browser (controlled + uncontrolled paths)
