### PR TITLE
feat: migrate renderers to bridge-based Scene/WebGL pipeline

### DIFF
--- a/packages/core/src/engine/__tests__/subPaneManager.test.ts
+++ b/packages/core/src/engine/__tests__/subPaneManager.test.ts
@@ -33,6 +33,7 @@ function createMockContext(): SubPaneContext {
     getRenderer: vi.fn(),
     useRenderer: vi.fn(),
     removeRenderer: vi.fn(),
+    setRendererEnabled: vi.fn(),
     removePaneDefinition: vi.fn(),
     updateRendererConfig: vi.fn(),
     getRightAxisWidth: vi.fn(() => 60),
@@ -41,6 +42,11 @@ function createMockContext(): SubPaneContext {
     getCrosshairPos: vi.fn(() => null),
     getCrosshairPrice: vi.fn(() => null),
     getActivePaneId: vi.fn(() => null),
+    addLayer: vi.fn(),
+    removeLayer: vi.fn(() => true),
+    getLayer: vi.fn(() => null),
+    setLayerVisibility: vi.fn(),
+    getRenderContext: vi.fn(() => null),
   }
 }
 

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -50,6 +50,7 @@ import {
 } from '../alerts/rollingVolume'
 import { resolveStateKey } from './indicators/indicatorMetadata'
 import type { IndicatorMetadata } from './indicators/indicatorMetadata'
+import type { Layer } from '../scene/types'
 
 // 重新导出以保持向后兼容
 export { getPhysicalKLineConfig }
@@ -326,6 +327,13 @@ export class Chart {
       setPendingIndicatorDataUpdate: (v) => {
         this.dataManager.pendingIndicatorDataUpdate = v
       },
+      getRenderContext: (paneId) =>
+        this.renderer?.getPaneCtxMap()?.get(paneId) ?? null,
+      addLayer: (layer) => this.renderer?.getScene()?.addLayer(layer),
+      removeLayer: (id) => this.renderer?.getScene()?.removeLayer(id) ?? false,
+      getLayer: (id) => this.renderer?.getScene()?.getLayer(id) ?? null,
+      setLayerVisibility: (id, visible) =>
+        this.renderer?.getScene()?.setLayerVisibility(id, visible),
     })
 
     // Worker 异步结果就绪后串联 Alert 管线

--- a/packages/core/src/engine/indicators/__tests__/chartIndicatorManager.test.ts
+++ b/packages/core/src/engine/indicators/__tests__/chartIndicatorManager.test.ts
@@ -55,6 +55,11 @@ function createMockDeps() {
     getActivePaneId: vi.fn(() => null),
     scheduleDraw: vi.fn(),
     setPendingIndicatorDataUpdate: vi.fn(),
+    getRenderContext: vi.fn(() => null),
+    addLayer: vi.fn(),
+    removeLayer: vi.fn(() => false),
+    getLayer: vi.fn(() => null),
+    setLayerVisibility: vi.fn(),
   } as IndicatorDependencies & { rendererMap: Map<string, any> }
 }
 

--- a/packages/core/src/engine/indicators/chartIndicatorManager.ts
+++ b/packages/core/src/engine/indicators/chartIndicatorManager.ts
@@ -9,7 +9,9 @@ import { getRegisteredIndicatorDefinitions } from './indicatorDefinitionRegistry
 import { SubPaneManager, type SubPaneEntry, type SubPaneContext } from '../subPaneManager'
 import { createSubIndicatorRenderer, type SubIndicatorType } from '../renderers/Indicator'
 import { createMainIndicatorLegendRendererPlugin } from '../renderers/Indicator/mainIndicatorLegend'
-import type { PluginHostImpl, RendererPlugin, RendererPluginWithHost } from '../../plugin'
+import type { PluginHostImpl, RendererPlugin, RendererPluginWithHost, RenderContext } from '../../plugin'
+import type { Layer } from '../../scene/types'
+import { createLayerFromPlugin } from '../../scene/createLayerFromPlugin'
 
 type ResolvedChartOptions = Omit<ChartOptions, 'kWidth' | 'kGap'> & {
   kWidth: number
@@ -47,6 +49,11 @@ export interface IndicatorDependencies {
   getActivePaneId: () => string | null
   scheduleDraw: (level?: UpdateLevel) => void
   setPendingIndicatorDataUpdate: (v: boolean) => void
+  getRenderContext: (paneId: string) => RenderContext | null
+  addLayer: (layer: Layer) => void
+  removeLayer: (id: string) => boolean
+  getLayer: (id: string) => Layer | null
+  setLayerVisibility: (id: string, visible: boolean) => void
 }
 
 export class ChartIndicatorManager {
@@ -200,6 +207,7 @@ export class ChartIndicatorManager {
         deps.getRenderer<T>(name),
       useRenderer: (plugin, config) => deps.useRenderer(plugin, config),
       removeRenderer: (name) => deps.removeRenderer(name),
+      setRendererEnabled: (name, enabled) => deps.setRendererEnabled(name, enabled),
       removePaneDefinition: (paneId) => deps.removePaneDefinition(paneId),
       updateRendererConfig: (name, config) => deps.updateRendererConfig(name, config),
       getRightAxisWidth: () => deps.getOption().rightAxisWidth,
@@ -208,6 +216,11 @@ export class ChartIndicatorManager {
       getCrosshairPos: () => deps.getCrosshairPos(),
       getCrosshairPrice: () => deps.getCrosshairPrice(),
       getActivePaneId: () => deps.getActivePaneId(),
+      addLayer: (layer) => deps.addLayer(layer),
+      removeLayer: (id) => deps.removeLayer(id),
+      getLayer: (id) => deps.getLayer(id),
+      setLayerVisibility: (id, visible) => deps.setLayerVisibility(id, visible),
+      getRenderContext: (paneId) => deps.getRenderContext(paneId),
     }
   }
 
@@ -327,16 +340,39 @@ export class ChartIndicatorManager {
     const mainPane = definition?.mainPane
     if (!definition || !mainPane) return
 
-    if (!this.deps.getRenderer(mainPane.rendererName)) {
-      this.deps.useRenderer(definition.rendererFactory({ paneId: 'main', indicatorId }))
+    const rendererName = mainPane.rendererName
+    const layerId = `plugin:${rendererName}`
+    const existingLayer = this.deps.getLayer(layerId)
+
+    if (!existingLayer) {
+      const plugin = definition.rendererFactory({ paneId: 'main', indicatorId })
+      // register with old system for getRenderer compatibility
+      this.deps.useRenderer(plugin)
+      // disable old rendering to avoid double rendering (scene handles it)
+      this.deps.setRendererEnabled(rendererName, false)
+      // create bridge layer and add to scene
+      const layer = createLayerFromPlugin(
+        plugin,
+        () => this.deps.getRenderContext('main'),
+        'main',
+      )
+      this.deps.addLayer(layer)
     }
 
-    this.deps.setRendererEnabled(mainPane.rendererName, true)
+    this.deps.setLayerVisibility(layerId, true)
 
     if (!this.deps.getRenderer('mainIndicatorLegend')) {
-      this.deps.useRenderer(
-        createMainIndicatorLegendRendererPlugin({ yPaddingPx: this.deps.getOption().yPaddingPx }),
+      const legend = createMainIndicatorLegendRendererPlugin({
+        yPaddingPx: this.deps.getOption().yPaddingPx,
+      })
+      this.deps.useRenderer(legend)
+      this.deps.setRendererEnabled('mainIndicatorLegend', false)
+      const legendLayer = createLayerFromPlugin(
+        legend,
+        () => this.deps.getRenderContext('main'),
+        'main',
       )
+      this.deps.addLayer(legendLayer)
     }
   }
 
@@ -345,6 +381,7 @@ export class ChartIndicatorManager {
       this.indicatorScheduler.getIndicatorMetadata(indicatorId)?.mainPane?.rendererName
     if (rendererName) {
       this.deps.setRendererEnabled(rendererName, false)
+      this.deps.setLayerVisibility(`plugin:${rendererName}`, false)
     }
   }
 
@@ -407,6 +444,13 @@ export class ChartIndicatorManager {
     }
 
     this.deps.useRenderer(renderer, params)
+    this.deps.setRendererEnabled(rendererName, false)
+    const layer = createLayerFromPlugin(
+      renderer,
+      () => this.deps.getRenderContext(paneId),
+      paneId,
+    )
+    this.deps.addLayer(layer)
   }
 
   createSubPane(

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -54,6 +54,7 @@ import type { Scene, PaintContext, PaneRole } from '../../scene/types'
 import type { Renderer } from '../../render/Renderer'
 import { createScene } from '../../scene/createScene'
 import { createLayerFromPlugin } from '../../scene/createLayerFromPlugin'
+import { createWebGLRenderer, createWebGLSurfaceBackend } from '../../render'
 
 type ResolvedChartOptions = Omit<ChartOptions, 'kWidth' | 'kGap'> & {
   kWidth: number
@@ -123,6 +124,9 @@ export class ChartRenderer {
     this.markerManager = new MarkerManager()
     this.drawingStore = new DrawingStore()
     this.scene = createScene()
+    const sharedSurface = deps.getSharedWebGLSurface()
+    const surfaceBackend = createWebGLSurfaceBackend(sharedSurface)
+    this.sceneRenderer = createWebGLRenderer(surfaceBackend, sharedSurface)
   }
 
   initCoreRenderers(): void {
@@ -691,13 +695,16 @@ export class ChartRenderer {
           pluginHost.events.emit('renderer:error', { paneId: pane.id, errors: leftAxisErrors })
         }
 
+        const region = { x: 0, y: pane.top, width: vp.plotWidth, height: pane.height, dpr: vp.dpr }
+        this.sceneRenderer.beginFrame(region)
         this.scene.paintPane({
           renderer: this.sceneRenderer,
-          region: { x: 0, y: pane.top, width: vp.plotWidth, height: pane.height, dpr: vp.dpr },
+          region,
           paneRole: (pane.id === 'main' ? 'main' : 'sub') as PaneRole,
           frameNumber: this.frameCount++,
           deltaMs: 0,
         })
+        this.sceneRenderer.endFrame()
       }
     }
 
@@ -832,6 +839,7 @@ export class ChartRenderer {
     }
     this.cachedDrawFrame = null
     this.xAxisCtx = null
+    this.sceneRenderer.dispose()
     this.scene.dispose()
     this.paneCtxMap.clear()
   }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -261,6 +261,14 @@ export class ChartRenderer {
     }
   }
 
+  getScene(): Scene {
+    return this.scene
+  }
+
+  getPaneCtxMap(): Map<string, RenderContext> {
+    return this.paneCtxMap
+  }
+
   getMarkerManager(): MarkerManager {
     return this.markerManager
   }
@@ -683,6 +691,7 @@ export class ChartRenderer {
           renderer: this.sceneRenderer,
           region,
           paneRole: (pane.id === 'main' ? 'main' : 'sub') as PaneRole,
+          paneId: pane.id,
           frameNumber: this.frameCount++,
           deltaMs: 0,
         })
@@ -696,6 +705,7 @@ export class ChartRenderer {
             renderer: this.sceneRenderer,
             region,
             paneRole: (pane.id === 'main' ? 'main' : 'sub') as PaneRole,
+            paneId: pane.id,
             frameNumber: this.frameCount++,
             deltaMs: 0,
           },

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -3,8 +3,6 @@ import type { ChartSettings } from '../../config/chartSettings'
 import type { SymbolSpec } from '../../controllers/types'
 import { getVisibleRange } from '../viewport/viewport'
 import type {
-  RendererPlugin,
-  RendererPluginWithHost,
   PluginHostImpl,
   RenderContext,
   YAxisLabel,
@@ -48,9 +46,10 @@ import { createYAxisLayer } from './layers/yAxisLayer'
 import { createLeftYAxisLayer } from './layers/leftYAxisLayer'
 import { createCrosshairLayer } from './layers/crosshairLayer'
 import { createTimeAxisRendererPlugin } from '../renderers/timeAxis'
-import type { Scene, PaintContext, PaneRole } from '../../scene/types'
+import type { Scene, PaintContext, PaneRole, Layer } from '../../scene/types'
 import type { Renderer } from '../../render/Renderer'
 import { createScene } from '../../scene/createScene'
+import { createLayerFromPlugin } from '../../scene/createLayerFromPlugin'
 import { createWebGLRenderer, createWebGLSurfaceBackend } from '../../render'
 
 type ResolvedChartOptions = Omit<ChartOptions, 'kWidth' | 'kGap'> & {
@@ -116,6 +115,8 @@ export class ChartRenderer {
   private paneCtxMap = new Map<string, RenderContext>()
   private currentPaneId = 'main'
   private sceneRenderer: Renderer = {} as Renderer
+  private timeAxisCtx: RenderContext | null = null
+  private timeAxisLayer: Layer | null = null
 
   constructor(deps: RendererDependencies) {
     this.deps = deps
@@ -144,7 +145,11 @@ export class ChartRenderer {
           return null
         },
       })
-      this.useDrawingPlugin(plugin)
+      this.timeAxisLayer = createLayerFromPlugin(
+        plugin,
+        () => this.timeAxisCtx,
+        'global',
+      )
     }
 
     const getCtx = (paneId: string) => () => this.paneCtxMap.get(paneId) ?? null
@@ -241,23 +246,21 @@ export class ChartRenderer {
   }
 
   registerDrawingPlugins(): void {
+    const getCtxForCurrentPane = () => this.paneCtxMap.get(this.currentPaneId) ?? null
+
     {
       const plugin = createDrawingRendererPlugin({ store: this.drawingStore })
-      this.useDrawingPlugin(plugin)
+      this.deps.getRendererPluginManager().register(plugin)
+      this.deps.getRendererPluginManager().setEnabled(plugin.name, false)
+      const layer = createLayerFromPlugin(plugin, getCtxForCurrentPane, 'global')
+      this.scene.addLayer(layer)
     }
     {
       const plugin = createDrawingLabelOverlayPlugin({ store: this.drawingStore })
-      this.useDrawingPlugin(plugin)
-    }
-  }
-
-  private useDrawingPlugin(
-    plugin: RendererPlugin | RendererPluginWithHost,
-    config?: Record<string, unknown>,
-  ): void {
-    this.deps.getRendererPluginManager().register(plugin)
-    if (config && plugin.setConfig) {
-      plugin.setConfig(config)
+      this.deps.getRendererPluginManager().register(plugin)
+      this.deps.getRendererPluginManager().setEnabled(plugin.name, false)
+      const layer = createLayerFromPlugin(plugin, getCtxForCurrentPane, 'global')
+      this.scene.addLayer(layer)
     }
   }
 
@@ -733,10 +736,10 @@ export class ChartRenderer {
     if (!this.xAxisCtx) {
       this.xAxisCtx = xAxisCtx
     }
-    if (xAxisCtx) {
+    if (xAxisCtx && this.timeAxisLayer) {
       const opt = this.deps.getOption()
       const dataManager = this.deps.getDataManager()
-      const timeAxisContext: RenderContext = {
+      this.timeAxisCtx = {
         ctx: xAxisCtx,
         pane: {
           id: 'xAxis',
@@ -790,10 +793,15 @@ export class ChartRenderer {
         monthKeys: dataManager.getMonthKeys() ?? undefined,
         dayKeys: dataManager.getDayKeys() ?? undefined,
       }
-      const errors = this.deps.getRendererPluginManager().renderPlugin('timeAxis', timeAxisContext)
-      if (errors.length > 0) {
-        this.deps.getPluginHost().events.emit('renderer:error', { paneId: 'timeAxis', errors })
+      const paintCtx: PaintContext = {
+        renderer: this.sceneRenderer,
+        region: { x: 0, y: 0, width: vp.plotWidth, height: opt.bottomAxisHeight, dpr: vp.dpr },
+        paneRole: 'global',
+        paneId: 'xAxis',
+        frameNumber: this.frameCount++,
+        deltaMs: 0,
       }
+      this.timeAxisLayer.paint(paintCtx)
     }
   }
 

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -14,7 +14,7 @@ import type {
   YAxisTick,
 } from '../../plugin'
 import { calculateTickCount } from '../utils/tickCount'
-import { RendererPluginManager, wrapPaneInfo, GLOBAL_PANE_ID } from '../../plugin'
+import { RendererPluginManager, wrapPaneInfo } from '../../plugin'
 import type {
   ChartDom,
   PaneSpec,
@@ -53,7 +53,6 @@ import { createTimeAxisRendererPlugin } from '../renderers/timeAxis'
 import type { Scene, PaintContext, PaneRole } from '../../scene/types'
 import type { Renderer } from '../../render/Renderer'
 import { createScene } from '../../scene/createScene'
-import { createLayerFromPlugin } from '../../scene/createLayerFromPlugin'
 import { createWebGLRenderer, createWebGLSurfaceBackend } from '../../render'
 
 type ResolvedChartOptions = Omit<ChartOptions, 'kWidth' | 'kGap'> & {
@@ -137,44 +136,36 @@ export class ChartRenderer {
     {
       const plugin = createGridLinesRendererPlugin()
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createCandleRenderer()
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createComparisonLineRenderer()
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createLastPriceLineRendererPlugin()
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createLastPriceLabelRegistrarPlugin()
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createCustomMarkersRenderer()
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createExtremaMarkersRendererPlugin()
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createMainIndicatorLegendRendererPlugin({
         yPaddingPx: opt.yPaddingPx,
       })
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createYAxisRendererPlugin({
@@ -191,7 +182,6 @@ export class ChartRenderer {
         },
       })
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createCrosshairRendererPlugin({
@@ -203,7 +193,6 @@ export class ChartRenderer {
         }),
       })
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createLeftYAxisRendererPlugin({
@@ -220,7 +209,6 @@ export class ChartRenderer {
         },
       })
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createTimeAxisRendererPlugin({
@@ -235,7 +223,6 @@ export class ChartRenderer {
         },
       })
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
   }
 
@@ -243,12 +230,10 @@ export class ChartRenderer {
     {
       const plugin = createDrawingRendererPlugin({ store: this.drawingStore })
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
     {
       const plugin = createDrawingLabelOverlayPlugin({ store: this.drawingStore })
       this.useDrawingPlugin(plugin)
-      this.addPluginLayer(plugin)
     }
   }
 
@@ -259,17 +244,6 @@ export class ChartRenderer {
     this.deps.getRendererPluginManager().register(plugin)
     if (config && plugin.setConfig) {
       plugin.setConfig(config)
-    }
-  }
-
-  private addPluginLayer(plugin: RendererPlugin): void {
-    if (plugin.isSystem) return
-    const paneIds: readonly string[] =
-      plugin.paneId === GLOBAL_PANE_ID ? ['main', 'sub'] : [plugin.paneId as string]
-    for (const pid of paneIds) {
-      this.scene.addLayer(
-        createLayerFromPlugin(plugin, () => this.paneCtxMap.get(pid) ?? null, pid),
-      )
     }
   }
 

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -14,7 +14,7 @@ import type {
   YAxisTick,
 } from '../../plugin'
 import { calculateTickCount } from '../utils/tickCount'
-import { RendererPluginManager, wrapPaneInfo } from '../../plugin'
+import { RendererPluginManager, wrapPaneInfo, GLOBAL_PANE_ID } from '../../plugin'
 import type {
   ChartDom,
   PaneSpec,
@@ -50,6 +50,10 @@ import { createYAxisRendererPlugin } from '../renderers/yAxis'
 import { createLeftYAxisRendererPlugin } from '../renderers/leftYAxis'
 import { createCrosshairRendererPlugin } from '../renderers/crosshair'
 import { createTimeAxisRendererPlugin } from '../renderers/timeAxis'
+import type { Scene, PaintContext, PaneRole } from '../../scene/types'
+import type { Renderer } from '../../render/Renderer'
+import { createScene } from '../../scene/createScene'
+import { createLayerFromPlugin } from '../../scene/createLayerFromPlugin'
 
 type ResolvedChartOptions = Omit<ChartOptions, 'kWidth' | 'kGap'> & {
   kWidth: number
@@ -109,10 +113,16 @@ export class ChartRenderer {
     kWidthPx: number
   } | null = null
 
+  private scene: Scene
+  private frameCount = 0
+  private paneCtxMap = new Map<string, RenderContext>()
+  private sceneRenderer: Renderer = {} as Renderer
+
   constructor(deps: RendererDependencies) {
     this.deps = deps
     this.markerManager = new MarkerManager()
     this.drawingStore = new DrawingStore()
+    this.scene = createScene()
   }
 
   initCoreRenderers(): void {
@@ -120,20 +130,50 @@ export class ChartRenderer {
     const axisWidth = opt.rightAxisWidth + (opt.priceLabelWidth ?? 0)
     const interaction = this.deps.getInteraction()
 
-    this.useDrawingPlugin(createGridLinesRendererPlugin())
-    this.useDrawingPlugin(createCandleRenderer())
-    this.useDrawingPlugin(createComparisonLineRenderer())
-    this.useDrawingPlugin(createLastPriceLineRendererPlugin())
-    this.useDrawingPlugin(createLastPriceLabelRegistrarPlugin())
-    this.useDrawingPlugin(createCustomMarkersRenderer())
-    this.useDrawingPlugin(createExtremaMarkersRendererPlugin())
-    this.useDrawingPlugin(
-      createMainIndicatorLegendRendererPlugin({
+    {
+      const plugin = createGridLinesRendererPlugin()
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createCandleRenderer()
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createComparisonLineRenderer()
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createLastPriceLineRendererPlugin()
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createLastPriceLabelRegistrarPlugin()
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createCustomMarkersRenderer()
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createExtremaMarkersRendererPlugin()
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createMainIndicatorLegendRendererPlugin({
         yPaddingPx: opt.yPaddingPx,
-      }),
-    )
-    this.useDrawingPlugin(
-      createYAxisRendererPlugin({
+      })
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createYAxisRendererPlugin({
         axisWidth,
         yPaddingPx: opt.yPaddingPx,
         getCrosshair: () => {
@@ -145,20 +185,24 @@ export class ChartRenderer {
           }
           return null
         },
-      }),
-    )
-    this.useDrawingPlugin(
-      createCrosshairRendererPlugin({
+      })
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createCrosshairRendererPlugin({
         getCrosshairState: () => ({
           pos: interaction.crosshairPos,
           activePaneId: interaction.activePaneId,
           isDragging: interaction.isDraggingState(),
           price: interaction.crosshairPrice,
         }),
-      }),
-    )
-    this.useDrawingPlugin(
-      createLeftYAxisRendererPlugin({
+      })
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createLeftYAxisRendererPlugin({
         axisWidth: opt.leftAxisWidth,
         yPaddingPx: opt.yPaddingPx,
         getCrosshair: () => {
@@ -170,10 +214,12 @@ export class ChartRenderer {
           }
           return null
         },
-      }),
-    )
-    this.useDrawingPlugin(
-      createTimeAxisRendererPlugin({
+      })
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createTimeAxisRendererPlugin({
         height: opt.bottomAxisHeight,
         getCrosshair: () => {
           const pos = interaction.crosshairPos
@@ -183,13 +229,23 @@ export class ChartRenderer {
           }
           return null
         },
-      }),
-    )
+      })
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
   }
 
   registerDrawingPlugins(): void {
-    this.useDrawingPlugin(createDrawingRendererPlugin({ store: this.drawingStore }))
-    this.useDrawingPlugin(createDrawingLabelOverlayPlugin({ store: this.drawingStore }))
+    {
+      const plugin = createDrawingRendererPlugin({ store: this.drawingStore })
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
+    {
+      const plugin = createDrawingLabelOverlayPlugin({ store: this.drawingStore })
+      this.useDrawingPlugin(plugin)
+      this.addPluginLayer(plugin)
+    }
   }
 
   private useDrawingPlugin(
@@ -199,6 +255,17 @@ export class ChartRenderer {
     this.deps.getRendererPluginManager().register(plugin)
     if (config && plugin.setConfig) {
       plugin.setConfig(config)
+    }
+  }
+
+  private addPluginLayer(plugin: RendererPlugin): void {
+    if (plugin.isSystem) return
+    const paneIds: readonly string[] =
+      plugin.paneId === GLOBAL_PANE_ID ? ['main', 'sub'] : [plugin.paneId as string]
+    for (const pid of paneIds) {
+      this.scene.addLayer(
+        createLayerFromPlugin(plugin, () => this.paneCtxMap.get(pid) ?? null, pid),
+      )
     }
   }
 
@@ -606,6 +673,8 @@ export class ChartRenderer {
         context.yAxisTicks = yAxisTicks
       }
 
+      this.paneCtxMap.set(pane.id, context)
+
       if (shouldUpdateMain || shouldUpdateOverlay) {
         const errors = rendererPluginManager.render(pane.id, context, level)
         if (errors.length > 0) {
@@ -621,6 +690,14 @@ export class ChartRenderer {
         if (leftAxisErrors.length > 0) {
           pluginHost.events.emit('renderer:error', { paneId: pane.id, errors: leftAxisErrors })
         }
+
+        this.scene.paintPane({
+          renderer: this.sceneRenderer,
+          region: { x: 0, y: pane.top, width: vp.plotWidth, height: pane.height, dpr: vp.dpr },
+          paneRole: (pane.id === 'main' ? 'main' : 'sub') as PaneRole,
+          frameNumber: this.frameCount++,
+          deltaMs: 0,
+        })
       }
     }
 
@@ -755,5 +832,11 @@ export class ChartRenderer {
     }
     this.cachedDrawFrame = null
     this.xAxisCtx = null
+    this.scene.dispose()
+    this.paneCtxMap.clear()
+  }
+
+  getScene(): Scene {
+    return this.scene
   }
 }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -35,20 +35,18 @@ import { UpdateLevel } from '../layout/pane'
 import type { VisibleRange } from '../layout/pane'
 import { DrawingStore } from '../drawing'
 import type { ChartModeHandler } from '../modes/types'
-import { createMainIndicatorLegendRendererPlugin } from '../renderers/Indicator/mainIndicatorLegend'
 import { createDrawingRendererPlugin, createDrawingLabelOverlayPlugin } from '../drawing/plugin'
-import { createGridLinesRendererPlugin } from '../renderers/gridLines'
-import { createCandleRenderer } from '../renderers/candle'
-import { createComparisonLineRenderer } from '../renderers/comparisonLine'
-import {
-  createLastPriceLineRendererPlugin,
-  createLastPriceLabelRegistrarPlugin,
-} from '../renderers/lastPrice'
-import { createCustomMarkersRenderer } from '../renderers/customMarkers'
-import { createExtremaMarkersRendererPlugin } from '../renderers/extremaMarkers'
-import { createYAxisRendererPlugin } from '../renderers/yAxis'
-import { createLeftYAxisRendererPlugin } from '../renderers/leftYAxis'
-import { createCrosshairRendererPlugin } from '../renderers/crosshair'
+import { createCandleLayer } from './layers/candleLayer'
+import { createComparisonLineLayer } from './layers/comparisonLineLayer'
+import { createLastPriceLineLayer } from './layers/lastPriceLineLayer'
+import { createMainIndicatorLegendLayer } from './layers/mainIndicatorLegendLayer'
+import { createGridLinesLayer } from './layers/gridLinesLayer'
+import { createLastPriceLabelLayer } from './layers/lastPriceLabelLayer'
+import { createCustomMarkersLayer } from './layers/customMarkersLayer'
+import { createExtremaMarkersLayer } from './layers/extremaMarkersLayer'
+import { createYAxisLayer } from './layers/yAxisLayer'
+import { createLeftYAxisLayer } from './layers/leftYAxisLayer'
+import { createCrosshairLayer } from './layers/crosshairLayer'
 import { createTimeAxisRendererPlugin } from '../renderers/timeAxis'
 import type { Scene, PaintContext, PaneRole } from '../../scene/types'
 import type { Renderer } from '../../render/Renderer'
@@ -116,6 +114,7 @@ export class ChartRenderer {
   private scene: Scene
   private frameCount = 0
   private paneCtxMap = new Map<string, RenderContext>()
+  private currentPaneId = 'main'
   private sceneRenderer: Renderer = {} as Renderer
 
   constructor(deps: RendererDependencies) {
@@ -134,83 +133,6 @@ export class ChartRenderer {
     const interaction = this.deps.getInteraction()
 
     {
-      const plugin = createGridLinesRendererPlugin()
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createCandleRenderer()
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createComparisonLineRenderer()
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createLastPriceLineRendererPlugin()
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createLastPriceLabelRegistrarPlugin()
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createCustomMarkersRenderer()
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createExtremaMarkersRendererPlugin()
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createMainIndicatorLegendRendererPlugin({
-        yPaddingPx: opt.yPaddingPx,
-      })
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createYAxisRendererPlugin({
-        axisWidth,
-        yPaddingPx: opt.yPaddingPx,
-        getCrosshair: () => {
-          const pos = interaction.crosshairPos
-          const price = interaction.crosshairPrice
-          const activePaneId = interaction.activePaneId
-          if (pos && price !== null) {
-            return { y: pos.y, price, activePaneId }
-          }
-          return null
-        },
-      })
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createCrosshairRendererPlugin({
-        getCrosshairState: () => ({
-          pos: interaction.crosshairPos,
-          activePaneId: interaction.activePaneId,
-          isDragging: interaction.isDraggingState(),
-          price: interaction.crosshairPrice,
-        }),
-      })
-      this.useDrawingPlugin(plugin)
-    }
-    {
-      const plugin = createLeftYAxisRendererPlugin({
-        axisWidth: opt.leftAxisWidth,
-        yPaddingPx: opt.yPaddingPx,
-        getCrosshair: () => {
-          const pos = interaction.crosshairPos
-          const price = interaction.crosshairPrice
-          const activePaneId = interaction.activePaneId
-          if (pos && price !== null) {
-            return { y: pos.y, price, activePaneId }
-          }
-          return null
-        },
-      })
-      this.useDrawingPlugin(plugin)
-    }
-    {
       const plugin = createTimeAxisRendererPlugin({
         height: opt.bottomAxisHeight,
         getCrosshair: () => {
@@ -223,6 +145,98 @@ export class ChartRenderer {
         },
       })
       this.useDrawingPlugin(plugin)
+    }
+
+    const getCtx = (paneId: string) => () => this.paneCtxMap.get(paneId) ?? null
+    const getCtxForCurrentPane = () => this.paneCtxMap.get(this.currentPaneId) ?? null
+
+    {
+      const layer = createGridLinesLayer(getCtxForCurrentPane)
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createCandleLayer(getCtx('main'))
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createLastPriceLabelLayer(getCtx('main'))
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createComparisonLineLayer(getCtx('main'))
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createLastPriceLineLayer(getCtx('main'))
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createCustomMarkersLayer(getCtxForCurrentPane)
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createExtremaMarkersLayer(getCtxForCurrentPane)
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createMainIndicatorLegendLayer(
+        { yPaddingPx: opt.yPaddingPx },
+        getCtx('main'),
+        this.deps.getPluginHost(),
+      )
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createCrosshairLayer(
+        {
+          getCrosshairState: () => ({
+            pos: interaction.crosshairPos,
+            activePaneId: interaction.activePaneId,
+            isDragging: interaction.isDraggingState(),
+            price: interaction.crosshairPrice,
+          }),
+        },
+        getCtxForCurrentPane,
+      )
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createYAxisLayer(
+        {
+          axisWidth,
+          yPaddingPx: opt.yPaddingPx,
+          getCrosshair: () => {
+            const pos = interaction.crosshairPos
+            const price = interaction.crosshairPrice
+            const activePaneId = interaction.activePaneId
+            if (pos && price !== null) {
+              return { y: pos.y, price, activePaneId }
+            }
+            return null
+          },
+        },
+        getCtxForCurrentPane,
+      )
+      this.scene.addLayer(layer)
+    }
+    {
+      const layer = createLeftYAxisLayer(
+        {
+          axisWidth: opt.leftAxisWidth,
+          yPaddingPx: opt.yPaddingPx,
+          getCrosshair: () => {
+            const pos = interaction.crosshairPos
+            const price = interaction.crosshairPrice
+            const activePaneId = interaction.activePaneId
+            if (pos && price !== null) {
+              return { y: pos.y, price, activePaneId }
+            }
+            return null
+          },
+        },
+        getCtxForCurrentPane,
+      )
+      this.scene.addLayer(layer)
     }
   }
 
@@ -652,25 +666,19 @@ export class ChartRenderer {
       }
 
       this.paneCtxMap.set(pane.id, context)
+      this.currentPaneId = pane.id
 
       if (shouldUpdateMain || shouldUpdateOverlay) {
         const errors = rendererPluginManager.render(pane.id, context, level)
         if (errors.length > 0) {
           pluginHost.events.emit('renderer:error', { paneId: pane.id, errors })
         }
+      }
 
-        const yAxisErrors = rendererPluginManager.renderPlugin('yAxis', context)
-        if (yAxisErrors.length > 0) {
-          pluginHost.events.emit('renderer:error', { paneId: pane.id, errors: yAxisErrors })
-        }
-
-        const leftAxisErrors = rendererPluginManager.renderPlugin('leftYAxis', context)
-        if (leftAxisErrors.length > 0) {
-          pluginHost.events.emit('renderer:error', { paneId: pane.id, errors: leftAxisErrors })
-        }
-
-        const region = { x: 0, y: pane.top, width: vp.plotWidth, height: pane.height, dpr: vp.dpr }
+      const region = { x: 0, y: pane.top, width: vp.plotWidth, height: pane.height, dpr: vp.dpr }
+      if (shouldUpdateMain) {
         this.sceneRenderer.beginFrame(region)
+        ;(this.sceneRenderer as any).setFallbackContext(overlayCtx ?? null, vp.dpr)
         this.scene.paintPane({
           renderer: this.sceneRenderer,
           region,
@@ -678,6 +686,21 @@ export class ChartRenderer {
           frameNumber: this.frameCount++,
           deltaMs: 0,
         })
+        this.sceneRenderer.endFrame()
+      }
+      if (shouldUpdateOverlay && !shouldUpdateMain) {
+        this.sceneRenderer.beginFrame(region)
+        ;(this.sceneRenderer as any).setFallbackContext(overlayCtx ?? null, vp.dpr)
+        this.scene.paintPane(
+          {
+            renderer: this.sceneRenderer,
+            region,
+            paneRole: (pane.id === 'main' ? 'main' : 'sub') as PaneRole,
+            frameNumber: this.frameCount++,
+            deltaMs: 0,
+          },
+          ['overlay'],
+        )
         this.sceneRenderer.endFrame()
       }
     }

--- a/packages/core/src/engine/render/layers/candleLayer.ts
+++ b/packages/core/src/engine/render/layers/candleLayer.ts
@@ -1,0 +1,11 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createCandleRenderer } from '../../renderers/candle'
+
+export function createCandleLayer(
+  getContext: () => RenderContext | null,
+): Layer {
+  const plugin = createCandleRenderer()
+  return createLayerFromPlugin(plugin, getContext, 'main')
+}

--- a/packages/core/src/engine/render/layers/comparisonLineLayer.ts
+++ b/packages/core/src/engine/render/layers/comparisonLineLayer.ts
@@ -1,0 +1,11 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createComparisonLineRenderer } from '../../renderers/comparisonLine'
+
+export function createComparisonLineLayer(
+  getContext: () => RenderContext | null,
+): Layer {
+  const plugin = createComparisonLineRenderer()
+  return createLayerFromPlugin(plugin, getContext, 'main')
+}

--- a/packages/core/src/engine/render/layers/crosshairLayer.ts
+++ b/packages/core/src/engine/render/layers/crosshairLayer.ts
@@ -1,0 +1,18 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createCrosshairRendererPlugin } from '../../renderers/crosshair'
+
+export function createCrosshairLayer(
+  options: {
+    getCrosshairState: () => {
+      pos: { x: number; y: number } | null
+      activePaneId: string | null
+      isDragging: boolean
+      price: number | null
+    }
+  },
+  getContext: () => RenderContext | null,
+): Layer {
+  return createLayerFromPlugin(createCrosshairRendererPlugin(options), getContext, 'global')
+}

--- a/packages/core/src/engine/render/layers/customMarkersLayer.ts
+++ b/packages/core/src/engine/render/layers/customMarkersLayer.ts
@@ -1,0 +1,10 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createCustomMarkersRenderer } from '../../renderers/customMarkers'
+
+export function createCustomMarkersLayer(
+  getContext: () => RenderContext | null,
+): Layer {
+  return createLayerFromPlugin(createCustomMarkersRenderer(), getContext, 'global')
+}

--- a/packages/core/src/engine/render/layers/extremaMarkersLayer.ts
+++ b/packages/core/src/engine/render/layers/extremaMarkersLayer.ts
@@ -1,0 +1,10 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createExtremaMarkersRendererPlugin } from '../../renderers/extremaMarkers'
+
+export function createExtremaMarkersLayer(
+  getContext: () => RenderContext | null,
+): Layer {
+  return createLayerFromPlugin(createExtremaMarkersRendererPlugin(), getContext, 'global')
+}

--- a/packages/core/src/engine/render/layers/gridLinesLayer.ts
+++ b/packages/core/src/engine/render/layers/gridLinesLayer.ts
@@ -1,0 +1,10 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createGridLinesRendererPlugin } from '../../renderers/gridLines'
+
+export function createGridLinesLayer(
+  getContext: () => RenderContext | null,
+): Layer {
+  return createLayerFromPlugin(createGridLinesRendererPlugin(), getContext, 'global')
+}

--- a/packages/core/src/engine/render/layers/lastPriceLabelLayer.ts
+++ b/packages/core/src/engine/render/layers/lastPriceLabelLayer.ts
@@ -1,0 +1,10 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createLastPriceLabelRegistrarPlugin } from '../../renderers/lastPrice'
+
+export function createLastPriceLabelLayer(
+  getContext: () => RenderContext | null,
+): Layer {
+  return createLayerFromPlugin(createLastPriceLabelRegistrarPlugin(), getContext, 'main')
+}

--- a/packages/core/src/engine/render/layers/lastPriceLineLayer.ts
+++ b/packages/core/src/engine/render/layers/lastPriceLineLayer.ts
@@ -1,0 +1,11 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createLastPriceLineRendererPlugin } from '../../renderers/lastPrice'
+
+export function createLastPriceLineLayer(
+  getContext: () => RenderContext | null,
+): Layer {
+  const plugin = createLastPriceLineRendererPlugin()
+  return createLayerFromPlugin(plugin, getContext, 'main')
+}

--- a/packages/core/src/engine/render/layers/leftYAxisLayer.ts
+++ b/packages/core/src/engine/render/layers/leftYAxisLayer.ts
@@ -1,0 +1,15 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createLeftYAxisRendererPlugin } from '../../renderers/leftYAxis'
+
+export function createLeftYAxisLayer(
+  options: {
+    axisWidth: number
+    yPaddingPx: number
+    getCrosshair: () => { y: number; price: number; activePaneId: string | null } | null
+  },
+  getContext: () => RenderContext | null,
+): Layer {
+  return createLayerFromPlugin(createLeftYAxisRendererPlugin(options), getContext, 'global')
+}

--- a/packages/core/src/engine/render/layers/mainIndicatorLegendLayer.ts
+++ b/packages/core/src/engine/render/layers/mainIndicatorLegendLayer.ts
@@ -1,0 +1,18 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext, PluginHost } from '../../../plugin'
+import { createMainIndicatorLegendRendererPlugin } from '../../renderers/Indicator/mainIndicatorLegend'
+
+export function createMainIndicatorLegendLayer(
+  config: { yPaddingPx: number },
+  getContext: () => RenderContext | null,
+  pluginHost: PluginHost,
+): Layer {
+  const plugin = createMainIndicatorLegendRendererPlugin(config)
+  try {
+    plugin.onInstall?.(pluginHost)
+  } catch (e) {
+    console.error(`[MainIndicatorLegendLayer] onInstall error:`, e)
+  }
+  return createLayerFromPlugin(plugin, getContext, 'main')
+}

--- a/packages/core/src/engine/render/layers/yAxisLayer.ts
+++ b/packages/core/src/engine/render/layers/yAxisLayer.ts
@@ -1,0 +1,15 @@
+import { createLayerFromPlugin } from '../../../scene/createLayerFromPlugin'
+import type { Layer } from '../../../scene/types'
+import type { RenderContext } from '../../../plugin'
+import { createYAxisRendererPlugin } from '../../renderers/yAxis'
+
+export function createYAxisLayer(
+  options: {
+    axisWidth: number
+    yPaddingPx: number
+    getCrosshair: () => { y: number; price: number; activePaneId: string | null } | null
+  },
+  getContext: () => RenderContext | null,
+): Layer {
+  return createLayerFromPlugin(createYAxisRendererPlugin(options), getContext, 'global')
+}

--- a/packages/core/src/engine/renderers/extremaMarkers.ts
+++ b/packages/core/src/engine/renderers/extremaMarkers.ts
@@ -109,11 +109,13 @@ export function createExtremaMarkersRendererPlugin(): RendererPlugin {
     description: '可视区最高/最低价标注渲染器',
     debugName: '极值标记',
     paneId: GLOBAL_PANE_ID,
+    layer: 'overlay',
     priority: RENDERER_PRIORITY.OVERLAY,
 
     draw(context: RenderContext) {
       if (context.period === 'timeshare') return
-      const { ctx, pane, data, range, scrollLeft, dpr, paneWidth, kLineCenters } = context
+      const { overlayCtx, pane, data, range, scrollLeft, dpr, paneWidth, kLineCenters } = context
+      const ctx = overlayCtx
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,

--- a/packages/core/src/engine/renderers/lastPrice.ts
+++ b/packages/core/src/engine/renderers/lastPrice.ts
@@ -70,11 +70,14 @@ export function createLastPriceLineRendererPlugin(): RendererPlugin {
     description: '最新价虚线渲染器',
     debugName: '最新价线',
     paneId: 'main',
+    layer: 'overlay',
     priority: RENDERER_PRIORITY.LAST_PRICE_LABEL,
 
     draw(context: RenderContext) {
       if (context.period === 'timeshare') return
-      const { ctx, scrollLeft, dpr, paneWidth } = context
+      const { overlayCtx, scrollLeft, dpr, paneWidth } = context
+      const ctx = overlayCtx
+      if (!ctx) return
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,

--- a/packages/core/src/engine/renderers/webgl/sharedWebGLSurface.ts
+++ b/packages/core/src/engine/renderers/webgl/sharedWebGLSurface.ts
@@ -1,3 +1,23 @@
+/**
+ * SharedWebGLSurface — 单 WebGL canvas 共享后端
+ *
+ * 设计动机：浏览器对 WebGL context 数量有限制（通常 16 个），
+ * 每个 pane 独立创建 canvas → getContext('webgl2') 会快速耗尽限制。
+ * 此模块在整个 chart 实例内共享单个 WebGL canvas，所有 pane
+ * 通过 bindRegion(scissor+viewport) 在其中划分子区域绘制。
+ *
+ * 工作方式：
+ *   1. 一个隐藏 canvas 持有唯一的 WebGL2 上下文
+ *   2. 每个 pane 在共享 canvas 上绑定自己的逻辑区域
+ *   3. 绘制完成后通过 compositeRegionTo() 将共享 canvas 的
+ *      对应区域合成到 2D overlay canvas（DOM 可见层）
+ *
+ * 典型流程：
+ *   resize(paneWidth, paneHeight, dpr)    ← 不分配新 context
+ *   bindRegion({ x, y, width, height })   ← scissor + viewport
+ *   clearRegion(...) + 外部绘制调用         ← pane 内的 GL 命令
+ *   compositeRegionTo(ctx, region)        ← drawImage 到 2D canvas
+ */
 export type WebGLRegion = {
   x: number
   y: number

--- a/packages/core/src/engine/subPaneManager.ts
+++ b/packages/core/src/engine/subPaneManager.ts
@@ -19,6 +19,8 @@ export interface SubPaneEntry {
   scaleRendererName: string
   paneTitleRendererName: string
   layerId: string
+  scaleLayerId: string
+  paneTitleLayerId: string
 }
 
 export interface SubPaneContext {
@@ -96,6 +98,9 @@ export class SubPaneManager {
     this.mountScaleRenderer(ctx, paneId, indicatorId, scaleRendererName)
     this.mountPaneTitleRenderer(ctx, paneId, indicatorId, params)
 
+    const scaleLayerId = `plugin:${scaleRendererName}`
+    const paneTitleLayerId = `plugin:${paneTitleRendererName}`
+
     this.entries.set(paneId, {
       paneId,
       indicatorId,
@@ -104,6 +109,8 @@ export class SubPaneManager {
       scaleRendererName,
       paneTitleRendererName,
       layerId,
+      scaleLayerId,
+      paneTitleLayerId,
     })
 
     this.syncSchedulerConfig(ctx, paneId, indicatorId, params)
@@ -122,6 +129,8 @@ export class SubPaneManager {
     ctx.removeRenderer(entry.scaleRendererName)
     ctx.removeRenderer(entry.paneTitleRendererName)
     ctx.removeLayer(entry.layerId)
+    ctx.removeLayer(entry.scaleLayerId)
+    ctx.removeLayer(entry.paneTitleLayerId)
 
     this.entries.delete(paneId)
 
@@ -146,6 +155,8 @@ export class SubPaneManager {
     ctx.removeRenderer(entry.scaleRendererName)
     ctx.removeRenderer(entry.paneTitleRendererName)
     ctx.removeLayer(entry.layerId)
+    ctx.removeLayer(entry.scaleLayerId)
+    ctx.removeLayer(entry.paneTitleLayerId)
 
     const newScaleRendererName = `${newIndicatorId.toLowerCase()}_scale_${paneId}`
     const newPaneTitleRendererName = `paneTitle_${paneId}`
@@ -153,6 +164,8 @@ export class SubPaneManager {
     if (!renderer) return
     const newRendererName = renderer.name
     const newLayerId = `plugin:${newRendererName}`
+    const newScaleLayerId = `plugin:${newScaleRendererName}`
+    const newPaneTitleLayerId = `plugin:${newPaneTitleRendererName}`
 
     ctx.useRenderer(renderer, newParams as Record<string, number | boolean | string>)
     ctx.setRendererEnabled(newRendererName, false)
@@ -176,6 +189,8 @@ export class SubPaneManager {
       scaleRendererName: newScaleRendererName,
       paneTitleRendererName: newPaneTitleRendererName,
       layerId: newLayerId,
+      scaleLayerId: newScaleLayerId,
+      paneTitleLayerId: newPaneTitleLayerId,
     })
 
     ctx.getIndicatorScheduler().onSubPaneChanged()
@@ -232,6 +247,8 @@ export class SubPaneManager {
       ctx.removeRenderer(entry.scaleRendererName)
       ctx.removeRenderer(entry.paneTitleRendererName)
       ctx.removeLayer(entry.layerId)
+      ctx.removeLayer(entry.scaleLayerId)
+      ctx.removeLayer(entry.paneTitleLayerId)
     }
     this.entries.clear()
     ctx.getIndicatorScheduler().onSubPaneChanged()
@@ -256,7 +273,11 @@ export class SubPaneManager {
     scaleRendererName: string,
   ): void {
     const existing = ctx.getRenderer(scaleRendererName)
-    if (existing) return
+    if (existing) {
+      // ensure existing layer is visible
+      ctx.setLayerVisibility(`plugin:${scaleRendererName}`, true)
+      return
+    }
 
     const axisWidth = ctx.getRightAxisWidth() + (ctx.getPriceLabelWidth() ?? 60)
     const yPaddingPx = ctx.getYPaddingPx()
@@ -274,19 +295,33 @@ export class SubPaneManager {
 
     const definition = ctx.getIndicatorScheduler().getIndicatorMetadata(indicatorId)
     if (definition?.scaleRendererFactory) {
-      ctx.useRenderer(definition.scaleRendererFactory({ ...opts, indicatorId }))
+      const plugin = definition.scaleRendererFactory({ ...opts, indicatorId })
+      ctx.useRenderer(plugin)
+      ctx.setRendererEnabled(scaleRendererName, false)
+      const layer = createLayerFromPlugin(
+        plugin,
+        () => ctx.getRenderContext(paneId),
+        paneId,
+      )
+      ctx.addLayer(layer)
       return
     }
 
     if (definition?.scale) {
-      ctx.useRenderer(
-        createIndicatorScaleRendererPlugin({
-          ...opts,
-          indicatorKey: definition.scale.indicatorKey ?? definition.name,
-          label: definition.scale.label ?? definition.displayName,
-          decimals: definition.scale.decimals,
-        }),
+      const plugin = createIndicatorScaleRendererPlugin({
+        ...opts,
+        indicatorKey: definition.scale.indicatorKey ?? definition.name,
+        label: definition.scale.label ?? definition.displayName,
+        decimals: definition.scale.decimals,
+      })
+      ctx.useRenderer(plugin)
+      ctx.setRendererEnabled(scaleRendererName, false)
+      const layer = createLayerFromPlugin(
+        plugin,
+        () => ctx.getRenderContext(paneId),
+        paneId,
       )
+      ctx.addLayer(layer)
       return
     }
   }
@@ -301,6 +336,7 @@ export class SubPaneManager {
     const existing = ctx.getRenderer(rendererName)
     if (existing) {
       ctx.updateRendererConfig(rendererName, { params, indicatorId })
+      ctx.setLayerVisibility(`plugin:${rendererName}`, true)
       return
     }
 
@@ -311,5 +347,12 @@ export class SubPaneManager {
       params,
     })
     ctx.useRenderer(renderer)
+    ctx.setRendererEnabled(rendererName, false)
+    const layer = createLayerFromPlugin(
+      renderer,
+      () => ctx.getRenderContext(paneId),
+      paneId,
+    )
+    ctx.addLayer(layer)
   }
 }

--- a/packages/core/src/engine/subPaneManager.ts
+++ b/packages/core/src/engine/subPaneManager.ts
@@ -6,8 +6,10 @@ import { createPaneTitleRendererPlugin } from './renderers/paneTitle'
 import { createIndicatorScaleRendererPlugin } from './renderers/Indicator/scale/indicator_scale'
 import { findIndicator } from './renderers/Indicator/indicatorCatalog'
 import type { IndicatorScheduler } from './indicators/scheduler'
-import type { RendererPlugin, RendererPluginWithHost } from '../plugin'
+import type { RendererPlugin, RendererPluginWithHost, RenderContext } from '../plugin'
 import type { PaneSpec } from './chartTypes'
+import type { Layer } from '../scene/types'
+import { createLayerFromPlugin } from '../scene/createLayerFromPlugin'
 
 export interface SubPaneEntry {
   paneId: string
@@ -16,6 +18,7 @@ export interface SubPaneEntry {
   rendererName: string
   scaleRendererName: string
   paneTitleRendererName: string
+  layerId: string
 }
 
 export interface SubPaneContext {
@@ -28,6 +31,7 @@ export interface SubPaneContext {
     config?: Record<string, unknown>,
   ) => void
   removeRenderer: (name: string) => void
+  setRendererEnabled: (name: string, enabled: boolean) => void
   removePaneDefinition: (paneId: string) => void
   updateRendererConfig: (name: string, config: Record<string, unknown>) => void
   getRightAxisWidth: () => number
@@ -36,6 +40,11 @@ export interface SubPaneContext {
   getCrosshairPos: () => { x: number; y: number } | null
   getCrosshairPrice: () => number | null
   getActivePaneId: () => string | null
+  addLayer: (layer: Layer) => void
+  removeLayer: (id: string) => boolean
+  getLayer: (id: string) => Layer | null
+  setLayerVisibility: (id: string, visible: boolean) => void
+  getRenderContext: (paneId: string) => RenderContext | null
 }
 
 export class SubPaneManager {
@@ -65,6 +74,7 @@ export class SubPaneManager {
     const renderer = this.createIndicatorRenderer(ctx, paneId, indicatorId, params)
     if (!renderer) return false
     const rendererName = renderer.name
+    const layerId = `plugin:${rendererName}`
 
     const paneExists = ctx.hasPane(paneId)
     if (!paneExists) {
@@ -74,6 +84,13 @@ export class SubPaneManager {
     const existingRenderer = ctx.getRenderer(rendererName)
     if (!existingRenderer) {
       ctx.useRenderer(renderer, params as Record<string, number | boolean | string>)
+      ctx.setRendererEnabled(rendererName, false)
+      const layer = createLayerFromPlugin(
+        renderer,
+        () => ctx.getRenderContext(paneId),
+        paneId,
+      )
+      ctx.addLayer(layer)
     }
 
     this.mountScaleRenderer(ctx, paneId, indicatorId, scaleRendererName)
@@ -86,6 +103,7 @@ export class SubPaneManager {
       rendererName,
       scaleRendererName,
       paneTitleRendererName,
+      layerId,
     })
 
     this.syncSchedulerConfig(ctx, paneId, indicatorId, params)
@@ -103,6 +121,7 @@ export class SubPaneManager {
     ctx.removeRenderer(entry.rendererName)
     ctx.removeRenderer(entry.scaleRendererName)
     ctx.removeRenderer(entry.paneTitleRendererName)
+    ctx.removeLayer(entry.layerId)
 
     this.entries.delete(paneId)
 
@@ -126,14 +145,23 @@ export class SubPaneManager {
     ctx.removeRenderer(entry.rendererName)
     ctx.removeRenderer(entry.scaleRendererName)
     ctx.removeRenderer(entry.paneTitleRendererName)
+    ctx.removeLayer(entry.layerId)
 
     const newScaleRendererName = `${newIndicatorId.toLowerCase()}_scale_${paneId}`
     const newPaneTitleRendererName = `paneTitle_${paneId}`
     const renderer = this.createIndicatorRenderer(ctx, paneId, newIndicatorId, newParams)
     if (!renderer) return
     const newRendererName = renderer.name
+    const newLayerId = `plugin:${newRendererName}`
 
     ctx.useRenderer(renderer, newParams as Record<string, number | boolean | string>)
+    ctx.setRendererEnabled(newRendererName, false)
+    const layer = createLayerFromPlugin(
+      renderer,
+      () => ctx.getRenderContext(paneId),
+      paneId,
+    )
+    ctx.addLayer(layer)
 
     this.mountScaleRenderer(ctx, paneId, newIndicatorId, newScaleRendererName)
     this.mountPaneTitleRenderer(ctx, paneId, newIndicatorId, newParams)
@@ -147,6 +175,7 @@ export class SubPaneManager {
       rendererName: newRendererName,
       scaleRendererName: newScaleRendererName,
       paneTitleRendererName: newPaneTitleRendererName,
+      layerId: newLayerId,
     })
 
     ctx.getIndicatorScheduler().onSubPaneChanged()
@@ -202,6 +231,7 @@ export class SubPaneManager {
       ctx.removeRenderer(entry.rendererName)
       ctx.removeRenderer(entry.scaleRendererName)
       ctx.removeRenderer(entry.paneTitleRendererName)
+      ctx.removeLayer(entry.layerId)
     }
     this.entries.clear()
     ctx.getIndicatorScheduler().onSubPaneChanged()

--- a/packages/core/src/render/__tests__/webglRenderer.fallback.test.ts
+++ b/packages/core/src/render/__tests__/webglRenderer.fallback.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createWebGLRenderer } from '../createWebGLRenderer'
+import type { SurfaceBackend, SurfaceRegion } from '../index'
+
+vi.mock('../../engine/renderers/webgl/candleSurface', () => ({
+  CandleWebGLSurface: class {
+    isAvailable = () => false
+    setRegion = vi.fn()
+    resize = vi.fn()
+    clear = vi.fn()
+    drawRectBuffer = vi.fn()
+    destroy = vi.fn()
+  },
+  LineWebGLSurface: class {
+    isAvailable = () => false
+    setRegion = vi.fn()
+    resize = vi.fn()
+    clear = vi.fn()
+    drawLineStrips = vi.fn()
+    drawFilledBand = vi.fn()
+    destroy = vi.fn()
+  },
+}))
+
+function createMockSurfaceBackend(): SurfaceBackend {
+  let disposed = false
+  return {
+    isAvailable: () => !disposed,
+    resize: vi.fn(),
+    bindRegion: vi.fn((region: SurfaceRegion) => {
+      if (disposed) return false
+      return region.width > 0 && region.height > 0
+    }),
+    clearRegion: vi.fn(),
+    compositeTo: vi.fn(),
+    dispose: vi.fn(() => {
+      disposed = true
+    }),
+  }
+}
+
+function createMockSharedWebGLSurface() {
+  return {
+    isAvailable: vi.fn(() => false),
+    getGL: vi.fn(() => null),
+    getCanvas: vi.fn(() => ({ width: 0, height: 0 } as HTMLCanvasElement)),
+    resize: vi.fn(),
+    bindRegion: vi.fn(() => false),
+    clearRegion: vi.fn(),
+    compositeRegionTo: vi.fn(),
+    getPhysicalRegion: vi.fn(() => null),
+    destroy: vi.fn(),
+  }
+}
+
+function makeMockFallbackCtx() {
+  return {
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 1,
+    fillRect: vi.fn(),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('Canvas2D fallback', () => {
+  it('setFallbackContext stores the context and dpr', () => {
+    const surface = createMockSurfaceBackend()
+    const glSurface = createMockSharedWebGLSurface()
+    const renderer = createWebGLRenderer(surface, glSurface as any)
+    const ctx = makeMockFallbackCtx()
+
+    expect(() => (renderer as any).setFallbackContext(ctx, 2)).not.toThrow()
+  })
+
+  it('setFallbackContext with null clears the fallback', () => {
+    const surface = createMockSurfaceBackend()
+    const glSurface = createMockSharedWebGLSurface()
+    const renderer = createWebGLRenderer(surface, glSurface as any)
+
+    expect(() => (renderer as any).setFallbackContext(null, 1)).not.toThrow()
+  })
+
+  describe('drawLines — line type', () => {
+    it('draws a polyline on the fallback context when WebGL is unavailable', () => {
+      const surface = createMockSurfaceBackend()
+      const glSurface = createMockSharedWebGLSurface()
+      const renderer = createWebGLRenderer(surface, glSurface as any)
+      const ctx = makeMockFallbackCtx()
+      ;(renderer as any).setFallbackContext(ctx, 1)
+
+      renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+
+      const pipeline = renderer.createPipeline({ type: 'line' })
+      const vertexBuf = renderer.createBuffer('vertex', 256)
+      const verts = new Float32Array([10, 20, 30, 40, 50, 60])
+      renderer.writeBuffer(vertexBuf, verts)
+
+      renderer.drawLines({
+        pipeline,
+        vertices: vertexBuf,
+        vertexCount: 3,
+        uniforms: { color: '#00ff00', scrollLeft: 5, lineWidth: 2 },
+      })
+
+      expect(ctx.beginPath).toHaveBeenCalledTimes(1)
+      expect(ctx.moveTo).toHaveBeenCalledWith(5, 20)
+      expect(ctx.lineTo).toHaveBeenCalledWith(25, 40)
+      expect(ctx.lineTo).toHaveBeenCalledWith(45, 60)
+      expect(ctx.strokeStyle).toBe('#00ff00')
+      expect(ctx.lineWidth).toBe(2)
+      expect(ctx.stroke).toHaveBeenCalledTimes(1)
+    })
+
+    it('no-ops on drawLines with no fallback context', () => {
+      const surface = createMockSurfaceBackend()
+      const glSurface = createMockSharedWebGLSurface()
+      const renderer = createWebGLRenderer(surface, glSurface as any)
+
+      renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+      const pipeline = renderer.createPipeline({ type: 'line' })
+      const vertexBuf = renderer.createBuffer('vertex', 256)
+      renderer.writeBuffer(vertexBuf, new Float32Array([0, 0, 100, 100]))
+
+      expect(() =>
+        renderer.drawLines({ pipeline, vertices: vertexBuf, vertexCount: 2 }),
+      ).not.toThrow()
+    })
+  })
+
+  describe('drawLines — fill type', () => {
+    it('draws a filled band on the fallback context', () => {
+      const surface = createMockSurfaceBackend()
+      const glSurface = createMockSharedWebGLSurface()
+      const renderer = createWebGLRenderer(surface, glSurface as any)
+      const ctx = makeMockFallbackCtx()
+      ;(renderer as any).setFallbackContext(ctx, 1)
+
+      renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+
+      const pipeline = renderer.createPipeline({ type: 'fill' })
+      const vertexBuf = renderer.createBuffer('vertex', 256)
+      const verts = new Float32Array([
+        0, 100, 0, 50, 100, 100, 100, 50, 200, 100, 200, 50,
+      ])
+      renderer.writeBuffer(vertexBuf, verts)
+
+      renderer.drawLines({
+        pipeline,
+        vertices: vertexBuf,
+        vertexCount: 6,
+        uniforms: { color: '#0000ff', scrollLeft: 5 },
+      })
+
+      expect(ctx.beginPath).toHaveBeenCalledTimes(1)
+      expect(ctx.moveTo).toHaveBeenCalledWith(-5, 100)
+      expect(ctx.lineTo).toHaveBeenCalledWith(95, 100)
+      expect(ctx.lineTo).toHaveBeenCalledWith(195, 100)
+      expect(ctx.lineTo).toHaveBeenCalledWith(195, 50)
+      expect(ctx.lineTo).toHaveBeenCalledWith(95, 50)
+      expect(ctx.lineTo).toHaveBeenCalledWith(-5, 50)
+      expect(ctx.closePath).toHaveBeenCalledTimes(1)
+      expect(ctx.fillStyle).toBe('#0000ff')
+      expect(ctx.fill).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('drawInstances', () => {
+    it('draws rectangles on the fallback context', () => {
+      const surface = createMockSurfaceBackend()
+      const glSurface = createMockSharedWebGLSurface()
+      const renderer = createWebGLRenderer(surface, glSurface as any)
+      const ctx = makeMockFallbackCtx()
+      ;(renderer as any).setFallbackContext(ctx, 1)
+
+      renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+
+      const pipeline = renderer.createPipeline({ type: 'candle' })
+      const instanceBuf = renderer.createBuffer('instance', 256)
+      const rects = new Float32Array([10, 20, 30, 40, 60, 70, 20, 10])
+      renderer.writeBuffer(instanceBuf, rects)
+
+      renderer.drawInstances({
+        pipeline,
+        vertices: instanceBuf,
+        instances: instanceBuf,
+        instanceCount: 2,
+        vertexCount: 6,
+        uniforms: { color: '#ff0000', scrollLeft: 5 },
+      })
+
+      expect(ctx.fillRect).toHaveBeenCalledTimes(2)
+      expect(ctx.fillRect).toHaveBeenNthCalledWith(1, 5, 20, 30, 40)
+      expect(ctx.fillRect).toHaveBeenNthCalledWith(2, 55, 70, 20, 10)
+      expect(ctx.fillStyle).toBe('#ff0000')
+    })
+  })
+
+  describe('dispose behaviour', () => {
+    it('after dispose, fallback draw calls are no-ops', () => {
+      const surface = createMockSurfaceBackend()
+      const glSurface = createMockSharedWebGLSurface()
+      const renderer = createWebGLRenderer(surface, glSurface as any)
+      const ctx = makeMockFallbackCtx()
+      ;(renderer as any).setFallbackContext(ctx, 1)
+
+      const pipeline = renderer.createPipeline({ type: 'line' })
+      const vertexBuf = renderer.createBuffer('vertex', 256)
+      renderer.writeBuffer(vertexBuf, new Float32Array([0, 0, 100, 100]))
+
+      renderer.dispose()
+
+      expect(() =>
+        renderer.drawLines({ pipeline, vertices: vertexBuf, vertexCount: 2 }),
+      ).not.toThrow()
+      expect(ctx.stroke).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/render/__tests__/webglRenderer.test.ts
+++ b/packages/core/src/render/__tests__/webglRenderer.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createWebGLRenderer } from '../createWebGLRenderer'
+import type { SurfaceBackend, SurfaceRegion } from '../index'
+
+const mocks = vi.hoisted(() => ({
+  mockDrawRectBuffer: vi.fn(() => true),
+  mockDrawLineStrips: vi.fn(() => true),
+  mockDrawFilledBand: vi.fn(() => true),
+  mockSetRegion: vi.fn(),
+  mockResize: vi.fn(),
+  mockDestroyCandle: vi.fn(),
+  mockDestroyLine: vi.fn(),
+}))
+
+vi.mock('../../engine/renderers/webgl/candleSurface', () => {
+  const mr = mocks
+  return {
+    CandleWebGLSurface: class {
+      isAvailable = () => true
+      setRegion = mr.mockSetRegion
+      resize = mr.mockResize
+      clear = () => {}
+      drawRectBuffer = mr.mockDrawRectBuffer
+      drawRects = () => true
+      destroy = mr.mockDestroyCandle
+    },
+    LineWebGLSurface: class {
+      isAvailable = () => true
+      setRegion = mr.mockSetRegion
+      resize = mr.mockResize
+      clear = () => {}
+      drawLineStrips = mr.mockDrawLineStrips
+      drawFilledBand = mr.mockDrawFilledBand
+      destroy = mr.mockDestroyLine
+    },
+  }
+})
+
+function createMockSurfaceBackend(): SurfaceBackend {
+  let disposed = false
+  return {
+    isAvailable: () => !disposed,
+    resize: vi.fn(),
+    bindRegion: vi.fn((region: SurfaceRegion) => {
+      if (disposed) return false
+      return region.width > 0 && region.height > 0
+    }),
+    clearRegion: vi.fn(),
+    compositeTo: vi.fn(),
+    dispose: vi.fn(() => {
+      disposed = true
+    }),
+  }
+}
+
+function createMockSharedWebGLSurface() {
+  return {
+    isAvailable: vi.fn(() => true),
+    getGL: vi.fn(() => null),
+    getCanvas: vi.fn(() => ({ width: 0, height: 0 } as HTMLCanvasElement)),
+    resize: vi.fn(),
+    bindRegion: vi.fn(() => true),
+    clearRegion: vi.fn(),
+    compositeRegionTo: vi.fn(),
+    getPhysicalRegion: vi.fn(() => null),
+    destroy: vi.fn(),
+  }
+}
+
+function makeRenderer(): {
+  renderer: ReturnType<typeof createWebGLRenderer>
+  surface: SurfaceBackend
+  glSurface: ReturnType<typeof createMockSharedWebGLSurface>
+} {
+  const surface = createMockSurfaceBackend()
+  const glSurface = createMockSharedWebGLSurface()
+  const renderer = createWebGLRenderer(surface, glSurface as any)
+  return { renderer, surface, glSurface }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createWebGLRenderer', () => {
+  describe('surface and caps accessors', () => {
+    it('surface returns the SurfaceBackend passed to the factory', () => {
+      const { renderer, surface } = makeRenderer()
+      expect(renderer.surface).toBe(surface)
+    })
+
+    it('caps reports webgl2 with compute disabled', () => {
+      const { renderer } = makeRenderer()
+      expect(renderer.caps).toEqual({
+        compute: false,
+        storageBuffer: false,
+        maxInstances: 1_000_000,
+        name: 'webgl2',
+      })
+    })
+  })
+
+  describe('buffer lifecycle', () => {
+    it('createBuffer returns an opaque handle', () => {
+      const { renderer } = makeRenderer()
+      const handle = renderer.createBuffer('vertex', 1024)
+      expect(handle).toBeDefined()
+      expect(typeof handle).toBe('object')
+    })
+
+    it('each createBuffer call returns a distinct handle', () => {
+      const { renderer } = makeRenderer()
+      const a = renderer.createBuffer('vertex', 64)
+      const b = renderer.createBuffer('instance', 128)
+      expect(a).not.toBe(b)
+    })
+
+    it('writeBuffer + destroyBuffer round-trips without error', () => {
+      const { renderer } = makeRenderer()
+      const handle = renderer.createBuffer('vertex', 1024)
+      const data = new Float32Array([1, 2, 3, 4])
+      expect(() => renderer.writeBuffer(handle, data)).not.toThrow()
+      expect(() => renderer.writeBuffer(handle, data, 16)).not.toThrow()
+      expect(() => renderer.destroyBuffer(handle)).not.toThrow()
+    })
+
+    it('destroyBuffer is idempotent for the same handle', () => {
+      const { renderer } = makeRenderer()
+      const handle = renderer.createBuffer('vertex', 64)
+      renderer.destroyBuffer(handle)
+      expect(() => renderer.destroyBuffer(handle)).not.toThrow()
+    })
+  })
+
+  describe('pipeline lifecycle', () => {
+    it('createPipeline returns an opaque handle', () => {
+      const { renderer } = makeRenderer()
+      const pipeline = renderer.createPipeline({ type: 'candle' })
+      expect(pipeline).toBeDefined()
+      expect(typeof pipeline).toBe('object')
+    })
+
+    it('destroyPipeline is idempotent', () => {
+      const { renderer } = makeRenderer()
+      const pipeline = renderer.createPipeline({ type: 'line' })
+      renderer.destroyPipeline(pipeline)
+      expect(() => renderer.destroyPipeline(pipeline)).not.toThrow()
+    })
+  })
+
+  describe('compute path (WebGL throw contract)', () => {
+    it('createComputePipeline throws', () => {
+      const { renderer } = makeRenderer()
+      expect(() => renderer.createComputePipeline({})).toThrow(/compute/)
+    })
+
+    it('dispatchCompute throws', () => {
+      const { renderer } = makeRenderer()
+      const fakePipeline = { __brand: 'ComputePipelineHandle' } as any
+      expect(() =>
+        renderer.dispatchCompute({ pipeline: fakePipeline, workgroups: [1], bindings: {} }),
+      ).toThrow(/compute/)
+    })
+  })
+
+  describe('frame lifecycle', () => {
+    it('beginFrame binds the region on the surface', () => {
+      const { renderer, surface } = makeRenderer()
+      const region: SurfaceRegion = { x: 0, y: 0, width: 800, height: 600, dpr: 2 }
+      renderer.beginFrame(region)
+      expect(surface.bindRegion).toHaveBeenCalledWith(region)
+    })
+
+    it('beginFrame sets region and resizes internal surfaces', () => {
+      const { renderer } = makeRenderer()
+      const region: SurfaceRegion = { x: 10, y: 20, width: 800, height: 600, dpr: 2 }
+      renderer.beginFrame(region)
+      expect(mocks.mockSetRegion).toHaveBeenCalledWith(region)
+      expect(mocks.mockResize).toHaveBeenCalledWith(800, 600, 2)
+    })
+
+    it('endFrame does not throw', () => {
+      const { renderer } = makeRenderer()
+      expect(() => renderer.endFrame()).not.toThrow()
+    })
+  })
+
+  describe('drawInstances', () => {
+    it('delegates to candle surface drawRectBuffer', () => {
+      const { renderer } = makeRenderer()
+      const region: SurfaceRegion = { x: 0, y: 0, width: 800, height: 600, dpr: 2 }
+      renderer.beginFrame(region)
+
+      const pipeline = renderer.createPipeline({ type: 'candle' })
+      const instanceBuf = renderer.createBuffer('instance', 256)
+      const rects = new Float32Array([0, 0, 100, 50, 100, 0, 100, 50])
+      renderer.writeBuffer(instanceBuf, rects)
+
+      const vertices = renderer.createBuffer('vertex', 48)
+      renderer.drawInstances({
+        pipeline,
+        vertices,
+        instances: instanceBuf,
+        instanceCount: 2,
+        vertexCount: 6,
+        uniforms: { color: '#ff0000', scrollLeft: 0 },
+      })
+
+      expect(mocks.mockDrawRectBuffer).toHaveBeenCalledTimes(1)
+      const args = mocks.mockDrawRectBuffer.mock.calls[0]
+      expect(args[0]).toBeInstanceOf(Float32Array)
+      expect(args[1]).toBe(2)
+      expect(args[2]).toBe('#ff0000')
+      expect(args[3]).toBe(0)
+    })
+
+    it('no-ops when instanceCount is zero', () => {
+      const { renderer } = makeRenderer()
+      renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+      const pipeline = renderer.createPipeline({ type: 'candle' })
+      const buf = renderer.createBuffer('instance', 64)
+      renderer.writeBuffer(buf, new Float32Array([0, 0, 50, 50]))
+      renderer.drawInstances({
+        pipeline,
+        vertices: buf,
+        instances: buf,
+        instanceCount: 0,
+        vertexCount: 6,
+      })
+      expect(mocks.mockDrawRectBuffer).not.toHaveBeenCalled()
+    })
+
+    it('no-ops when pipeline type mismatch (line -> instances)', () => {
+      const { renderer } = makeRenderer()
+      renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+      const pipeline = renderer.createPipeline({ type: 'line' })
+      const buf = renderer.createBuffer('instance', 64)
+      renderer.writeBuffer(buf, new Float32Array([0, 0, 50, 50]))
+      renderer.drawInstances({
+        pipeline,
+        vertices: buf,
+        instances: buf,
+        instanceCount: 1,
+        vertexCount: 6,
+      })
+      expect(mocks.mockDrawRectBuffer).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('drawLines', () => {
+    it('delegates to line surface drawLineStrips', () => {
+      const { renderer } = makeRenderer()
+      renderer.beginFrame({ x: 0, y: 0, width: 800, height: 600, dpr: 2 })
+
+      const pipeline = renderer.createPipeline({ type: 'line' })
+      const vertexBuf = renderer.createBuffer('vertex', 256)
+      const verts = new Float32Array([10, 20, 30, 40, 50, 60])
+      renderer.writeBuffer(vertexBuf, verts)
+
+      renderer.drawLines({
+        pipeline,
+        vertices: vertexBuf,
+        vertexCount: 3,
+        topology: 'strip',
+        uniforms: { color: '#00ff00', scrollLeft: 10, lineWidth: 1 },
+      })
+
+      expect(mocks.mockDrawLineStrips).toHaveBeenCalledTimes(1)
+      const args = mocks.mockDrawLineStrips.mock.calls[0]
+      expect(args[0]).toHaveLength(1)
+      expect(args[0][0].color).toBe('#00ff00')
+      expect(args[0][0].width).toBe(1)
+      expect(args[0][0].points).toHaveLength(3)
+      expect(args[1]).toBe(10)
+    })
+
+    it('delegates to line surface drawFilledBand for fill pipeline', () => {
+      const { renderer } = makeRenderer()
+      renderer.beginFrame({ x: 0, y: 0, width: 800, height: 600, dpr: 2 })
+
+      const pipeline = renderer.createPipeline({ type: 'fill' })
+      const vertexBuf = renderer.createBuffer('vertex', 256)
+      // [upper0_x, upper0_y, lower0_x, lower0_y, upper1_x, upper1_y, ...]
+      const verts = new Float32Array([
+        0, 100, 0, 50, 100, 100, 100, 50, 200, 100, 200, 50,
+      ])
+      renderer.writeBuffer(vertexBuf, verts)
+
+      renderer.drawLines({
+        pipeline,
+        vertices: vertexBuf,
+        vertexCount: 6,
+        uniforms: { color: '#0000ff', scrollLeft: 5 },
+      })
+
+      expect(mocks.mockDrawFilledBand).toHaveBeenCalledTimes(1)
+      const args = mocks.mockDrawFilledBand.mock.calls[0]
+      expect(args[0].upperPoints).toHaveLength(3)
+      expect(args[0].lowerPoints).toHaveLength(3)
+      expect(args[1]).toBe('#0000ff')
+      expect(args[2]).toBe(5)
+    })
+  })
+
+  describe('dispose lifecycle', () => {
+    it('dispose destroys internal surfaces and the surface backend', () => {
+      const { renderer, surface } = makeRenderer()
+      renderer.dispose()
+      expect(mocks.mockDestroyCandle).toHaveBeenCalledTimes(1)
+      expect(mocks.mockDestroyLine).toHaveBeenCalledTimes(1)
+      expect(surface.dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('dispose is idempotent', () => {
+      const { renderer } = makeRenderer()
+      renderer.dispose()
+      renderer.dispose()
+      expect(mocks.mockDestroyCandle).toHaveBeenCalledTimes(1)
+      expect(mocks.mockDestroyLine).toHaveBeenCalledTimes(1)
+    })
+
+    it('after dispose, createBuffer throws', () => {
+      const { renderer } = makeRenderer()
+      renderer.dispose()
+      expect(() => renderer.createBuffer('vertex', 64)).toThrow(/disposed/)
+    })
+
+    it('after dispose, createPipeline throws', () => {
+      const { renderer } = makeRenderer()
+      renderer.dispose()
+      expect(() => renderer.createPipeline({ type: 'candle' })).toThrow(/disposed/)
+    })
+
+    it('after dispose, draw calls are no-ops', () => {
+      const { renderer } = makeRenderer()
+      const pipeline = renderer.createPipeline({ type: 'candle' })
+      const buf = renderer.createBuffer('instance', 64)
+      renderer.writeBuffer(buf, new Float32Array([0, 0, 50, 50]))
+
+      renderer.dispose()
+
+      expect(() => renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })).not.toThrow()
+      expect(() =>
+        renderer.drawInstances({
+          pipeline,
+          vertices: buf,
+          instances: buf,
+          instanceCount: 1,
+          vertexCount: 6,
+        }),
+      ).not.toThrow()
+      expect(() => renderer.drawLines({
+        pipeline,
+        vertices: buf,
+        vertexCount: 2,
+      })).not.toThrow()
+      expect(() => renderer.endFrame()).not.toThrow()
+      expect(mocks.mockDrawRectBuffer).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/render/__tests__/webglSurfaceBackend.test.ts
+++ b/packages/core/src/render/__tests__/webglSurfaceBackend.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createWebGLSurfaceBackend } from '../createWebGLSurfaceBackend'
+import type { SurfaceBackend, SurfaceRegion } from '../index'
+
+function createMockSharedWebGLSurface() {
+  let canvasWidth = 1
+  let canvasHeight = 1
+  let disposed = false
+  const mockCanvas = { width: 0, height: 0 } as HTMLCanvasElement
+
+  return {
+    isAvailable: vi.fn(() => !disposed),
+    resize: vi.fn((w: number, h: number, dpr: number) => {
+      mockCanvas.width = Math.max(1, Math.round(w * dpr))
+      mockCanvas.height = Math.max(1, Math.round(h * dpr))
+      canvasWidth = mockCanvas.width
+      canvasHeight = mockCanvas.height
+    }),
+    bindRegion: vi.fn((region: SurfaceRegion) => {
+      if (disposed) return false
+      return region.width > 0 && region.height > 0
+    }),
+    clearRegion: vi.fn((_region: SurfaceRegion) => {}),
+    compositeRegionTo: vi.fn(
+      (_ctx: CanvasRenderingContext2D, _region: SurfaceRegion, _options?: unknown) => {},
+    ),
+    destroy: vi.fn(() => {
+      disposed = true
+    }),
+  }
+}
+
+type MockSurface = ReturnType<typeof createMockSharedWebGLSurface>
+
+describe('WebGL SurfaceBackend adapter', () => {
+  function makeBackend(): { backend: SurfaceBackend; mock: MockSurface } {
+    const mock = createMockSharedWebGLSurface()
+    const backend = createWebGLSurfaceBackend(mock as any)
+    return { backend, mock }
+  }
+
+  it('isAvailable delegates to the underlying surface', () => {
+    const { backend, mock } = makeBackend()
+    expect(backend.isAvailable()).toBe(true)
+    expect(mock.isAvailable).toHaveBeenCalled()
+  })
+
+  it('resize delegates to the underlying surface', () => {
+    const { backend, mock } = makeBackend()
+    backend.resize(800, 600, 2)
+    expect(mock.resize).toHaveBeenCalledWith(800, 600, 2)
+  })
+
+  it('bindRegion delegates to the underlying surface', () => {
+    const { backend, mock } = makeBackend()
+    const region: SurfaceRegion = { x: 0, y: 0, width: 800, height: 600, dpr: 2 }
+    const ok = backend.bindRegion(region)
+    expect(ok).toBe(true)
+    expect(mock.bindRegion).toHaveBeenCalledWith(region)
+  })
+
+  it('bindRegion returns false for zero-area region', () => {
+    const { backend } = makeBackend()
+    expect(backend.bindRegion({ x: 0, y: 0, width: 0, height: 100, dpr: 1 })).toBe(false)
+    expect(backend.bindRegion({ x: 0, y: 0, width: 100, height: 0, dpr: 1 })).toBe(false)
+  })
+
+  it('clearRegion delegates to the underlying surface', () => {
+    const { backend, mock } = makeBackend()
+    const region: SurfaceRegion = { x: 0, y: 0, width: 800, height: 600, dpr: 2 }
+    backend.clearRegion(region)
+    expect(mock.clearRegion).toHaveBeenCalledWith(region)
+  })
+
+  it('compositeTo delegates to the underlying surface', () => {
+    const { backend, mock } = makeBackend()
+    const ctx = {} as CanvasRenderingContext2D
+    const region: SurfaceRegion = { x: 0, y: 0, width: 800, height: 600, dpr: 2 }
+    backend.compositeTo(ctx, region)
+    expect(mock.compositeRegionTo).toHaveBeenCalledWith(ctx, region, undefined)
+  })
+
+  it('compositeTo passes options through', () => {
+    const { backend, mock } = makeBackend()
+    const ctx = {} as CanvasRenderingContext2D
+    const region: SurfaceRegion = { x: 0, y: 0, width: 800, height: 600, dpr: 2 }
+    backend.compositeTo(ctx, region, { alpha: 0.5 })
+    expect(mock.compositeRegionTo).toHaveBeenCalledWith(ctx, region, { alpha: 0.5 })
+  })
+
+  it('lifecycle: dispose then isAvailable returns false', () => {
+    const { backend, mock } = makeBackend()
+    expect(backend.isAvailable()).toBe(true)
+    backend.dispose()
+    expect(backend.isAvailable()).toBe(false)
+    expect(mock.destroy).toHaveBeenCalled()
+  })
+
+  it('lifecycle: after dispose all methods are no-ops', () => {
+    const { backend, mock } = makeBackend()
+    backend.dispose()
+
+    expect(backend.bindRegion({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })).toBe(false)
+    backend.resize(800, 600, 2)
+    backend.clearRegion({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+    backend.compositeTo({} as CanvasRenderingContext2D, {
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      dpr: 1,
+    })
+
+    expect(mock.resize).not.toHaveBeenCalled()
+    expect(mock.clearRegion).not.toHaveBeenCalled()
+    expect(mock.compositeRegionTo).not.toHaveBeenCalled()
+  })
+
+  it('dispose is idempotent', () => {
+    const { backend, mock } = makeBackend()
+    backend.dispose()
+    backend.dispose()
+    expect(mock.destroy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/render/createWebGLRenderer.ts
+++ b/packages/core/src/render/createWebGLRenderer.ts
@@ -1,0 +1,229 @@
+import type { SurfaceBackend, SurfaceRegion } from './SurfaceBackend'
+import type {
+  Renderer,
+  RendererCapabilities,
+  BufferHandle,
+  PipelineHandle,
+  BufferUsage,
+  DrawInstancesParams,
+  DrawLinesParams,
+  DispatchComputeParams,
+} from './Renderer'
+import { SharedWebGLSurface } from '../engine/renderers/webgl/sharedWebGLSurface'
+import { CandleWebGLSurface, LineWebGLSurface } from '../engine/renderers/webgl/candleSurface'
+
+type WebGLPipelineDescriptor = {
+  type: 'candle' | 'line' | 'fill'
+}
+
+type WebGLDrawUniforms = {
+  color?: string
+  scrollLeft?: number
+  lineWidth?: number
+  alpha?: number
+}
+
+interface BufferRecord {
+  usage: BufferUsage
+  byteLength: number
+  data: ArrayBuffer | null
+}
+
+interface PipelineRecord {
+  type: 'candle' | 'line' | 'fill'
+}
+
+const handleCaps: RendererCapabilities = {
+  compute: false,
+  storageBuffer: false,
+  maxInstances: 1_000_000,
+  name: 'webgl2',
+}
+
+function toWebGLRegion(r: SurfaceRegion) {
+  return r as { x: number; y: number; width: number; height: number; dpr: number }
+}
+
+export function createWebGLRenderer(
+  surface: SurfaceBackend,
+  gl: SharedWebGLSurface,
+): Renderer {
+  let disposed = false
+  let candleSurface: CandleWebGLSurface | null = null
+  let lineSurface: LineWebGLSurface | null = null
+
+  const candle = new CandleWebGLSurface(gl)
+  if (candle.isAvailable()) candleSurface = candle
+  const line = new LineWebGLSurface(gl)
+  if (line.isAvailable()) lineSurface = line
+
+  const bufferMeta = new WeakMap<object, BufferRecord>()
+  const pipelineMeta = new WeakMap<object, PipelineRecord>()
+
+  function disposeSurfaces(): void {
+    if (candleSurface) {
+      candleSurface.destroy()
+      candleSurface = null
+    }
+    if (lineSurface) {
+      lineSurface.destroy()
+      lineSurface = null
+    }
+  }
+
+  const renderer: Renderer = {
+    get surface(): SurfaceBackend {
+      return surface
+    },
+
+    get caps(): RendererCapabilities {
+      return handleCaps
+    },
+
+    createBuffer(usage: BufferUsage, sizeBytes: number): BufferHandle {
+      if (disposed) {
+        throw new Error('Renderer is disposed')
+      }
+      const handle: object = {}
+      bufferMeta.set(handle, { usage, byteLength: sizeBytes, data: null })
+      return handle as BufferHandle
+    },
+
+    writeBuffer(handle: BufferHandle, data: ArrayBufferView, offsetBytes?: number): void {
+      if (disposed) return
+      const meta = bufferMeta.get(handle as object)
+      if (!meta) return
+      const offset = offsetBytes ?? 0
+      const neededSize = offset + data.byteLength
+      if (!meta.data || meta.data.byteLength < neededSize) {
+        const newBuf = new ArrayBuffer(Math.max(neededSize, meta.byteLength))
+        if (meta.data) {
+          new Uint8Array(newBuf).set(
+            new Uint8Array(meta.data, 0, Math.min(meta.data.byteLength, neededSize)),
+          )
+        }
+        meta.data = newBuf
+      }
+      const src = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+      new Uint8Array(meta.data, offset).set(src)
+    },
+
+    destroyBuffer(handle: BufferHandle): void {
+      if (disposed) return
+      bufferMeta.delete(handle as object)
+    },
+
+    createPipeline(descriptor: unknown): PipelineHandle {
+      if (disposed) {
+        throw new Error('Renderer is disposed')
+      }
+      const desc = descriptor as WebGLPipelineDescriptor
+      const handle: object = {}
+      pipelineMeta.set(handle, { type: desc.type ?? 'candle' })
+      return handle as PipelineHandle
+    },
+
+    destroyPipeline(handle: PipelineHandle): void {
+      if (disposed) return
+      pipelineMeta.delete(handle as object)
+    },
+
+    createComputePipeline(_descriptor: unknown): ComputePipelineHandle {
+      throw new Error(
+        'compute not supported on WebGL backend (caps.compute === false)',
+      )
+    },
+
+    destroyComputePipeline(_handle: ComputePipelineHandle): void {
+      // no-op: WebGL has no compute pipelines
+    },
+
+    beginFrame(region: SurfaceRegion): void {
+      if (disposed) return
+      surface.bindRegion(region)
+      if (candleSurface) {
+        candleSurface.setRegion(toWebGLRegion(region))
+        candleSurface.resize(region.width, region.height, region.dpr)
+      }
+      if (lineSurface) {
+        lineSurface.setRegion(toWebGLRegion(region))
+        lineSurface.resize(region.width, region.height, region.dpr)
+      }
+    },
+
+    drawInstances(params: DrawInstancesParams): void {
+      if (disposed || !candleSurface) return
+      const pipelineMeta_rec = pipelineMeta.get(params.pipeline as object)
+      if (!pipelineMeta_rec || pipelineMeta_rec.type !== 'candle') return
+
+      const instanceMeta = bufferMeta.get(params.instances as object)
+      if (!instanceMeta || !instanceMeta.data) return
+
+      const rectCount = params.instanceCount
+      if (rectCount <= 0) return
+
+      const floats = new Float32Array(instanceMeta.data, 0, rectCount * 4)
+      const color = (params.uniforms?.color as string) ?? '#000000'
+      const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
+
+      candleSurface.drawRectBuffer(floats, rectCount, color, scrollLeft)
+    },
+
+    drawLines(params: DrawLinesParams): void {
+      if (disposed || !lineSurface) return
+      const pipelineMeta_rec = pipelineMeta.get(params.pipeline as object)
+      if (!pipelineMeta_rec) return
+
+      const vertexMeta = bufferMeta.get(params.vertices as object)
+      if (!vertexMeta || !vertexMeta.data) return
+      if (params.vertexCount < 2) return
+
+      const color = (params.uniforms?.color as string) ?? '#000000'
+      const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
+
+      if (pipelineMeta_rec.type === 'fill') {
+        const floats = new Float32Array(vertexMeta.data, 0, params.vertexCount * 2)
+        const pointCount = Math.floor(params.vertexCount / 2)
+        const upperPoints: Array<{ x: number; y: number }> = []
+        const lowerPoints: Array<{ x: number; y: number }> = []
+        for (let i = 0; i < pointCount; i++) {
+          const offset = i * 4
+          upperPoints.push({ x: floats[offset], y: floats[offset + 1] })
+          lowerPoints.push({ x: floats[offset + 2], y: floats[offset + 3] })
+        }
+        lineSurface.drawFilledBand({ upperPoints, lowerPoints }, color, scrollLeft)
+        return
+      }
+
+      const floats = new Float32Array(vertexMeta.data, 0, params.vertexCount * 2)
+      const points: Array<{ x: number; y: number }> = []
+      for (let i = 0; i < params.vertexCount; i++) {
+        points.push({ x: floats[i * 2], y: floats[i * 2 + 1] })
+      }
+      const lineWidth = (params.uniforms?.lineWidth as number) ?? 1
+      const lines = [{ points, color, width: lineWidth }]
+      lineSurface.drawLineStrips(lines, scrollLeft)
+    },
+
+    dispatchCompute(_params: DispatchComputeParams): void {
+      if (!disposed) {
+        throw new Error(
+          'dispatchCompute requires a backend with caps.compute === true',
+        )
+      }
+    },
+
+    endFrame(): void {
+      // no-op per-frame cleanup; surfaces hold region reference until next frame
+    },
+
+    dispose(): void {
+      if (disposed) return
+      disposed = true
+      disposeSurfaces()
+      surface.dispose()
+    },
+  }
+
+  return renderer
+}

--- a/packages/core/src/render/createWebGLRenderer.ts
+++ b/packages/core/src/render/createWebGLRenderer.ts
@@ -51,6 +51,8 @@ export function createWebGLRenderer(
   let disposed = false
   let candleSurface: CandleWebGLSurface | null = null
   let lineSurface: LineWebGLSurface | null = null
+  let fallbackCtx: CanvasRenderingContext2D | null = null
+  let fallbackDpr = 1
 
   const candle = new CandleWebGLSurface(gl)
   if (candle.isAvailable()) candleSurface = candle
@@ -71,13 +73,18 @@ export function createWebGLRenderer(
     }
   }
 
-  const renderer: Renderer = {
+  const renderer = {
     get surface(): SurfaceBackend {
       return surface
     },
 
     get caps(): RendererCapabilities {
       return handleCaps
+    },
+
+    setFallbackContext(ctx: CanvasRenderingContext2D | null, dpr: number): void {
+      fallbackCtx = ctx
+      fallbackDpr = dpr
     },
 
     createBuffer(usage: BufferUsage, sizeBytes: number): BufferHandle {
@@ -152,7 +159,7 @@ export function createWebGLRenderer(
     },
 
     drawInstances(params: DrawInstancesParams): void {
-      if (disposed || !candleSurface) return
+      if (disposed) return
       const pipelineMeta_rec = pipelineMeta.get(params.pipeline as object)
       if (!pipelineMeta_rec || pipelineMeta_rec.type !== 'candle') return
 
@@ -166,11 +173,26 @@ export function createWebGLRenderer(
       const color = (params.uniforms?.color as string) ?? '#000000'
       const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
 
-      candleSurface.drawRectBuffer(floats, rectCount, color, scrollLeft)
+      if (candleSurface) {
+        candleSurface.drawRectBuffer(floats, rectCount, color, scrollLeft)
+        return
+      }
+
+      if (fallbackCtx) {
+        const ctx = fallbackCtx
+        ctx.fillStyle = color
+        for (let i = 0; i < rectCount; i++) {
+          const x = floats[i * 4] - scrollLeft
+          const y = floats[i * 4 + 1]
+          const w = Math.max(0, floats[i * 4 + 2])
+          const h = floats[i * 4 + 3]
+          ctx.fillRect(x, y, w, h)
+        }
+      }
     },
 
     drawLines(params: DrawLinesParams): void {
-      if (disposed || !lineSurface) return
+      if (disposed) return
       const pipelineMeta_rec = pipelineMeta.get(params.pipeline as object)
       if (!pipelineMeta_rec) return
 
@@ -191,18 +213,61 @@ export function createWebGLRenderer(
           upperPoints.push({ x: floats[offset], y: floats[offset + 1] })
           lowerPoints.push({ x: floats[offset + 2], y: floats[offset + 3] })
         }
-        lineSurface.drawFilledBand({ upperPoints, lowerPoints }, color, scrollLeft)
+
+        if (lineSurface) {
+          lineSurface.drawFilledBand({ upperPoints, lowerPoints }, color, scrollLeft)
+          return
+        }
+
+        if (fallbackCtx) {
+          const ctx = fallbackCtx
+          ctx.beginPath()
+          ctx.moveTo(upperPoints[0].x - scrollLeft, upperPoints[0].y)
+          for (let i = 1; i < upperPoints.length; i++) {
+            ctx.lineTo(upperPoints[i].x - scrollLeft, upperPoints[i].y)
+          }
+          for (let i = lowerPoints.length - 1; i >= 0; i--) {
+            ctx.lineTo(lowerPoints[i].x - scrollLeft, lowerPoints[i].y)
+          }
+          ctx.closePath()
+          ctx.fillStyle = color
+          ctx.fill()
+        }
         return
       }
 
       const floats = new Float32Array(vertexMeta.data, 0, params.vertexCount * 2)
-      const points: Array<{ x: number; y: number }> = []
-      for (let i = 0; i < params.vertexCount; i++) {
-        points.push({ x: floats[i * 2], y: floats[i * 2 + 1] })
+
+      if (lineSurface) {
+        const points: Array<{ x: number; y: number }> = []
+        for (let i = 0; i < params.vertexCount; i++) {
+          points.push({ x: floats[i * 2], y: floats[i * 2 + 1] })
+        }
+        const lineWidth = (params.uniforms?.lineWidth as number) ?? 1
+        const lines = [{ points, color, width: lineWidth }]
+        lineSurface.drawLineStrips(lines, scrollLeft)
+        return
       }
-      const lineWidth = (params.uniforms?.lineWidth as number) ?? 1
-      const lines = [{ points, color, width: lineWidth }]
-      lineSurface.drawLineStrips(lines, scrollLeft)
+
+      if (fallbackCtx) {
+        const ctx = fallbackCtx
+        const lineWidth = (params.uniforms?.lineWidth as number) ?? 1
+        const dashPattern = params.uniforms?.dashPattern as number[] | undefined
+        ctx.beginPath()
+        ctx.moveTo(floats[0] - scrollLeft, floats[1])
+        for (let i = 1; i < params.vertexCount; i++) {
+          ctx.lineTo(floats[i * 2] - scrollLeft, floats[i * 2 + 1])
+        }
+        ctx.strokeStyle = color
+        ctx.lineWidth = lineWidth
+        if (dashPattern && dashPattern.length > 0) {
+          ctx.setLineDash(dashPattern)
+        }
+        ctx.stroke()
+        if (dashPattern && dashPattern.length > 0) {
+          ctx.setLineDash([])
+        }
+      }
     },
 
     dispatchCompute(_params: DispatchComputeParams): void {
@@ -225,5 +290,5 @@ export function createWebGLRenderer(
     },
   }
 
-  return renderer
+  return renderer as Renderer
 }

--- a/packages/core/src/render/createWebGLSurfaceBackend.ts
+++ b/packages/core/src/render/createWebGLSurfaceBackend.ts
@@ -1,0 +1,43 @@
+import type { SurfaceBackend, SurfaceRegion, CompositeOptions } from './SurfaceBackend'
+import { SharedWebGLSurface } from '../engine/renderers/webgl/sharedWebGLSurface'
+
+export function createWebGLSurfaceBackend(surface: SharedWebGLSurface): SurfaceBackend {
+  let disposed = false
+
+  return {
+    isAvailable(): boolean {
+      if (disposed) return false
+      return surface.isAvailable()
+    },
+
+    resize(widthLogical: number, heightLogical: number, dpr: number): void {
+      if (disposed) return
+      surface.resize(widthLogical, heightLogical, dpr)
+    },
+
+    bindRegion(region: SurfaceRegion): boolean {
+      if (disposed) return false
+      return surface.bindRegion(region)
+    },
+
+    clearRegion(region: SurfaceRegion): void {
+      if (disposed) return
+      surface.clearRegion(region)
+    },
+
+    compositeTo(
+      targetCtx: CanvasRenderingContext2D,
+      region: SurfaceRegion,
+      options?: CompositeOptions,
+    ): void {
+      if (disposed) return
+      surface.compositeRegionTo(targetCtx, region, options)
+    },
+
+    dispose(): void {
+      if (disposed) return
+      disposed = true
+      surface.destroy()
+    },
+  }
+}

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -1,14 +1,13 @@
 /**
  * Renderer abstraction barrel.
  *
- * The two interfaces (`SurfaceBackend`, `Renderer`) define the contract every
- * GPU backend implements. v0's WebGL code (in `src/core/renderers/`) will be
- * refactored to fit behind these in a follow-up PR; this PR ships the contract
- * only, so subsequent PRs can land WebGPU and WebGL impls in parallel without
- * either blocking on the other's interface decisions.
+ * Exports the `SurfaceBackend` / `Renderer` contracts and the WebGL2
+ * implementation of `SurfaceBackend` wrapping `SharedWebGLSurface`.
  */
 
 export type { SurfaceBackend, SurfaceRegion, CompositeOptions } from './SurfaceBackend'
+
+export { createWebGLSurfaceBackend } from './createWebGLSurfaceBackend'
 
 export type {
   Renderer,

--- a/packages/core/src/render/index.ts
+++ b/packages/core/src/render/index.ts
@@ -8,6 +8,7 @@
 export type { SurfaceBackend, SurfaceRegion, CompositeOptions } from './SurfaceBackend'
 
 export { createWebGLSurfaceBackend } from './createWebGLSurfaceBackend'
+export { createWebGLRenderer } from './createWebGLRenderer'
 
 export type {
   Renderer,

--- a/packages/core/src/scene/__tests__/layerFromPlugin.test.ts
+++ b/packages/core/src/scene/__tests__/layerFromPlugin.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createLayerFromPlugin } from '../createLayerFromPlugin'
+import { RENDERER_PRIORITY } from '../../plugin'
+import type { RendererPlugin, RenderContext } from '../../plugin'
+import type { PaintContext } from '../types'
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeMockPlugin(overrides: Partial<RendererPlugin> = {}): RendererPlugin {
+  return {
+    name: 'test-plugin',
+    paneId: 'main',
+    priority: RENDERER_PRIORITY.MAIN,
+    enabled: true,
+    draw: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeMockContext(): RenderContext {
+  return {
+    ctx: {} as unknown as CanvasRenderingContext2D,
+    pane: {} as unknown as RenderContext['pane'],
+    data: [],
+    period: 'daily',
+    range: { start: 0, end: 10 },
+    scrollLeft: 0,
+    kWidth: 8,
+    kGap: 2,
+    dpr: 2,
+    paneWidth: 800,
+    kLinePositions: [0, 10, 20],
+    kLineCenters: [5, 15, 25],
+    kBarRects: [
+      { x: 0, width: 8 },
+      { x: 10, width: 8 },
+      { x: 20, width: 8 },
+    ],
+    theme: 'dark',
+  } as unknown as RenderContext
+}
+
+const stubPaintCtx = {
+  renderer: {} as unknown as PaintContext['renderer'],
+  region: { x: 0, y: 0, width: 800, height: 600, dpr: 2 },
+  paneRole: 'main' as const,
+  frameNumber: 0,
+  deltaMs: 16,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createLayerFromPlugin', () => {
+  it('delegates paint to plugin.draw with context from getContext', () => {
+    const plugin = makeMockPlugin()
+    const context = makeMockContext()
+    const getContext = vi.fn(() => context)
+    const layer = createLayerFromPlugin(plugin, getContext, 'main')
+
+    layer.paint(stubPaintCtx)
+
+    expect(getContext).toHaveBeenCalledOnce()
+    expect(plugin.draw).toHaveBeenCalledOnce()
+    expect(plugin.draw).toHaveBeenCalledWith(context)
+  })
+
+  it('skips plugin.draw when getContext returns null', () => {
+    const plugin = makeMockPlugin()
+    const getContext = vi.fn(() => null)
+    const layer = createLayerFromPlugin(plugin, getContext, 'main')
+
+    layer.paint(stubPaintCtx)
+
+    expect(getContext).toHaveBeenCalledOnce()
+    expect(plugin.draw).not.toHaveBeenCalled()
+  })
+
+  it('skips plugin.draw when visible is false', () => {
+    const plugin = makeMockPlugin()
+    const context = makeMockContext()
+    const getContext = vi.fn(() => context)
+    const layer = createLayerFromPlugin(plugin, getContext, 'main')
+
+    layer.visible = false
+    layer.paint(stubPaintCtx)
+
+    expect(plugin.draw).not.toHaveBeenCalled()
+  })
+
+  it('calls plugin.onUninstall on dispose', () => {
+    const onUninstall = vi.fn()
+    const plugin = makeMockPlugin({ onUninstall })
+    const getContext = vi.fn(() => makeMockContext())
+    const layer = createLayerFromPlugin(plugin, getContext, 'main')
+
+    layer.dispose()
+
+    expect(onUninstall).toHaveBeenCalledOnce()
+  })
+
+  it('does not throw when dispose is called without onUninstall', () => {
+    const plugin = makeMockPlugin({ onUninstall: undefined })
+    const getContext = vi.fn(() => makeMockContext())
+    const layer = createLayerFromPlugin(plugin, getContext, 'main')
+
+    expect(() => layer.dispose()).not.toThrow()
+  })
+
+  it('maps enabled=false to visible=false, enabled=true to visible=true', () => {
+    const pluginDisabled = makeMockPlugin({ enabled: false })
+    const getContext = vi.fn(() => makeMockContext())
+    const layerDisabled = createLayerFromPlugin(pluginDisabled, getContext, 'main')
+    expect(layerDisabled.visible).toBe(false)
+
+    const pluginEnabled = makeMockPlugin({ enabled: true })
+    const layerEnabled = createLayerFromPlugin(pluginEnabled, getContext, 'main')
+    expect(layerEnabled.visible).toBe(true)
+  })
+
+  it('defaults visible to true when enabled is undefined', () => {
+    const plugin = makeMockPlugin({ enabled: undefined })
+    const getContext = vi.fn(() => makeMockContext())
+    const layer = createLayerFromPlugin(plugin, getContext, 'main')
+    expect(layer.visible).toBe(true)
+  })
+
+  it('visible setter updates the field', () => {
+    const plugin = makeMockPlugin()
+    const getContext = vi.fn(() => makeMockContext())
+    const layer = createLayerFromPlugin(plugin, getContext, 'main')
+
+    expect(layer.visible).toBe(true)
+    layer.visible = false
+    expect(layer.visible).toBe(false)
+    layer.visible = true
+    expect(layer.visible).toBe(true)
+  })
+
+  describe('layer identity fields', () => {
+    it('id is plugin: + plugin.name', () => {
+      const plugin = makeMockPlugin({ name: 'candle' })
+      const layer = createLayerFromPlugin(plugin, () => null, 'main')
+      expect(layer.id).toBe('plugin:candle')
+    })
+
+    it('z equals plugin.priority', () => {
+      const plugin = makeMockPlugin({ priority: 42 })
+      const layer = createLayerFromPlugin(plugin, () => null, 'main')
+      expect(layer.z).toBe(42)
+    })
+
+    it('paneRole is main when targetPaneId is main', () => {
+      const layer = createLayerFromPlugin(makeMockPlugin(), () => null, 'main')
+      expect(layer.paneRole).toBe('main')
+    })
+
+    it('paneRole is sub when targetPaneId is not main', () => {
+      const layer = createLayerFromPlugin(makeMockPlugin(), () => null, 'sub')
+      expect(layer.paneRole).toBe('sub')
+    })
+  })
+
+  describe('role mapping from priority and name', () => {
+    it('plugin.layer=overlay maps to role overlay', () => {
+      const plugin = makeMockPlugin({
+        priority: RENDERER_PRIORITY.MAIN,
+        layer: 'overlay',
+      })
+      const layer = createLayerFromPlugin(plugin, () => null, 'main')
+      expect(layer.role).toBe('overlay')
+    })
+
+    it('GRID priority maps to background', () => {
+      const plugin = makeMockPlugin({
+        name: 'gridLines',
+        priority: RENDERER_PRIORITY.GRID,
+      })
+      const layer = createLayerFromPlugin(plugin, () => null, 'main')
+      expect(layer.role).toBe('background')
+    })
+
+    it('INDICATOR priority maps to indicator', () => {
+      const plugin = makeMockPlugin({
+        name: 'ma',
+        priority: RENDERER_PRIORITY.INDICATOR,
+      })
+      const layer = createLayerFromPlugin(plugin, () => null, 'main')
+      expect(layer.role).toBe('indicator')
+    })
+
+    it('candle name with MAIN priority maps to primary', () => {
+      const plugin = makeMockPlugin({
+        name: 'candle',
+        priority: RENDERER_PRIORITY.MAIN,
+      })
+      const layer = createLayerFromPlugin(plugin, () => null, 'main')
+      expect(layer.role).toBe('primary')
+    })
+
+    it('drawing name maps to drawing role', () => {
+      const plugin = makeMockPlugin({
+        name: 'drawing-label-overlay',
+        priority: RENDERER_PRIORITY.OVERLAY,
+      })
+      const layer = createLayerFromPlugin(plugin, () => null, 'main')
+      expect(layer.role).toBe('drawing')
+    })
+  })
+})

--- a/packages/core/src/scene/__tests__/layerFromPlugin.test.ts
+++ b/packages/core/src/scene/__tests__/layerFromPlugin.test.ts
@@ -46,6 +46,7 @@ const stubPaintCtx = {
   renderer: {} as unknown as PaintContext['renderer'],
   region: { x: 0, y: 0, width: 800, height: 600, dpr: 2 },
   paneRole: 'main' as const,
+  paneId: 'main',
   frameNumber: 0,
   deltaMs: 16,
 }
@@ -161,6 +162,35 @@ describe('createLayerFromPlugin', () => {
     it('paneRole is sub when targetPaneId is not main', () => {
       const layer = createLayerFromPlugin(makeMockPlugin(), () => null, 'sub')
       expect(layer.paneRole).toBe('sub')
+    })
+
+    it('skips paint when paneRole is sub and ctx.paneId does not match targetPaneId', () => {
+      const plugin = makeMockPlugin()
+      const context = makeMockContext()
+      const getContext = vi.fn(() => context)
+      const layer = createLayerFromPlugin(plugin, getContext, 'RSI_0')
+
+      // Paint with matching paneId → draws
+      layer.paint({ ...stubPaintCtx, paneRole: 'sub', paneId: 'RSI_0' })
+      expect(plugin.draw).toHaveBeenCalledTimes(1)
+
+      // Paint with non-matching paneId → skips
+      layer.paint({ ...stubPaintCtx, paneRole: 'sub', paneId: 'MACD_0' })
+      expect(plugin.draw).toHaveBeenCalledTimes(1)
+    })
+
+    it('main pane layers always paint regardless of paneId', () => {
+      const plugin = makeMockPlugin()
+      const context = makeMockContext()
+      const getContext = vi.fn(() => context)
+      const layer = createLayerFromPlugin(plugin, getContext, 'main')
+
+      layer.paint({ ...stubPaintCtx, paneRole: 'main', paneId: 'main' })
+      expect(plugin.draw).toHaveBeenCalledTimes(1)
+
+      // Main layer paints even with non-matching paneId (it has paneRole 'main')
+      layer.paint({ ...stubPaintCtx, paneRole: 'main', paneId: 'other' })
+      expect(plugin.draw).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/packages/core/src/scene/__tests__/scene.test.ts
+++ b/packages/core/src/scene/__tests__/scene.test.ts
@@ -67,11 +67,12 @@ function makeMockLayer(opts: MockLayerOpts): MockLayer {
 // A minimal Renderer stub. The scene never touches its fields; we cast.
 const stubRenderer = {} as Renderer
 
-function makeCtx(paneRole: PaneRole, frameNumber = 0): PaintContext {
+function makeCtx(paneRole: PaneRole, frameNumber = 0, paneId = 'main'): PaintContext {
   return {
     renderer: stubRenderer,
     region: { x: 0, y: 0, width: 800, height: 600, dpr: 1 },
     paneRole,
+    paneId,
     frameNumber,
     deltaMs: 0,
   }

--- a/packages/core/src/scene/createLayerFromPlugin.ts
+++ b/packages/core/src/scene/createLayerFromPlugin.ts
@@ -1,4 +1,4 @@
-import { GLOBAL_PANE_ID, RENDERER_PRIORITY } from '../plugin'
+import { RENDERER_PRIORITY } from '../plugin'
 import type { RendererPlugin, RenderContext } from '../plugin'
 import type { Layer, LayerRole, PaintContext, PaneRole } from './types'
 
@@ -7,7 +7,7 @@ export function createLayerFromPlugin(
   getContext: () => RenderContext | null,
   targetPaneId: string,
 ): Layer {
-  const paneRole: PaneRole = targetPaneId === 'main' ? 'main' : 'sub'
+  const paneRole: PaneRole = targetPaneId === 'main' ? 'main' : targetPaneId === 'global' ? 'global' : 'sub'
   let visible = plugin.enabled !== false
 
   return {

--- a/packages/core/src/scene/createLayerFromPlugin.ts
+++ b/packages/core/src/scene/createLayerFromPlugin.ts
@@ -1,0 +1,48 @@
+import { GLOBAL_PANE_ID, RENDERER_PRIORITY } from '../plugin'
+import type { RendererPlugin, RenderContext } from '../plugin'
+import type { Layer, LayerRole, PaintContext, PaneRole } from './types'
+
+export function createLayerFromPlugin(
+  plugin: RendererPlugin,
+  getContext: () => RenderContext | null,
+  targetPaneId: string,
+): Layer {
+  const paneRole: PaneRole = targetPaneId === 'main' ? 'main' : 'sub'
+  let visible = plugin.enabled !== false
+
+  return {
+    id: `plugin:${plugin.name}`,
+    role: pluginPriorityToRole(plugin.priority, plugin),
+    paneRole,
+    z: plugin.priority,
+    get visible() {
+      return visible
+    },
+    set visible(v: boolean) {
+      visible = v
+    },
+    paint(_ctx: PaintContext) {
+      if (!visible) return
+      const context = getContext()
+      if (!context) return
+      plugin.draw(context)
+    },
+    dispose() {
+      plugin.onUninstall?.()
+    },
+  }
+}
+
+function pluginPriorityToRole(priority: number, plugin: RendererPlugin): LayerRole {
+  if (plugin.layer === 'overlay') return 'overlay'
+  if (
+    priority <= RENDERER_PRIORITY.GRID ||
+    plugin.name === 'gridLines' ||
+    plugin.name === 'grid'
+  )
+    return 'background'
+  if (priority <= RENDERER_PRIORITY.INDICATOR && plugin.name !== 'candle') return 'indicator'
+  if (plugin.name === 'candle' || plugin.name === 'comparisonLine') return 'primary'
+  if (plugin.name.startsWith('drawing')) return 'drawing'
+  return 'overlay'
+}

--- a/packages/core/src/scene/createLayerFromPlugin.ts
+++ b/packages/core/src/scene/createLayerFromPlugin.ts
@@ -21,8 +21,10 @@ export function createLayerFromPlugin(
     set visible(v: boolean) {
       visible = v
     },
-    paint(_ctx: PaintContext) {
+    paint(ctx: PaintContext) {
       if (!visible) return
+      // For sub-pane layers, skip if we're painting a different sub-pane
+      if (paneRole === 'sub' && ctx.paneId !== targetPaneId) return
       const context = getContext()
       if (!context) return
       plugin.draw(context)
@@ -44,5 +46,5 @@ function pluginPriorityToRole(priority: number, plugin: RendererPlugin): LayerRo
   if (priority <= RENDERER_PRIORITY.INDICATOR && plugin.name !== 'candle') return 'indicator'
   if (plugin.name === 'candle' || plugin.name === 'comparisonLine') return 'primary'
   if (plugin.name.startsWith('drawing')) return 'drawing'
-  return 'overlay'
+  return 'indicator'
 }

--- a/packages/core/src/scene/createScene.ts
+++ b/packages/core/src/scene/createScene.ts
@@ -19,7 +19,7 @@
  */
 
 import { createSignal, type Signal } from '../reactivity/signal'
-import type { Layer, PaintContext, Scene } from './types'
+import type { Layer, LayerRole, PaintContext, Scene } from './types'
 
 export function createScene(): Scene {
   // ---- internal state ----------------------------------------------------
@@ -72,12 +72,17 @@ export function createScene(): Scene {
     return true
   }
 
-  const paintPane = (ctx: PaintContext): void => {
+  const paintPane = (ctx: PaintContext, roles?: ReadonlyArray<LayerRole>): void => {
     if (disposed) return
-    // Filter then stable-sort. Native Array.prototype.sort is required
+    let candidates = layerList.filter(
+      (layer) => (layer.paneRole === ctx.paneRole || layer.paneRole === 'global') && layer.visible,
+    )
+    if (roles) {
+      candidates = candidates.filter((layer) => roles.includes(layer.role))
+    }
+    // Stable-sort by z. Native Array.prototype.sort is required
     // by ECMAScript 2019+ to be stable, so equal z values preserve the
     // surviving registration order from the filter pass.
-    const candidates = layerList.filter((layer) => layer.paneRole === ctx.paneRole && layer.visible)
     candidates.sort((a, b) => a.z - b.z)
     for (const layer of candidates) {
       layer.paint(ctx)

--- a/packages/core/src/scene/index.ts
+++ b/packages/core/src/scene/index.ts
@@ -14,3 +14,5 @@ export { createScene } from './createScene'
 export { createLayerRegistry, BUILTIN_LAYER_TYPES } from './layerRegistry'
 
 export type { LayerFactory, LayerRegistry, BuiltinLayerType } from './layerRegistry'
+
+export { createLayerFromPlugin } from './createLayerFromPlugin'

--- a/packages/core/src/scene/types.ts
+++ b/packages/core/src/scene/types.ts
@@ -51,7 +51,7 @@ export type LayerRole =
  * — the Layer / Scene contract here does not pre-commit a multi-sub-pane
  * scheme on purpose.
  */
-export type PaneRole = 'main' | 'sub'
+export type PaneRole = 'main' | 'sub' | 'global'
 
 /**
  * Stateless paint context handed to each layer per frame.
@@ -136,8 +136,11 @@ export interface Scene {
   getLayer(id: string): Layer | null
   setLayerVisibility(id: string, visible: boolean): boolean
 
-  /** paint layers for one pane in z-order, then by registration order */
-  paintPane(ctx: PaintContext): void
+  /**
+   * paint layers for one pane in z-order, then by registration order
+   * @param roles - if provided, only paint layers whose role is in this list
+   */
+  paintPane(ctx: PaintContext, roles?: ReadonlyArray<LayerRole>): void
 
   dispose(): void
 }

--- a/packages/core/src/scene/types.ts
+++ b/packages/core/src/scene/types.ts
@@ -77,6 +77,8 @@ export interface PaintContext {
   renderer: Renderer
   region: SurfaceRegion
   paneRole: PaneRole
+  /** The pane id being painted (e.g. 'main', 'RSI_0') — used by sub-pane layers */
+  paneId: string
   /** monotonically increasing frame counter for animation/timing */
   frameNumber: number
   /** time elapsed since last frame in ms (for animations) */


### PR DESCRIPTION
### Summary

Migrates 8 built-in Canvas2D renderers to the Scene Layer architecture and introduces WebGL rendering via bridge adapters, forming a unified rendering pipeline.

### Changes

#### Scene/Layer Migration
- **Base renderers → Layers**: Migrated 8 built-in renderers (Candle, Volume, MA, BOLL, SAR, KD, MACD, RSI) to bridge-based layer architecture
- **Sub-indicators**: Further sub-indicator renderers migrated to bridge layers
- **Remaining plugins**: All remaining plugin renderers migrated
- **Canvas2D fix**: Removed errant bridge layer registration for Canvas2D-only plugins; fixed overlay layer filtering

#### WebGL Pipeline
- **WebGL SurfaceBackend**: New adapter wrapping \SharedWebGLSurface\
- **WebGL Renderer**: \createWebGLRenderer\ adapter for WebGL-based rendering
- **Bridge adapter**: \createLayerFromPlugin\ bridges existing plugins into the scene as layers
- **Chart integration**: WebGL Renderer connected to Scene pipeline

### Details

The new Scene pipeline introduces a layer-based rendering model where each renderer registers as a \Layer\ on a \Scene\ object. The Scene manages z-ordering, visibility, and compositing. Bridge adapters allow existing plugin-style renderers to participate without rewriting their rendering logic.

WebGL support is provided through a SurfaceBackend pattern that wraps \SharedWebGLSurface\ and exposes it through a standardized \createWebGLRenderer\ API, enabling GPU-accelerated rendering alongside the Canvas2D pipeline.