### PR TITLE
feat(core): add real-time depth data pipeline (SSE → HeatmapController)

### DIFF
--- a/packages/core/src/__tests__/depthPipeline.test.ts
+++ b/packages/core/src/__tests__/depthPipeline.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { BinanceSSESource } from '../data-fetchers/binance'
+import { DepthConnector } from '../data-fetchers/depthConnector'
+import { createHeatmapController } from '../components/orderBookHeatmap/createHeatmapController'
+import type { HeatmapController } from '../components/orderBookHeatmap/types'
+
+// ---------------------------------------------------------------------------
+// Fake EventSource — same shape as binance.test.ts
+// ---------------------------------------------------------------------------
+interface FakeES {
+  onopen: (() => void) | null
+  onerror: ((e: unknown) => void) | null
+  onmessage: ((event: { data: string }) => void) | null
+  close: ReturnType<typeof vi.fn>
+}
+
+function createFakeES(): FakeES {
+  return {
+    onopen: null,
+    onerror: null,
+    onmessage: null,
+    close: vi.fn(),
+  }
+}
+
+function snapshotMsg(
+  bids: ReadonlyArray<readonly [number, number]>,
+  asks: ReadonlyArray<readonly [number, number]>,
+  timestamp: number,
+) {
+  return { data: JSON.stringify({ type: 'snapshot', bids, asks, timestamp }) }
+}
+
+function deltaMsg(entries: { side: 'bid' | 'ask'; price: number; size: number; timestamp: number }[]) {
+  return { data: JSON.stringify({ type: 'delta', entries }) }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeController(
+  snapshotIntervalMs = 100,
+  tickSize = 0.01,
+): HeatmapController {
+  return createHeatmapController({
+    tickSize,
+    snapshotIntervalMs,
+    snapshotRingCapacity: 100,
+    deltaArchiveMaxSize: 10_000,
+    logColorRange: { sizeMin: 1, sizeMax: 1_000_000 },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
+describe('depth pipeline: BinanceSSESource → DepthConnector → HeatmapController', () => {
+  let es: FakeES
+  let esFactory: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    es = createFakeES()
+    esFactory = vi.fn(() => es as unknown as EventSource)
+  })
+
+  /**
+   * Helper: create source, connector, controller, open the SSE connection,
+   * and return everything so the test can drive events through `es`.
+   */
+  function wired() {
+    const source = new BinanceSSESource('btcusdt', 'http://fake/sse', esFactory)
+    const ctrl = makeController()
+    const connector = new DepthConnector(source)
+    connector.addController(ctrl)
+    connector.start()
+    // Simulate SSE open
+    es.onopen!()
+    return { source, connector, ctrl, es }
+  }
+
+  afterEach(() => {
+    // Ensure no dangling connectors — each test tears down explicitly
+  })
+
+  // ── Snapshot → deltas → verify ring/archive ─────────────────────────
+
+  it('full lifecycle: snapshot resetBook then deltas drive snapshots into the ring', () => {
+    const { connector, ctrl, es } = wired()
+
+    // --- Step 1: snapshot resets the book ---
+    es.onmessage!(snapshotMsg([[100, 10], [99, 5]], [[101, 8], [102, 3]], 1000))
+    let st = ctrl.state.peek()
+    expect(st.latestSnapshot).not.toBeNull()
+    // Book is populated from snapshot
+    expect(st.latestSnapshot!.bids).toEqual([[100, 10], [99, 5]])
+    expect(st.latestSnapshot!.asks).toEqual([[101, 8], [102, 3]])
+    // Ring and archive are cleared
+    expect(st.snapshotCount).toBe(0)
+    expect(st.deltaCount).toBe(0)
+
+    // --- Step 2: first delta anchors the clock (no snapshot emitted) ---
+    es.onmessage!(deltaMsg([{ side: 'bid', price: 100, size: 15, timestamp: 1000 }]))
+    st = ctrl.state.peek()
+    // latestSnapshot hasn't changed (first delta doesn't emit one)
+    expect(st.latestSnapshot!.bids).toEqual([[100, 10], [99, 5]])
+    expect(st.snapshotCount).toBe(0)
+    expect(st.deltaCount).toBe(1)
+    // But the book was updated — verify via forceSnapshot
+    ctrl.forceSnapshot()
+    expect(ctrl.state.peek().latestSnapshot!.bids).toEqual([[100, 15], [99, 5]])
+
+    // --- Step 3: second delta crosses snapshotIntervalMs (100ms) → one snapshot ---
+    es.onmessage!(deltaMsg([{ side: 'ask', price: 101, size: 0, timestamp: 1100 }]))
+    st = ctrl.state.peek()
+    // Interval crossed → snapshot was emitted at 1100
+    expect(st.snapshotCount).toBe(2) // previous forceSnapshot + 1
+    expect(st.deltaCount).toBe(2)
+    // Snapshot captured book BEFORE the delta was applied (101 is still present)
+    expect(st.latestSnapshot!.asks).toEqual([[101, 8], [102, 3]])
+
+    // --- Step 4: more deltas produce more snapshots ---
+    es.onmessage!(deltaMsg([{ side: 'bid', price: 99, size: 0, timestamp: 1250 }]))
+    st = ctrl.state.peek()
+    // Crossed 1200 → snapshot (captures pre-delta state: bid 99 still present)
+    expect(st.snapshotCount).toBe(3)
+    expect(st.deltaCount).toBe(3)
+
+    connector.destroy()
+  })
+
+  // ── Reconnect: second snapshot replaces book ────────────────────────
+
+  it('second snapshot (simulating SSE reconnect) resets the book and clears state', () => {
+    const { connector, ctrl, es } = wired()
+
+    // Initial snapshot + deltas
+    es.onmessage!(snapshotMsg([[100, 10]], [[101, 8]], 1000))
+    es.onmessage!(deltaMsg([{ side: 'bid', price: 100, size: 20, timestamp: 1100 }]))
+    ctrl.forceSnapshot() // capture state after first delta
+    expect(ctrl.state.peek().snapshotCount).toBe(1)
+    expect(ctrl.state.peek().deltaCount).toBe(1)
+
+    // --- Reconnect: second snapshot ---
+    es.onmessage!(snapshotMsg([[200, 50]], [[201, 40]], 2000))
+    let st = ctrl.state.peek()
+    // Book replaced and published
+    expect(st.latestSnapshot!.bids).toEqual([[200, 50]])
+    expect(st.latestSnapshot!.asks).toEqual([[201, 40]])
+    // Everything reset
+    expect(st.snapshotCount).toBe(0)
+    expect(st.deltaCount).toBe(0)
+
+    // Deltas after reconnect work normally
+    es.onmessage!(deltaMsg([{ side: 'bid', price: 200, size: 60, timestamp: 2100 }]))
+    st = ctrl.state.peek()
+    // First delta anchors clock → no snapshot
+    expect(st.snapshotCount).toBe(0)
+    expect(st.deltaCount).toBe(1)
+    // forceSnapshot to verify book state
+    ctrl.forceSnapshot()
+    expect(ctrl.state.peek().latestSnapshot!.bids).toEqual([[200, 60]])
+
+    // Second delta crosses 100ms → snapshot
+    es.onmessage!(deltaMsg([{ side: 'ask', price: 201, size: 35, timestamp: 2200 }]))
+    st = ctrl.state.peek()
+    expect(st.snapshotCount).toBe(2) // forceSnapshot + 1
+    expect(st.deltaCount).toBe(2)
+    // Snapshot at 2200 captured pre-delta book: asks still show 201→40
+    expect(st.latestSnapshot!.bids).toEqual([[200, 60]])
+    expect(st.latestSnapshot!.asks).toEqual([[201, 40]])
+
+    connector.destroy()
+  })
+
+  // ── Multiple controllers ────────────────────────────────────────────
+
+  it('one source feeds two controllers independently', () => {
+    const source = new BinanceSSESource('btcusdt', 'http://fake/sse', esFactory)
+    const ctrlA = makeController()
+    const ctrlB = makeController()
+    const connector = new DepthConnector(source)
+    connector.addController(ctrlA)
+    connector.addController(ctrlB)
+    connector.start()
+    es.onopen!()
+
+    // Snapshot — resetBook publishes book snapshot
+    es.onmessage!(snapshotMsg([[100, 5]], [[101, 3]], 500))
+    expect(ctrlA.state.peek().latestSnapshot!.bids).toEqual([[100, 5]])
+    expect(ctrlB.state.peek().latestSnapshot!.bids).toEqual([[100, 5]])
+
+    // Delta — first delta anchors, no new snapshot emitted
+    es.onmessage!(deltaMsg([{ side: 'bid', price: 100, size: 10, timestamp: 600 }]))
+    expect(ctrlA.state.peek().deltaCount).toBe(1)
+    expect(ctrlB.state.peek().deltaCount).toBe(1)
+    // forceSnapshot to peek book state
+    ctrlA.forceSnapshot()
+    ctrlB.forceSnapshot()
+    expect(ctrlA.state.peek().latestSnapshot!.bids).toEqual([[100, 10]])
+    expect(ctrlB.state.peek().latestSnapshot!.bids).toEqual([[100, 10]])
+
+    // Remove ctrlA — only ctrlB gets subsequent deltas
+    connector.removeController(ctrlA)
+    es.onmessage!(deltaMsg([{ side: 'ask', price: 101, size: 5, timestamp: 700 }]))
+    // Delta at 700 triggers a snapshot at 700 (pre-delta state: ask 101 still 3)
+    expect(ctrlB.state.peek().latestSnapshot!.asks).toEqual([[101, 3]])
+    // The book did apply the delta though — verify via forceSnapshot
+    ctrlB.forceSnapshot()
+    expect(ctrlB.state.peek().latestSnapshot!.asks).toEqual([[101, 5]])
+    // ctrlA never received this delta — forceSnapshot to verify
+    ctrlA.forceSnapshot()
+    expect(ctrlA.state.peek().latestSnapshot!.asks).toEqual([[101, 3]])
+
+    connector.destroy()
+  })
+
+  // ── Quantization through the pipeline ───────────────────────────────
+
+  it('prices are quantized through the full pipeline', () => {
+    const source = new BinanceSSESource('btcusdt', 'http://fake/sse', esFactory)
+    // tickSize 0.05 — coarse quantization
+    const ctrl = makeController(100, 0.05)
+    const connector = new DepthConnector(source)
+    connector.addController(ctrl)
+    connector.start()
+    es.onopen!()
+
+    // 100.07 with tick 0.05 → index 2001 → dequantized 100.05
+    es.onmessage!(snapshotMsg([[100.07, 3]], [[101.03, 2]], 100))
+    const st = ctrl.state.peek()
+    expect(st.latestSnapshot!.bids).toEqual([[100.05, 3]])
+    expect(st.latestSnapshot!.asks).toEqual([[101.05, 2]])
+
+    connector.destroy()
+  })
+
+  // ── Destroy stops data flow ─────────────────────────────────────────
+
+  it('destroy stops data from reaching the controller', () => {
+    const { connector, ctrl, es } = wired()
+
+    es.onmessage!(snapshotMsg([[100, 1]], [[101, 1]], 100))
+    expect(ctrl.state.peek().latestSnapshot).not.toBeNull()
+
+    connector.destroy()
+
+    // After destroy, delta does nothing
+    es.onmessage!(deltaMsg([{ side: 'bid', price: 100, size: 99, timestamp: 200 }]))
+    expect(ctrl.state.peek().latestSnapshot!.bids).toEqual([[100, 1]])
+  })
+
+  // ── Error from source is caught ─────────────────────────────────────
+
+  it('malformed SSE JSON fires error but does not crash the pipeline', () => {
+    const { connector, ctrl, es } = wired()
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Bad JSON
+    es.onmessage!({ data: 'not valid json' })
+    // Controller state is unaffected
+    expect(ctrl.state.peek().latestSnapshot).toBeNull()
+    expect(consoleSpy).toHaveBeenCalled()
+
+    // Subsequent valid message still works
+    es.onmessage!(snapshotMsg([[100, 1]], [[101, 1]], 100))
+    expect(ctrl.state.peek().latestSnapshot).not.toBeNull()
+
+    consoleSpy.mockRestore()
+    connector.destroy()
+  })
+
+  // ── Snapshot with empty book ────────────────────────────────────────
+
+  it('snapshot with empty bids/asks clears the book', () => {
+    const { connector, ctrl, es } = wired()
+
+    // Populate book
+    es.onmessage!(snapshotMsg([[100, 10]], [[101, 8]], 500))
+    expect(ctrl.state.peek().latestSnapshot!.bids).toHaveLength(1)
+
+    // Empty snapshot
+    es.onmessage!(snapshotMsg([], [], 600))
+    const st = ctrl.state.peek()
+    expect(st.latestSnapshot!.bids).toEqual([])
+    expect(st.latestSnapshot!.asks).toEqual([])
+
+    connector.destroy()
+  })
+})

--- a/packages/core/src/components/orderBookHeatmap/__tests__/controller.test.ts
+++ b/packages/core/src/components/orderBookHeatmap/__tests__/controller.test.ts
@@ -232,4 +232,133 @@ describe('createHeatmapController', () => {
     off()
     ctrl.dispose()
   })
+
+  describe('resetBook', () => {
+    it('replaces book state with snapshot, resets ring/archive/clock', () => {
+      const ctrl = createHeatmapController({
+        tickSize: 0.01,
+        snapshotIntervalMs: 100,
+        snapshotRingCapacity: 10,
+        deltaArchiveMaxSize: 1000,
+        logColorRange: { sizeMin: 1, sizeMax: 1000 },
+      })
+      // Establish some live state.
+      ctrl.ingestDelta(bid(0, 100, 1))
+      ctrl.ingestDelta(bid(150, 100, 2)) // crosses 100ms → 1 snapshot
+      expect(ctrl.state.peek().snapshotCount).toBe(1)
+      expect(ctrl.state.peek().deltaCount).toBe(2)
+
+      const snap: BookSnapshot = {
+        bids: [[99, 10], [98, 5]],
+        asks: [[101, 8]],
+        timestamp: 500,
+      }
+      ctrl.resetBook(snap)
+
+      const st = ctrl.state.peek()
+      expect(st.snapshotCount).toBe(0)
+      expect(st.deltaCount).toBe(0)
+      expect(st.latestSnapshot?.bids).toEqual([[99, 10], [98, 5]])
+      expect(st.latestSnapshot?.asks).toEqual([[101, 8]])
+      expect(st.latestSnapshot?.timestamp).toBe(500)
+      ctrl.dispose()
+    })
+
+    it('clears snapshot ring and delta archive', () => {
+      const ctrl = createHeatmapController({
+        tickSize: 0.01,
+        snapshotIntervalMs: 100,
+        snapshotRingCapacity: 10,
+        deltaArchiveMaxSize: 1000,
+        logColorRange: { sizeMin: 1, sizeMax: 1000 },
+      })
+      // Ingest enough to create snapshots in the ring.
+      ctrl.ingestDelta(bid(0, 100, 1))
+      ctrl.ingestDelta(bid(150, 100, 2))
+      ctrl.ingestDelta(bid(250, 100, 3))
+      // Snapshots at 100 and 200.
+      expect(ctrl.state.peek().snapshotCount).toBe(2)
+
+      // Replay must return something before reset.
+      const beforeReplay = ctrl.replay(0, 250, 50)
+      expect(beforeReplay.length).toBeGreaterThan(0)
+
+      ctrl.resetBook({
+        bids: [[100, 5]],
+        asks: [[101, 3]],
+        timestamp: 300,
+      })
+
+      // Ring is cleared.
+      expect(ctrl.state.peek().snapshotCount).toBe(0)
+      // Archive is cleared — replay produces skeleton snapshots (empty book).
+      const after = ctrl.replay(0, 500, 50)
+      expect(after.length).toBeGreaterThan(0)
+      for (const snap of after) {
+        expect(snap.bids).toEqual([])
+        expect(snap.asks).toEqual([])
+      }
+      ctrl.dispose()
+    })
+
+    it('resets snapshot clock so next ingest anchors fresh', () => {
+      const ctrl = createHeatmapController({
+        tickSize: 0.01,
+        snapshotIntervalMs: 100,
+        snapshotRingCapacity: 10,
+        deltaArchiveMaxSize: 1000,
+        logColorRange: { sizeMin: 1, sizeMax: 1000 },
+      })
+      ctrl.ingestDelta(bid(0, 100, 1))
+      // Clock at 0. Next delta at 50 should NOT trigger snapshot (not past
+      // interval). But after resetBook, the clock resets so the next delta
+      // anchors anew.
+      ctrl.resetBook({
+        bids: [[100, 5]],
+        asks: [[101, 3]],
+        timestamp: 200,
+      })
+      // Delta at 250 — clock was reset to null, so this anchors at 250
+      // and should NOT produce a snapshot (first delta never does).
+      ctrl.ingestDelta(bid(250, 100, 2))
+      expect(ctrl.state.peek().snapshotCount).toBe(0)
+
+      // Now a delta at 400 crosses 100ms from anchor → 1 snapshot.
+      ctrl.ingestDelta(bid(400, 100, 3))
+      expect(ctrl.state.peek().snapshotCount).toBe(1)
+      ctrl.dispose()
+    })
+
+    it('resetBook ingests the snapshot as deltas into the book', () => {
+      const ctrl = createHeatmapController({
+        tickSize: 0.5,
+        snapshotIntervalMs: 1000,
+        snapshotRingCapacity: 10,
+        deltaArchiveMaxSize: 1000,
+        logColorRange: { sizeMin: 1, sizeMax: 1000 },
+      })
+      // Tick size 0.5 means 100.25 → 100.0.
+      ctrl.resetBook({
+        bids: [[100.25, 7]],
+        asks: [[101.0, 4]],
+        timestamp: 10,
+      })
+      const st = ctrl.state.peek()
+      // tickSize 0.5: 100.25 → index 201 → dequantized 100.5
+      expect(st.latestSnapshot?.bids).toEqual([[100.5, 7]])
+      expect(st.latestSnapshot?.asks).toEqual([[101.0, 4]])
+      ctrl.dispose()
+    })
+
+    it('disposed controller silently ignores resetBook', () => {
+      const ctrl = createHeatmapController()
+      ctrl.dispose()
+      ctrl.resetBook({
+        bids: [[100, 5]],
+        asks: [[101, 3]],
+        timestamp: 1,
+      })
+      expect(ctrl.state.peek().latestSnapshot).toBeNull()
+    })
+  })
 })

--- a/packages/core/src/components/orderBookHeatmap/__tests__/controller.test.ts
+++ b/packages/core/src/components/orderBookHeatmap/__tests__/controller.test.ts
@@ -118,7 +118,7 @@ describe('createHeatmapController', () => {
     for (const snap of replayed) {
       const oracle = createOrderBookState({ tickSize: 0.01 })
       for (const d of deltas) {
-        if (d.timestamp <= snap.timestamp) oracle.applyDelta(d)
+        if (d.timestamp < snap.timestamp) oracle.applyDelta(d)
       }
       const expected = oracle.snapshot()
       expect(snap.bids).toEqual(expected.bids)
@@ -149,7 +149,7 @@ describe('createHeatmapController', () => {
 
     // Live midpoint reference: replay BOOK alone, no controller, up to t=80.
     const reference = createOrderBookState({ tickSize: 0.01 })
-    for (const d of deltas) if (d.timestamp <= 80) reference.applyDelta(d)
+    for (const d of deltas) if (d.timestamp < 80) reference.applyDelta(d)
     const refSnap = reference.snapshot()
 
     // Controller-produced replay snapshot at exactly t=80.

--- a/packages/core/src/components/orderBookHeatmap/createHeatmapController.ts
+++ b/packages/core/src/components/orderBookHeatmap/createHeatmapController.ts
@@ -169,7 +169,7 @@ export function createHeatmapController(
     let cursor = 0
     while (nextSnapTs <= toTimestamp) {
       // Apply every delta with ts ≤ nextSnapTs.
-      while (cursor < sorted.length && sorted[cursor].timestamp <= nextSnapTs) {
+      while (cursor < sorted.length && sorted[cursor].timestamp < nextSnapTs) {
         replayBook.applyDelta(sorted[cursor])
         cursor++
       }

--- a/packages/core/src/components/orderBookHeatmap/createHeatmapController.ts
+++ b/packages/core/src/components/orderBookHeatmap/createHeatmapController.ts
@@ -224,6 +224,23 @@ export function createHeatmapController(
     publish(state.peek().latestSnapshot)
   }
 
+  function resetBook(snapshot: BookSnapshot): void {
+    if (disposed) return
+    book = createOrderBookState({ tickSize: config.tickSize })
+    for (const [price, size] of snapshot.bids) {
+      book.applyDelta({ side: 'bid', price, size, timestamp: snapshot.timestamp })
+    }
+    for (const [price, size] of snapshot.asks) {
+      book.applyDelta({ side: 'ask', price, size, timestamp: snapshot.timestamp })
+    }
+    snapshotClock = null
+    snapshotCount = 0
+    deltaCount = 0
+    ring.clear()
+    archive.clear()
+    publish(book.snapshot())
+  }
+
   function dispose(): void {
     if (disposed) return
     disposed = true
@@ -239,6 +256,7 @@ export function createHeatmapController(
     ingest: ingestDelta,
     ingestDelta,
     forceSnapshot,
+    resetBook,
     replay,
     setConfig,
     dispose,

--- a/packages/core/src/components/orderBookHeatmap/types.ts
+++ b/packages/core/src/components/orderBookHeatmap/types.ts
@@ -163,6 +163,16 @@ export interface HeatmapController {
     snapshotIntervalMs: number,
   ): ReadonlyArray<BookSnapshot>
 
+  /**
+   * Replace the internal book with a full snapshot. Resets the snapshot clock,
+   * ring, and archive so the controller is in a clean state — subsequent
+   * `ingest(delta)` calls continue normally.
+   *
+   * Designed for SSE reconnect: Go backend pushes a `type:"snapshot"` event
+   * on connect, the connector calls `resetBook()`, then live deltas resume.
+   * This avoids racing between REST snapshot and SSE stream.
+   */
+  resetBook(snapshot: BookSnapshot): void
   setConfig(next: Partial<HeatmapControllerConfig>): void
   dispose(): void
 }

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -62,8 +62,11 @@ export {
   baostockDataFetcher,
   routerDataFetcher,
   DataBuffer,
+  BinanceSSESource,
+  DEFAULT_BINANCE_SSE_URL,
+  DepthConnector,
 } from '../data-fetchers'
-export type { DataWindow } from '../data-fetchers'
+export type { DataWindow, DepthSource, DepthDelta, DepthSnapshot, DepthSourceStatus } from '../data-fetchers'
 
 // Drawing
 export { DrawingInteractionController } from '../engine/drawing'

--- a/packages/core/src/data-fetchers/__tests__/binance.test.ts
+++ b/packages/core/src/data-fetchers/__tests__/binance.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { BinanceSSESource, DEFAULT_BINANCE_SSE_URL } from '../binance'
+import type { DepthDelta, DepthSnapshot, DepthSourceStatus } from '../depthTypes'
+
+interface FakeEventSource {
+  onopen: (() => void) | null
+  onerror: ((e: unknown) => void) | null
+  onmessage: ((event: { data: string }) => void) | null
+  close: ReturnType<typeof vi.fn>
+}
+
+function createFakeES(): FakeEventSource {
+  return {
+    onopen: null,
+    onerror: null,
+    onmessage: null,
+    close: vi.fn(),
+  }
+}
+
+function makeSnapshotEvent(
+  bids: ReadonlyArray<readonly [number, number]>,
+  asks: ReadonlyArray<readonly [number, number]>,
+  timestamp: number,
+) {
+  return {
+    data: JSON.stringify({ type: 'snapshot', bids, asks, timestamp }),
+  }
+}
+
+function makeDeltaEvent(entries: DepthDelta[]) {
+  return {
+    data: JSON.stringify({ type: 'delta', entries }),
+  }
+}
+
+describe('BinanceSSESource', () => {
+  let es: FakeEventSource
+  let esFactory: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    es = createFakeES()
+    esFactory = vi.fn(() => es as unknown as EventSource)
+  })
+
+  afterEach(() => {
+    // Clean up any source that might still be connecting
+  })
+
+  function createSource(symbol = 'btcusdt', baseUrl = DEFAULT_BINANCE_SSE_URL) {
+    return new BinanceSSESource(symbol, baseUrl, esFactory)
+  }
+
+  describe('connect / disconnect', () => {
+    it('creates EventSource with the correct URL', () => {
+      const src = createSource('ethusdt', 'http://example.com/sse')
+      src.connect()
+      expect(esFactory).toHaveBeenCalledWith('http://example.com/sse?symbol=ethusdt')
+      src.destroy()
+    })
+
+    it('calls onopen → emits connected status', () => {
+      const src = createSource()
+      const statuses: DepthSourceStatus[] = []
+      src.onStatus((s) => statuses.push(s))
+      src.connect()
+      expect(statuses).toEqual(['connecting'])
+      es.onopen!()
+      expect(statuses).toEqual(['connecting', 'connected'])
+      src.destroy()
+    })
+
+    it('calls onerror → emits disconnected status', () => {
+      const src = createSource()
+      const statuses: DepthSourceStatus[] = []
+      src.onStatus((s) => statuses.push(s))
+      src.connect()
+      es.onopen!()
+      statuses.length = 0
+      es.onerror!(null)
+      expect(statuses).toEqual(['disconnected'])
+      src.destroy()
+    })
+
+    it('disconnect() closes EventSource and emits disconnected', () => {
+      const src = createSource()
+      const statuses: DepthSourceStatus[] = []
+      src.onStatus((s) => statuses.push(s))
+      src.connect()
+      es.onopen!()
+      statuses.length = 0
+      src.disconnect()
+      expect(es.close).toHaveBeenCalledOnce()
+      expect(statuses).toEqual(['disconnected'])
+      src.destroy()
+    })
+
+    it('disconnect() when already disconnected is a no-op', () => {
+      const src = createSource()
+      src.disconnect()
+      expect(es.close).not.toHaveBeenCalled()
+      src.destroy()
+    })
+
+    it('connect() closes previous EventSource before creating a new one', () => {
+      const src = createSource()
+      src.connect()
+      const es1 = es
+      const es2 = createFakeES()
+      esFactory.mockReturnValue(es2 as unknown as EventSource)
+      src.connect()
+      expect(es1.close).toHaveBeenCalledOnce()
+      expect(esFactory).toHaveBeenCalledTimes(2)
+      src.destroy()
+    })
+  })
+
+  describe('snapshot messages', () => {
+    it('calls registered snapshot callbacks on snapshot event', () => {
+      const src = createSource()
+      const snapshots: DepthSnapshot[] = []
+      src.onSnapshot((s) => snapshots.push(s))
+      src.connect()
+      es.onopen!()
+
+      es.onmessage!(makeSnapshotEvent([[100, 5]], [[101, 3]], 1000))
+      expect(snapshots).toHaveLength(1)
+      expect(snapshots[0].bids).toEqual([[100, 5]])
+      expect(snapshots[0].asks).toEqual([[101, 3]])
+      expect(snapshots[0].timestamp).toBe(1000)
+      src.destroy()
+    })
+
+    it('ignores snapshot when bids/asks/timestamp are missing', () => {
+      const src = createSource()
+      const snapshots: DepthSnapshot[] = []
+      src.onSnapshot((s) => snapshots.push(s))
+      src.connect()
+      es.onopen!()
+
+      // type=snapshot but missing bids → silently ignored, no error thrown
+      es.onmessage!({ data: JSON.stringify({ type: 'snapshot', asks: [], timestamp: 1 }) })
+      expect(snapshots).toHaveLength(0)
+
+      // type=snapshot but missing timestamp
+      es.onmessage!({ data: JSON.stringify({ type: 'snapshot', bids: [], asks: [] }) })
+      expect(snapshots).toHaveLength(0)
+      src.destroy()
+    })
+  })
+
+  describe('delta messages', () => {
+    it('calls registered delta callbacks on delta event', () => {
+      const src = createSource()
+      const deltas: ReadonlyArray<DepthDelta>[] = []
+      src.onDelta((d) => deltas.push(d))
+      src.connect()
+      es.onopen!()
+
+      const entries: DepthDelta[] = [
+        { side: 'bid', price: 100, size: 5, timestamp: 2000 },
+        { side: 'ask', price: 101, size: 3, timestamp: 2000 },
+      ]
+      es.onmessage!(makeDeltaEvent(entries))
+      expect(deltas).toHaveLength(1)
+      expect(deltas[0]).toEqual(entries)
+      src.destroy()
+    })
+
+    it('ignores delta when entries is missing', () => {
+      const src = createSource()
+      const deltas: ReadonlyArray<DepthDelta>[] = []
+      src.onDelta((d) => deltas.push(d))
+      src.connect()
+      es.onopen!()
+
+      es.onmessage!({ data: JSON.stringify({ type: 'delta' }) })
+      expect(deltas).toHaveLength(0)
+      src.destroy()
+    })
+  })
+
+  describe('keepalive handling', () => {
+    it('ignores empty messages', () => {
+      const src = createSource()
+      const deltas: ReadonlyArray<DepthDelta>[] = []
+      const snapshots: DepthSnapshot[] = []
+      src.onDelta((d) => deltas.push(d))
+      src.onSnapshot((s) => snapshots.push(s))
+      src.connect()
+      es.onopen!()
+
+      es.onmessage!({ data: '' })
+      es.onmessage!({ data: ':' })
+      es.onmessage!({ data: ': heartbeat' })
+      expect(deltas).toHaveLength(0)
+      expect(snapshots).toHaveLength(0)
+      src.destroy()
+    })
+
+    it('ignores SSE comments starting with colon', () => {
+      const src = createSource()
+      const deltas: ReadonlyArray<DepthDelta>[] = []
+      src.onDelta((d) => deltas.push(d))
+      src.connect()
+      es.onopen!()
+
+      es.onmessage!({ data: ':ok' })
+      expect(deltas).toHaveLength(0)
+      src.destroy()
+    })
+  })
+
+  describe('error handling', () => {
+    it('fires error callbacks on JSON parse error', () => {
+      const src = createSource()
+      const errors: Error[] = []
+      src.onError((e) => errors.push(e))
+      src.connect()
+      es.onopen!()
+
+      es.onmessage!({ data: 'not json' })
+      expect(errors).toHaveLength(1)
+      expect(errors[0].message).toContain('BinanceSSE parse error')
+      src.destroy()
+    })
+  })
+
+  describe('destroy', () => {
+    it('destroys closes EventSource and clears callbacks', () => {
+      const src = createSource()
+      const deltas: ReadonlyArray<DepthDelta>[] = []
+      src.onDelta((d) => deltas.push(d))
+      src.connect()
+      es.onopen!()
+      src.destroy()
+
+      // After destroy, messages are ignored
+      es.onmessage!(makeDeltaEvent([{ side: 'bid', price: 100, size: 1, timestamp: 1 }]))
+      expect(deltas).toHaveLength(0)
+    })
+
+    it('connect() after destroy() is a no-op', () => {
+      const src = createSource()
+      src.destroy()
+      src.connect()
+      expect(esFactory).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('multiple subscribers', () => {
+    it('notifies all delta subscribers', () => {
+      const src = createSource()
+      const a: ReadonlyArray<DepthDelta>[] = []
+      const b: ReadonlyArray<DepthDelta>[] = []
+      src.onDelta((d) => a.push(d))
+      src.onDelta((d) => b.push(d))
+      src.connect()
+      es.onopen!()
+
+      es.onmessage!(makeDeltaEvent([{ side: 'bid', price: 100, size: 1, timestamp: 1 }]))
+      expect(a).toHaveLength(1)
+      expect(b).toHaveLength(1)
+      src.destroy()
+    })
+
+    it('notifies all snapshot subscribers', () => {
+      const src = createSource()
+      const a: DepthSnapshot[] = []
+      const b: DepthSnapshot[] = []
+      src.onSnapshot((s) => a.push(s))
+      src.onSnapshot((s) => b.push(s))
+      src.connect()
+      es.onopen!()
+
+      es.onmessage!(makeSnapshotEvent([[100, 5]], [[101, 3]], 1))
+      expect(a).toHaveLength(1)
+      expect(b).toHaveLength(1)
+      src.destroy()
+    })
+
+    it('unsubscribe removes a callback', () => {
+      const src = createSource()
+      const calls: number[] = []
+      const unsub = src.onDelta(() => calls.push(1))
+      src.onDelta(() => calls.push(2))
+      src.connect()
+      es.onopen!()
+      es.onmessage!(makeDeltaEvent([{ side: 'bid', price: 100, size: 1, timestamp: 1 }]))
+      expect(calls).toEqual([1, 2])
+      unsub()
+      es.onmessage!(makeDeltaEvent([{ side: 'bid', price: 100, size: 1, timestamp: 2 }]))
+      expect(calls).toEqual([1, 2, 2])
+      src.destroy()
+    })
+  })
+})

--- a/packages/core/src/data-fetchers/__tests__/depthConnector.test.ts
+++ b/packages/core/src/data-fetchers/__tests__/depthConnector.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DepthConnector } from '../depthConnector'
+import type {
+  DepthDelta,
+  DepthSnapshot,
+  DepthSource,
+  DepthSourceStatus,
+} from '../depthTypes'
+import type { HeatmapController, HeatmapControllerConfig } from '../../components/orderBookHeatmap'
+
+// ---------------------------------------------------------------------------
+// Fake DepthSource — controllable callbacks
+// ---------------------------------------------------------------------------
+function createFakeSource(): DepthSource & {
+  triggerDelta: (deltas: ReadonlyArray<DepthDelta>) => void
+  triggerSnapshot: (snap: DepthSnapshot) => void
+  triggerError: (err: Error) => void
+  triggerStatus: (s: DepthSourceStatus) => void
+} {
+  const deltaCbs: Array<(d: ReadonlyArray<DepthDelta>) => void> = []
+  const snapshotCbs: Array<(s: DepthSnapshot) => void> = []
+  const errorCbs: Array<(e: Error) => void> = []
+  const statusCbs: Array<(s: DepthSourceStatus) => void> = []
+
+  return {
+    exchange: 'test',
+    symbol: 'test-symbol',
+    onDelta: (cb) => {
+      deltaCbs.push(cb)
+      return () => {
+        const idx = deltaCbs.indexOf(cb)
+        if (idx >= 0) deltaCbs.splice(idx, 1)
+      }
+    },
+    onSnapshot: (cb) => {
+      snapshotCbs.push(cb)
+      return () => {
+        const idx = snapshotCbs.indexOf(cb)
+        if (idx >= 0) snapshotCbs.splice(idx, 1)
+      }
+    },
+    onError: (cb) => {
+      errorCbs.push(cb)
+      return () => {
+        const idx = errorCbs.indexOf(cb)
+        if (idx >= 0) errorCbs.splice(idx, 1)
+      }
+    },
+    onStatus: (cb) => {
+      statusCbs.push(cb)
+      return () => {
+        const idx = statusCbs.indexOf(cb)
+        if (idx >= 0) statusCbs.splice(idx, 1)
+      }
+    },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    destroy: vi.fn(),
+    triggerDelta: (deltas) => {
+      for (const cb of deltaCbs) cb(deltas)
+    },
+    triggerSnapshot: (snap) => {
+      for (const cb of snapshotCbs) cb(snap)
+    },
+    triggerError: (err) => {
+      for (const cb of errorCbs) cb(err)
+    },
+    triggerStatus: (s) => {
+      for (const cb of statusCbs) cb(s)
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake HeatmapController
+// ---------------------------------------------------------------------------
+function createFakeController(): HeatmapController & { calls: { ingest: DepthDelta[]; resetBook: DepthSnapshot[] } } {
+  const calls: { ingest: DepthDelta[]; resetBook: DepthSnapshot[] } = {
+    ingest: [],
+    resetBook: [],
+  }
+  return {
+    state: null as never,
+    ingest: (d: DepthDelta) => calls.ingest.push(d),
+    ingestDelta: () => {},
+    forceSnapshot: () => {},
+    replay: () => [],
+    resetBook: (s: DepthSnapshot) => calls.resetBook.push(s),
+    setConfig: () => {},
+    dispose: vi.fn(),
+    calls,
+  }
+}
+
+describe('DepthConnector', () => {
+  let source: ReturnType<typeof createFakeSource>
+  let connector: DepthConnector
+
+  beforeEach(() => {
+    source = createFakeSource()
+    connector = new DepthConnector(source)
+  })
+
+  describe('start / stop', () => {
+    it('start() subscribes to source events and calls source.connect()', () => {
+      connector.start()
+      expect(source.connect).toHaveBeenCalledOnce()
+    })
+
+    it('start() is idempotent — second call does nothing', () => {
+      connector.start()
+      connector.start()
+      expect(source.connect).toHaveBeenCalledOnce()
+    })
+
+    it('stop() unsubscribes and calls source.disconnect()', () => {
+      connector.start()
+      connector.stop()
+      expect(source.disconnect).toHaveBeenCalledOnce()
+    })
+
+    it('stop() is idempotent', () => {
+      connector.stop()
+      connector.stop()
+      expect(source.disconnect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('delta forwarding', () => {
+    it('forwards deltas from source to controller.ingest()', () => {
+      const ctrl = createFakeController()
+      connector.addController(ctrl)
+      connector.start()
+
+      const d1: DepthDelta = { side: 'bid', price: 100, size: 5, timestamp: 1000 }
+      const d2: DepthDelta = { side: 'ask', price: 101, size: 3, timestamp: 1000 }
+      source.triggerDelta([d1, d2])
+
+      expect(ctrl.calls.ingest).toEqual([d1, d2])
+      connector.destroy()
+    })
+
+    it('forwards deltas to all controllers', () => {
+      const ctrl1 = createFakeController()
+      const ctrl2 = createFakeController()
+      connector.addController(ctrl1)
+      connector.addController(ctrl2)
+      connector.start()
+
+      const d: DepthDelta = { side: 'bid', price: 100, size: 1, timestamp: 1 }
+      source.triggerDelta([d])
+
+      expect(ctrl1.calls.ingest).toEqual([d])
+      expect(ctrl2.calls.ingest).toEqual([d])
+      connector.destroy()
+    })
+
+    it('removed controller stops receiving deltas', () => {
+      const ctrl1 = createFakeController()
+      const ctrl2 = createFakeController()
+      connector.addController(ctrl1)
+      connector.addController(ctrl2)
+      connector.start()
+
+      const d1: DepthDelta = { side: 'bid', price: 100, size: 1, timestamp: 1 }
+      source.triggerDelta([d1])
+      expect(ctrl1.calls.ingest).toHaveLength(1)
+
+      connector.removeController(ctrl1)
+      const d2: DepthDelta = { side: 'ask', price: 101, size: 1, timestamp: 2 }
+      source.triggerDelta([d2])
+      expect(ctrl1.calls.ingest).toHaveLength(1)
+      expect(ctrl2.calls.ingest).toHaveLength(2)
+      connector.destroy()
+    })
+  })
+
+  describe('snapshot forwarding', () => {
+    it('forwards snapshot from source to controller.resetBook()', () => {
+      const ctrl = createFakeController()
+      connector.addController(ctrl)
+      connector.start()
+
+      const snap: DepthSnapshot = { bids: [[100, 5]], asks: [[101, 3]], timestamp: 5000 }
+      source.triggerSnapshot(snap)
+
+      expect(ctrl.calls.resetBook).toEqual([snap])
+      connector.destroy()
+    })
+
+    it('forwards snapshot to all controllers', () => {
+      const ctrl1 = createFakeController()
+      const ctrl2 = createFakeController()
+      connector.addController(ctrl1)
+      connector.addController(ctrl2)
+      connector.start()
+
+      const snap: DepthSnapshot = { bids: [[100, 5]], asks: [], timestamp: 1 }
+      source.triggerSnapshot(snap)
+
+      expect(ctrl1.calls.resetBook).toHaveLength(1)
+      expect(ctrl2.calls.resetBook).toHaveLength(1)
+      connector.destroy()
+    })
+  })
+
+  describe('error handling', () => {
+    it('catches source errors without throwing (logs to console)', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      connector.start()
+      source.triggerError(new Error('test error'))
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[DepthConnector] test test-symbol:'),
+        expect.stringContaining('test error'),
+      )
+      consoleSpy.mockRestore()
+      connector.destroy()
+    })
+  })
+
+  describe('destroy', () => {
+    it('destroy() stops connector and disposes all controllers and source', () => {
+      const ctrl1 = createFakeController()
+      const ctrl2 = createFakeController()
+      connector.addController(ctrl1)
+      connector.addController(ctrl2)
+      connector.start()
+
+      connector.destroy()
+
+      expect(source.disconnect).toHaveBeenCalled()
+      expect(ctrl1.dispose).toHaveBeenCalledOnce()
+      expect(ctrl2.dispose).toHaveBeenCalledOnce()
+      expect(source.destroy).toHaveBeenCalledOnce()
+      expect(connector.getControllerCount()).toBe(0)
+    })
+  })
+
+  describe('addController before start', () => {
+    it('controllers added before start still receive events', () => {
+      const ctrl = createFakeController()
+      connector.addController(ctrl)
+      connector.start()
+
+      source.triggerDelta([{ side: 'bid', price: 100, size: 1, timestamp: 1 }])
+      expect(ctrl.calls.ingest).toHaveLength(1)
+      connector.destroy()
+    })
+  })
+
+  describe('getControllerCount', () => {
+    it('reports correct controller count', () => {
+      expect(connector.getControllerCount()).toBe(0)
+      connector.addController(createFakeController())
+      expect(connector.getControllerCount()).toBe(1)
+      connector.addController(createFakeController())
+      expect(connector.getControllerCount()).toBe(2)
+      connector.destroy()
+      expect(connector.getControllerCount()).toBe(0)
+    })
+  })
+})

--- a/packages/core/src/data-fetchers/binance.ts
+++ b/packages/core/src/data-fetchers/binance.ts
@@ -1,0 +1,127 @@
+import { KLineChartError } from '../errors'
+import type { DepthDelta, DepthSnapshot, DepthSource, DepthSourceStatus } from './depthTypes'
+
+export const DEFAULT_BINANCE_SSE_URL = 'http://localhost:8081/api/biance/depth-events'
+
+/**
+ * SSE-based depth source for Binance.
+ *
+ * Connects to the Go backend's SSE endpoint, which internally proxies
+ * Binance's WebSocket `depthUpdate` stream and pushes deltas as SSE events.
+ *
+ * EventSource natively handles reconnection — no manual reconnect logic needed.
+ */
+export class BinanceSSESource implements DepthSource {
+  readonly exchange = 'binance'
+
+  private es: EventSource | null = null
+  private deltaCbs = new Set<(deltas: ReadonlyArray<DepthDelta>) => void>()
+  private snapshotCbs = new Set<(snapshot: DepthSnapshot) => void>()
+  private statusCbs = new Set<(status: DepthSourceStatus) => void>()
+  private errorCbs = new Set<(err: Error) => void>()
+  private destroyed = false
+
+  constructor(
+    readonly symbol: string,
+    private readonly baseUrl: string = DEFAULT_BINANCE_SSE_URL,
+    private readonly esFactory?: (url: string) => EventSource,
+  ) {}
+
+  private get url(): string {
+    return `${this.baseUrl}?symbol=${this.symbol}`
+  }
+
+  onDelta(cb: (deltas: ReadonlyArray<DepthDelta>) => void): () => void {
+    this.deltaCbs.add(cb)
+    return () => this.deltaCbs.delete(cb)
+  }
+
+  onSnapshot(cb: (snapshot: DepthSnapshot) => void): () => void {
+    this.snapshotCbs.add(cb)
+    return () => this.snapshotCbs.delete(cb)
+  }
+
+  onStatus(cb: (status: DepthSourceStatus) => void): () => void {
+    this.statusCbs.add(cb)
+    return () => this.statusCbs.delete(cb)
+  }
+
+  onError(cb: (err: Error) => void): () => void {
+    this.errorCbs.add(cb)
+    return () => this.errorCbs.delete(cb)
+  }
+
+  connect(): void {
+    if (this.destroyed) return
+    this.disconnect()
+    this.emitStatus('connecting')
+
+    const factory = this.esFactory ?? ((url: string) => new EventSource(url))
+    this.es = factory(this.url)
+
+    this.es.onopen = () => {
+      if (this.destroyed) return
+      this.emitStatus('connected')
+    }
+
+    this.es.onerror = () => {
+      if (this.destroyed) return
+      this.emitStatus('disconnected')
+      // EventSource auto-reconnects — no explicit reconnect needed
+    }
+
+    this.es.onmessage = (event: MessageEvent) => {
+      if (this.destroyed) return
+      const raw = event.data as string
+      if (raw === '' || raw.startsWith(':')) return  // keepalive
+
+      try {
+        const msg = JSON.parse(raw) as {
+          type: string
+          bids?: ReadonlyArray<readonly [number, number]>
+          asks?: ReadonlyArray<readonly [number, number]>
+          entries?: ReadonlyArray<DepthDelta>
+          timestamp?: number
+        }
+
+        if (msg.type === 'snapshot' && msg.bids && msg.asks && msg.timestamp !== undefined) {
+          const snapshot: DepthSnapshot = {
+            bids: msg.bids,
+            asks: msg.asks,
+            timestamp: msg.timestamp,
+          }
+          for (const cb of this.snapshotCbs) cb(snapshot)
+        } else if (msg.type === 'delta' && Array.isArray(msg.entries)) {
+          for (const cb of this.deltaCbs) cb(msg.entries)
+        }
+      } catch (e) {
+        const err =
+          e instanceof KLineChartError
+            ? e
+            : new KLineChartError('DEPTH_SOURCE_ERROR', `BinanceSSE parse error: ${(e as Error).message}`)
+        for (const cb of this.errorCbs) cb(err)
+      }
+    }
+  }
+
+  disconnect(): void {
+    if (this.es) {
+      this.es.close()
+      this.es = null
+      this.emitStatus('disconnected')
+    }
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    this.disconnect()
+    this.deltaCbs.clear()
+    this.snapshotCbs.clear()
+    this.statusCbs.clear()
+    this.errorCbs.clear()
+  }
+
+  private emitStatus(status: DepthSourceStatus): void {
+    for (const cb of this.statusCbs) cb(status)
+  }
+}

--- a/packages/core/src/data-fetchers/depthConnector.ts
+++ b/packages/core/src/data-fetchers/depthConnector.ts
@@ -1,0 +1,103 @@
+/**
+ * DepthConnector — bridges a DepthSource (data-fetcher layer) to one or
+ * more HeatmapControllers (component layer).
+ *
+ * Usage:
+ * ```ts
+ * const source = new BinanceSSESource('btcusdt')
+ * const controller = createHeatmapController({ tickSize: 0.01 })
+ * const connector = new DepthConnector(source)
+ * connector.addController(controller)
+ * connector.start()
+ * ```
+ */
+
+import type { DepthSource, DepthDelta, DepthSnapshot } from './depthTypes'
+import type { HeatmapController, HeatmapControllerConfig } from '../components/orderBookHeatmap'
+
+export interface DepthConnectorOptions {
+  /** Initial config passed to each controller created by addController */
+  defaultConfig?: Partial<HeatmapControllerConfig>
+}
+
+/**
+ * Wires a real-time DepthSource to HeatmapController instances.
+ *
+ * Multiple controllers can be attached to the same source so a single
+ * Binance stream can feed e.g. both a heatmap and a footprint component.
+ */
+export class DepthConnector {
+  private controllers = new Set<HeatmapController>()
+  private unsubDelta: (() => void) | null = null
+  private unsubSnapshot: (() => void) | null = null
+  private unsubError: (() => void) | null = null
+  private started = false
+
+  constructor(
+    private readonly source: DepthSource,
+    private readonly options?: DepthConnectorOptions,
+  ) {}
+
+  /**
+   * Add a controller to receive deltas from the source.
+   * Safe to call before or after start() — already-started sources
+   * will begin feeding immediately.
+   */
+  addController(controller: HeatmapController): void {
+    this.controllers.add(controller)
+  }
+
+  removeController(controller: HeatmapController): void {
+    this.controllers.delete(controller)
+  }
+
+  getControllerCount(): number {
+    return this.controllers.size
+  }
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+
+    this.unsubDelta = this.source.onDelta((deltas: ReadonlyArray<DepthDelta>) => {
+      for (const delta of deltas) {
+        for (const ctrl of this.controllers) {
+          ctrl.ingest(delta)
+        }
+      }
+    })
+
+    this.unsubSnapshot = this.source.onSnapshot((snapshot: DepthSnapshot) => {
+      for (const ctrl of this.controllers) {
+        ctrl.resetBook(snapshot)
+      }
+    })
+
+    this.unsubError = this.source.onError((err: Error) => {
+      console.error(`[DepthConnector] ${this.source.exchange} ${this.source.symbol}:`, err.message)
+    })
+
+    this.source.connect()
+  }
+
+  stop(): void {
+    if (!this.started) return
+    this.started = false
+    this.source.disconnect()
+    this.unsubDelta?.()
+    this.unsubDelta = null
+    this.unsubSnapshot?.()
+    this.unsubSnapshot = null
+    this.unsubError?.()
+    this.unsubError = null
+  }
+
+  destroy(): void {
+    this.stop()
+    for (const ctrl of this.controllers) {
+      ctrl.dispose()
+    }
+    this.controllers.clear()
+    this.source.destroy()
+  }
+}

--- a/packages/core/src/data-fetchers/depthTypes.ts
+++ b/packages/core/src/data-fetchers/depthTypes.ts
@@ -1,0 +1,69 @@
+/**
+ * Depth/L2 data source interfaces.
+ *
+ * These types are data-fetcher-level abstractions — independent of any
+ * specific exchange or rendering component. The connector layer
+ * (depthConnector.ts) maps these into e.g. OrderBookHeatmap's types.
+ */
+
+// ---------------------------------------------------------------------------
+// Delta — one exchange-pushed depth update
+// ---------------------------------------------------------------------------
+
+/**
+ * A single price-level change in the L2 order book.
+ * `size === 0` means the price level was removed.
+ */
+export interface DepthDelta {
+  side: 'bid' | 'ask'
+  price: number
+  size: number
+  /** Exchange wall-clock ms — used as the data source's clock */
+  timestamp: number
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot — full book at one instant
+// ---------------------------------------------------------------------------
+
+/**
+ * Immutable point-in-time view of the order book.
+ * Bids sorted descending (best first), asks ascending (best first).
+ */
+export interface DepthSnapshot {
+  readonly bids: ReadonlyArray<readonly [number, number]>
+  readonly asks: ReadonlyArray<readonly [number, number]>
+  readonly timestamp: number
+}
+
+// ---------------------------------------------------------------------------
+// Source — abstraction over any real-time depth provider
+// ---------------------------------------------------------------------------
+
+export type DepthSourceStatus = 'connecting' | 'connected' | 'disconnected'
+
+/**
+ * Real-time depth data source (SSE, WS, polling — whatever).
+ * Every exchange adapter implements this interface so the connector
+ * layer is exchange-agnostic.
+ */
+export interface DepthSource {
+  readonly exchange: string
+  readonly symbol: string
+
+  /** Register a delta callback. Returns unsubscribe. */
+  onDelta(cb: (deltas: ReadonlyArray<DepthDelta>) => void): () => void
+  /** Register a snapshot callback (full book replace). Returns unsubscribe. */
+  onSnapshot(cb: (snapshot: DepthSnapshot) => void): () => void
+  /** Register a status callback. Returns unsubscribe. */
+  onStatus(cb: (status: DepthSourceStatus) => void): () => void
+  /** Register an error callback. Returns unsubscribe. */
+  onError(cb: (err: Error) => void): () => void
+
+  /** Start the connection. Safe to call multiple times. */
+  connect(): void
+  /** Stop the connection. Safe to call multiple times. */
+  disconnect(): void
+  /** Tear down permanently — no reconnects. */
+  destroy(): void
+}

--- a/packages/core/src/data-fetchers/index.ts
+++ b/packages/core/src/data-fetchers/index.ts
@@ -19,5 +19,8 @@ export {
   KLineFetchService,
   TimeShareFetchService,
 } from './dataBuffer.effects'
+export { BinanceSSESource, DEFAULT_BINANCE_SSE_URL } from './binance'
+export { DepthConnector } from './depthConnector'
+export type { DepthSource, DepthDelta, DepthSnapshot, DepthSourceStatus } from './depthTypes'
 import './gotdx'
 import './tradingview'

--- a/packages/core/src/errors-help.ts
+++ b/packages/core/src/errors-help.ts
@@ -100,6 +100,8 @@ const HINTS: Readonly<Record<KLineChartErrorCode, string>> = {
   // Data-fetcher
   FETCH_FAILED:
     'A remote data-fetch failed. Check network connectivity, API endpoint, and authentication tokens. If using baostock/tradingview provider, verify the symbol and period are valid.',
+  DEPTH_SOURCE_ERROR:
+    'The depth/SSE data source encountered an error. Verify the Go backend SSE endpoint is reachable and the symbol is valid. EventSource will auto-reconnect.',
 
   // Serialization
   SCHEMA_VERSION_MISMATCH:

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -64,6 +64,8 @@ export type KLineChartErrorCode =
   | 'CONTROLLER_CONFIG_INVALID'
   // data-fetcher (gotdx / baostock / tradingview)
   | 'FETCH_FAILED'
+  // depth/SSE source
+  | 'DEPTH_SOURCE_ERROR'
   // serialization
   | 'SCHEMA_VERSION_MISMATCH'
   | 'INVALID_JSON'

--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -55,8 +55,31 @@
             <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
           </svg>
         </button>
+        <button
+          :class="{ 'is-active': useDepthDemo }"
+          @click="onToggleDepthDemo"
+          title="Toggle Depth Pipeline (Binance SSE → HeatmapController)"
+        >
+          <svg
+            class="debug-icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="2" y="10" width="4" height="10" rx="1" />
+            <rect x="10" y="4" width="4" height="16" rx="1" />
+            <rect x="18" y="7" width="4" height="13" rx="1" />
+          </svg>
+        </button>
       </div>
       <div class="debug-right">
+        <span v-if="useDepthDemo" class="depth-status-badge" :class="depthStatusClass">{{
+          depthStatusText
+        }}</span>
         <span class="version-badge">{{ displayVersion }}</span>
         <a
           class="debug-link"
@@ -131,7 +154,13 @@
   import { ref, computed, provide, inject, type Ref, type InjectionKey } from 'vue'
   import KLineChart from '../src/components/KLineChart.vue'
   import { VERSION, CORE_VERSION } from '../src/version'
-  import { type KLineData, type CustomDataSource } from '@363045841yyt/klinechart-core/controllers'
+  import {
+    type KLineData,
+    type CustomDataSource,
+    BinanceSSESource,
+    DepthConnector,
+    createHeatmapController,
+  } from '@363045841yyt/klinechart-core/controllers'
   import { executeTool } from '@363045841yyt/klinechart-ai-runtime'
 
   /** 硬编码演示数据：主品种 CUSTOM.DEMO（15 根日 K） */
@@ -628,6 +657,41 @@
       customData.value = undefined
     }
   }
+
+  // ── 深度行情 Pipeline Demo ──
+  const useDepthDemo = ref(false)
+  const depthStatusText = ref('')
+  const depthStatusClass = ref('')
+  let depthConnector: DepthConnector | null = null
+  let depthController: ReturnType<typeof createHeatmapController> | null = null
+  let depthUnsubState: (() => void) | null = null
+
+  function onToggleDepthDemo() {
+    useDepthDemo.value = !useDepthDemo.value
+    if (useDepthDemo.value) {
+      const source = new BinanceSSESource('btcusdt')
+      depthController = createHeatmapController({ tickSize: 0.01 })
+      depthConnector = new DepthConnector(source)
+      depthConnector.addController(depthController)
+      depthUnsubState = depthController.state.on((s) => {
+        if (s.latestSnapshot) {
+          depthStatusText.value = `depth: ${s.snapshotCount} snapshots · ${s.deltaCount} deltas`
+          depthStatusClass.value = 'depth-connected'
+        } else {
+          depthStatusText.value = 'depth: awaiting data...'
+          depthStatusClass.value = 'depth-awaiting'
+        }
+      })
+      depthConnector.start()
+    } else {
+      depthUnsubState?.()
+      depthUnsubState = null
+      depthConnector?.destroy()
+      depthConnector = null
+      depthController = null
+      depthStatusText.value = ''
+    }
+  }
 </script>
 
 <style>
@@ -686,6 +750,27 @@
     font-family: monospace;
   }
 
+  .depth-status-badge {
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-family: monospace;
+    white-space: nowrap;
+    border: 1px solid;
+  }
+
+  .depth-status-badge.depth-awaiting {
+    background: #fffbe6;
+    border-color: #ffe58f;
+    color: #ad8b00;
+  }
+
+  .depth-status-badge.depth-connected {
+    background: #f6ffed;
+    border-color: #b7eb8f;
+    color: #389e0d;
+  }
+
   .debug-controls button {
     width: 32px;
     height: 32px;
@@ -700,6 +785,12 @@
   }
 
   .debug-controls button:hover {
+    border-color: #1890ff;
+    color: #1890ff;
+  }
+
+  .debug-controls button.is-active {
+    background: #e6f7ff;
     border-color: #1890ff;
     color: #1890ff;
   }
@@ -872,6 +963,12 @@
     color: #60a5fa;
   }
 
+  .app-container[data-theme='dark'] .debug-controls button.is-active {
+    background: #1e3a5f;
+    border-color: #60a5fa;
+    color: #60a5fa;
+  }
+
   .app-container[data-theme='dark'] .version-badge {
     color: #9ca3af;
   }
@@ -879,6 +976,18 @@
   .app-container[data-theme='dark'] .version-badge {
     background: #374151;
     border-color: #4b5563;
+  }
+
+  .app-container[data-theme='dark'] .depth-status-badge.depth-awaiting {
+    background: #2b1d0b;
+    border-color: #5c3a0e;
+    color: #e8b839;
+  }
+
+  .app-container[data-theme='dark'] .depth-status-badge.depth-connected {
+    background: #0b2b1a;
+    border-color: #0e5c2e;
+    color: #52c41a;
   }
 
   .app-container[data-theme='dark'] .embed-container {


### PR DESCRIPTION
## Summary

Introduces a production-grade real-time depth data pipeline: **SSE data source ? exchange-agnostic connector ? HeatmapController**. The pipeline is designed for Binance (via a Go SSE proxy) but is fully exchange-agnostic through the DepthSource interface.

## Changes

### Depth Pipeline (new)

- **BinanceSSESource** (packages/core/src/data-fetchers/binance.ts): SSE-based depth source that wraps the native EventSource API. Connects to the Go backend's SSE endpoint, parses snapshot/delta/keepalive events, and dispatches via typed callbacks. Built-in reconnection via EventSource semantics.

- **DepthConnector** (packages/core/src/data-fetchers/depthConnector.ts): Bridge layer that subscribes to a DepthSource and fans out deltas/snapshots to one or more HeatmapController instances. Supports ddController/emoveController at any point in the lifecycle.

- **DepthSource interface** (packages/core/src/data-fetchers/depthTypes.ts): Exchange-agnostic abstraction (onDelta, onSnapshot, onStatus, onError, connect, disconnect, destroy) ? any exchange adapter can implement it without coupling to rendering components.

- **DEPTH_SOURCE_ERROR** error code and hint in errors.ts / errors-help.ts.

### HeatmapController Changes

- **esetBook(snapshot)** ? replaces the internal order book with a full snapshot, clears the snapshot ring, delta archive, and resets the snapshot clock. Designed for SSE reconnect where the Go backend pushes a 	ype:"snapshot" event on connection, avoiding race conditions between REST snapshot and SSE stream.

- **eplay() boundary fix** ? changed <= to < in timestamp comparison for delta application, ensuring a delta at exactly the snapshot boundary timestamp is not double-counted.

### Public API Exports

BinanceSSESource, DEFAULT_BINANCE_SSE_URL, DepthConnector, and depth types are now re-exported from packages/core/src/controllers/index.ts.

### Demo / Preview

Vue preview (packages/vue/preview/App.vue) gains a toggle button to start/stop the depth pipeline with a live status badge showing snapshot/delta counts.

## Files Changed

| File | Change |
|------|--------|
| packages/core/src/data-fetchers/binance.ts | **new** ? Binance SSE source |
| packages/core/src/data-fetchers/depthConnector.ts | **new** ? bridge layer |
| packages/core/src/data-fetchers/depthTypes.ts | **new** ? depth source types |
| packages/core/src/data-fetchers/index.ts | export new modules & types |
| packages/core/src/data-fetchers/__tests__/binance.test.ts | **new** ? unit tests |
| packages/core/src/data-fetchers/__tests__/depthConnector.test.ts | **new** ? unit tests |
| packages/core/src/components/orderBookHeatmap/types.ts | add esetBook() to interface |
| packages/core/src/components/orderBookHeatmap/createHeatmapController.ts | implement esetBook(), fix replay boundary |
| packages/core/src/components/orderBookHeatmap/__tests__/controller.test.ts | add resetBook tests, fix boundary tests |
| packages/core/src/__tests__/depthPipeline.test.ts | **new** ? full pipeline integration test |
| packages/core/src/errors.ts | add DEPTH_SOURCE_ERROR code |
| packages/core/src/errors-help.ts | add hint for DEPTH_SOURCE_ERROR |
| packages/core/src/controllers/index.ts | re-export depth exports |
| packages/vue/preview/App.vue | add depth demo toggle + status badge |
