### PR TITLE
feat: rename KlineChart, add SymbolSpec.incremental, migrate to Scene pipeline

### DIFF
--- a/examples/vue-test/src/App.vue
+++ b/examples/vue-test/src/App.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="app-container" :data-theme="currentTheme">
-    <KLineChart v-model:theme="currentTheme" :custom-data="customData" />
+    <KlineChart v-model:theme="currentTheme" :custom-data="customData" />
   </div>
 </template>
 
 <script setup lang="ts">
   import { ref } from 'vue'
-  import { CustomDataSource, KLineChartVue as KLineChart } from '@363045841yyt/klinechart'
+  import { CustomDataSource, KlineChart } from '@363045841yyt/klinechart'
   import demoData from './demo-data.json'
 
   const currentTheme = ref<'light' | 'dark'>('dark')

--- a/examples/vue-test/src/App.vue
+++ b/examples/vue-test/src/App.vue
@@ -1,36 +1,28 @@
 <template>
   <div class="app-container" :data-theme="currentTheme">
-    <KLineChart
-      v-model:theme="currentTheme"
-      :custom-data="customData"
-    />
+    <KLineChart v-model:theme="currentTheme" :custom-data="customData" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { CustomDataSource, KLineChart } from '@363045841yyt/klinechart'
-import demoData from './demo-data.json'
+  import { ref } from 'vue'
+  import { CustomDataSource, KLineChartVue as KLineChart } from '@363045841yyt/klinechart'
+  import demoData from './demo-data.json'
 
-const currentTheme = ref<'light' | 'dark'>('dark')
+  const currentTheme = ref<'light' | 'dark'>('dark')
 
-const customData = ref<CustomDataSource>(demoData as CustomDataSource)
+  const customData = ref<CustomDataSource>(demoData as CustomDataSource)
 </script>
 
 <style>
-body {
-  margin: 0;
-}
+  .app-container {
+    display: flex;
+    flex-direction: column;
+    height: 80vh;
+  }
 
-.app-container {
-  width: 100%;
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.app-container[data-theme='dark'] {
-  background: #000;
-  color: #e5e7eb;
-}
+  .app-container[data-theme='dark'] {
+    background: #000;
+    color: #e5e7eb;
+  }
 </style>

--- a/packages/angular/src/__tests__/_mockController.ts
+++ b/packages/angular/src/__tests__/_mockController.ts
@@ -22,6 +22,7 @@ import type {
   PaneSpec,
   SubPaneInfo,
   SymbolSpec,
+  SymbolInfo,
 } from '@363045841yyt/klinechart-core'
 
 export interface MockControllerHandle {
@@ -184,7 +185,11 @@ export function createMockChartController(
     getLeftLoadBufferWidth() {
       return 0
     },
+    symbolCatalog: createSignal([] as ReadonlyArray<SymbolInfo>),
     setSymbols() {
+      /* no-op */
+    },
+    registerSymbols() {
       /* no-op */
     },
     addComparisonSymbol() {

--- a/packages/core/src/__tests__/depthPipeline.test.ts
+++ b/packages/core/src/__tests__/depthPipeline.test.ts
@@ -31,17 +31,16 @@ function snapshotMsg(
   return { data: JSON.stringify({ type: 'snapshot', bids, asks, timestamp }) }
 }
 
-function deltaMsg(entries: { side: 'bid' | 'ask'; price: number; size: number; timestamp: number }[]) {
+function deltaMsg(
+  entries: { side: 'bid' | 'ask'; price: number; size: number; timestamp: number }[],
+) {
   return { data: JSON.stringify({ type: 'delta', entries }) }
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-function makeController(
-  snapshotIntervalMs = 100,
-  tickSize = 0.01,
-): HeatmapController {
+function makeController(snapshotIntervalMs = 100, tickSize = 0.01): HeatmapController {
   return createHeatmapController({
     tickSize,
     snapshotIntervalMs,
@@ -88,12 +87,30 @@ describe('depth pipeline: BinanceSSESource → DepthConnector → HeatmapControl
     const { connector, ctrl, es } = wired()
 
     // --- Step 1: snapshot resets the book ---
-    es.onmessage!(snapshotMsg([[100, 10], [99, 5]], [[101, 8], [102, 3]], 1000))
+    es.onmessage!(
+      snapshotMsg(
+        [
+          [100, 10],
+          [99, 5],
+        ],
+        [
+          [101, 8],
+          [102, 3],
+        ],
+        1000,
+      ),
+    )
     let st = ctrl.state.peek()
     expect(st.latestSnapshot).not.toBeNull()
     // Book is populated from snapshot
-    expect(st.latestSnapshot!.bids).toEqual([[100, 10], [99, 5]])
-    expect(st.latestSnapshot!.asks).toEqual([[101, 8], [102, 3]])
+    expect(st.latestSnapshot!.bids).toEqual([
+      [100, 10],
+      [99, 5],
+    ])
+    expect(st.latestSnapshot!.asks).toEqual([
+      [101, 8],
+      [102, 3],
+    ])
     // Ring and archive are cleared
     expect(st.snapshotCount).toBe(0)
     expect(st.deltaCount).toBe(0)
@@ -102,12 +119,18 @@ describe('depth pipeline: BinanceSSESource → DepthConnector → HeatmapControl
     es.onmessage!(deltaMsg([{ side: 'bid', price: 100, size: 15, timestamp: 1000 }]))
     st = ctrl.state.peek()
     // latestSnapshot hasn't changed (first delta doesn't emit one)
-    expect(st.latestSnapshot!.bids).toEqual([[100, 10], [99, 5]])
+    expect(st.latestSnapshot!.bids).toEqual([
+      [100, 10],
+      [99, 5],
+    ])
     expect(st.snapshotCount).toBe(0)
     expect(st.deltaCount).toBe(1)
     // But the book was updated — verify via forceSnapshot
     ctrl.forceSnapshot()
-    expect(ctrl.state.peek().latestSnapshot!.bids).toEqual([[100, 15], [99, 5]])
+    expect(ctrl.state.peek().latestSnapshot!.bids).toEqual([
+      [100, 15],
+      [99, 5],
+    ])
 
     // --- Step 3: second delta crosses snapshotIntervalMs (100ms) → one snapshot ---
     es.onmessage!(deltaMsg([{ side: 'ask', price: 101, size: 0, timestamp: 1100 }]))
@@ -116,7 +139,10 @@ describe('depth pipeline: BinanceSSESource → DepthConnector → HeatmapControl
     expect(st.snapshotCount).toBe(2) // previous forceSnapshot + 1
     expect(st.deltaCount).toBe(2)
     // Snapshot captured book BEFORE the delta was applied (101 is still present)
-    expect(st.latestSnapshot!.asks).toEqual([[101, 8], [102, 3]])
+    expect(st.latestSnapshot!.asks).toEqual([
+      [101, 8],
+      [102, 3],
+    ])
 
     // --- Step 4: more deltas produce more snapshots ---
     es.onmessage!(deltaMsg([{ side: 'bid', price: 99, size: 0, timestamp: 1250 }]))

--- a/packages/core/src/components/orderBookHeatmap/__tests__/controller.test.ts
+++ b/packages/core/src/components/orderBookHeatmap/__tests__/controller.test.ts
@@ -249,7 +249,10 @@ describe('createHeatmapController', () => {
       expect(ctrl.state.peek().deltaCount).toBe(2)
 
       const snap: BookSnapshot = {
-        bids: [[99, 10], [98, 5]],
+        bids: [
+          [99, 10],
+          [98, 5],
+        ],
         asks: [[101, 8]],
         timestamp: 500,
       }
@@ -258,7 +261,10 @@ describe('createHeatmapController', () => {
       const st = ctrl.state.peek()
       expect(st.snapshotCount).toBe(0)
       expect(st.deltaCount).toBe(0)
-      expect(st.latestSnapshot?.bids).toEqual([[99, 10], [98, 5]])
+      expect(st.latestSnapshot?.bids).toEqual([
+        [99, 10],
+        [98, 5],
+      ])
       expect(st.latestSnapshot?.asks).toEqual([[101, 8]])
       expect(st.latestSnapshot?.timestamp).toBe(500)
       ctrl.dispose()

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -29,6 +29,7 @@ import type {
   PaneLayoutInfo,
   PaneSpec,
   SymbolSpec,
+  SymbolInfo,
   DataFetcher,
   CustomDataSource,
 } from './types'
@@ -422,6 +423,9 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
   >(new Map())
   const comparisonLoading: Signal<boolean> = createSignal(false)
 
+  // symbolCatalog — bridge from Chart's data manager
+  const symbolCatalog: Signal<ReadonlyArray<SymbolInfo>> = chart.symbolCatalog
+
   // -------------------------------------------------------------------
   // Apply initial render state + seed data
   // -------------------------------------------------------------------
@@ -579,6 +583,11 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
   function switchToTimeShareForDate(dateYYYYMMDD: number): void {
     if (disposed) return
     chart.switchToTimeShareForDate(dateYYYYMMDD)
+  }
+
+  function registerSymbols(infos: ReadonlyArray<SymbolInfo>): void {
+    if (disposed) return
+    chart.registerSymbols(infos)
   }
 
   function applyCustomData(source: CustomDataSource): void {
@@ -932,9 +941,11 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
     interactionState,
     comparisonColors,
     comparisonLoading,
+    symbolCatalog,
     catalog: DEFAULT_INDICATOR_CATALOG,
     alertController: chart.alertController,
     setSymbols,
+    registerSymbols,
     addComparisonSymbol,
     removeComparisonSymbol,
     setComparisonData,

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -67,7 +67,13 @@ export {
   DEFAULT_BINANCE_SSE_URL,
   DepthConnector,
 } from '../data-fetchers'
-export type { DataWindow, DepthSource, DepthDelta, DepthSnapshot, DepthSourceStatus } from '../data-fetchers'
+export type {
+  DataWindow,
+  DepthSource,
+  DepthDelta,
+  DepthSnapshot,
+  DepthSourceStatus,
+} from '../data-fetchers'
 
 // Heatmap controller (depth pipeline rendering half)
 export { createHeatmapController } from '../components/orderBookHeatmap'

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -27,6 +27,7 @@ export type {
   DrawingChartViewport,
   PaneLayoutInfo,
   SymbolSpec,
+  SymbolInfo,
   DataFetcher,
   CustomDataSource,
 } from './types'

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -106,6 +106,13 @@ export interface SymbolSpec {
   source?: string
   startDate?: string
   endDate?: string
+  /**
+   * Whether incremental loading is supported for this symbol.
+   * When false, the data buffer will not fetch additional data
+   * beyond what was initially provided (e.g. via setInlineData).
+   * Defaults to true when not set.
+   */
+  incremental?: boolean
 }
 
 export type DataFetcher = (

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -87,6 +87,14 @@ export interface TimeShareData {
 export type { PaneSpec }
 
 // ---------------------------------------------------------------------------
+/** Registered symbol metadata — for the symbol catalog/dropdown UI */
+export interface SymbolInfo {
+  code: string
+  description?: string
+  exchange?: string
+  source?: string
+}
+
 // Symbol specification & DataFetcher adapter
 // ---------------------------------------------------------------------------
 
@@ -117,6 +125,12 @@ export interface CustomDataSource {
   symbol?: string
   period?: string
   adjust?: string
+  /** Display description for the symbol catalog (defaults to symbol code) */
+  description?: string
+  /** Exchange code for the symbol catalog */
+  exchange?: string
+  /** Data source label for the symbol catalog */
+  source?: string
   /** Main chart K-line data (required) */
   data: ReadonlyArray<KLineData>
   /** Comparison products keyed by symbol */
@@ -268,6 +282,9 @@ export interface ChartController extends DrawingChartAdapter {
   readonly comparisonColors: Signal<ReadonlyMap<string, string>>
   readonly comparisonLoading: Signal<boolean>
 
+  /** Registered symbol catalog — adapters use for picker UI */
+  readonly symbolCatalog: Signal<ReadonlyArray<SymbolInfo>>
+
   // indicator catalog (static — adapters use for picker UI)
   readonly catalog: ReadonlyArray<IndicatorDefinition>
 
@@ -276,6 +293,8 @@ export interface ChartController extends DrawingChartAdapter {
 
   // ---- Data ----
   setSymbols(next: ReadonlyArray<SymbolSpec>): void
+  /** Register symbols into the available symbol catalog for UI pickers */
+  registerSymbols(symbols: ReadonlyArray<SymbolInfo>): void
   addComparisonSymbol(spec: SymbolSpec): void
   removeComparisonSymbol(symbol: string): void
   /** Inject comparison product data directly (bypasses fetcher) */

--- a/packages/core/src/data-fetchers/__tests__/depthConnector.test.ts
+++ b/packages/core/src/data-fetchers/__tests__/depthConnector.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { DepthConnector } from '../depthConnector'
-import type {
-  DepthDelta,
-  DepthSnapshot,
-  DepthSource,
-  DepthSourceStatus,
-} from '../depthTypes'
+import type { DepthDelta, DepthSnapshot, DepthSource, DepthSourceStatus } from '../depthTypes'
 import type { HeatmapController, HeatmapControllerConfig } from '../../components/orderBookHeatmap'
 
 // ---------------------------------------------------------------------------
@@ -74,7 +69,9 @@ function createFakeSource(): DepthSource & {
 // ---------------------------------------------------------------------------
 // Fake HeatmapController
 // ---------------------------------------------------------------------------
-function createFakeController(): HeatmapController & { calls: { ingest: DepthDelta[]; resetBook: DepthSnapshot[] } } {
+function createFakeController(): HeatmapController & {
+  calls: { ingest: DepthDelta[]; resetBook: DepthSnapshot[] }
+} {
   const calls: { ingest: DepthDelta[]; resetBook: DepthSnapshot[] } = {
     ingest: [],
     resetBook: [],

--- a/packages/core/src/data-fetchers/binance.ts
+++ b/packages/core/src/data-fetchers/binance.ts
@@ -73,7 +73,7 @@ export class BinanceSSESource implements DepthSource {
     this.es.onmessage = (event: MessageEvent) => {
       if (this.destroyed) return
       const raw = event.data as string
-      if (raw === '' || raw.startsWith(':')) return  // keepalive
+      if (raw === '' || raw.startsWith(':')) return // keepalive
 
       try {
         const msg = JSON.parse(raw) as {
@@ -98,7 +98,10 @@ export class BinanceSSESource implements DepthSource {
         const err =
           e instanceof KLineChartError
             ? e
-            : new KLineChartError('DEPTH_SOURCE_ERROR', `BinanceSSE parse error: ${(e as Error).message}`)
+            : new KLineChartError(
+                'DEPTH_SOURCE_ERROR',
+                `BinanceSSE parse error: ${(e as Error).message}`,
+              )
         for (const cb of this.errorCbs) cb(err)
       }
     }

--- a/packages/core/src/data-fetchers/dataBuffer.ts
+++ b/packages/core/src/data-fetchers/dataBuffer.ts
@@ -130,6 +130,7 @@ export class DataBuffer implements DataBufferLike {
 
   ensureRange(requestStartTs: number, _requestEndTs: number): void {
     if (this._disposed || (!this._requestFetch && !this._fetcher) || !this._currentSpec) return
+    if (this._currentSpec.incremental === false) return
     if (!this._loadedWindow) return
 
     if (requestStartTs >= this._loadedWindow.earliestTs) return
@@ -160,6 +161,7 @@ export class DataBuffer implements DataBufferLike {
 
   private fetchRange(startTs: number, endTs: number): void {
     if ((!this._requestFetch && !this._fetcher) || !this._currentSpec || this._disposed) return
+    if (this._currentSpec.incremental === false) return
 
     if (this._pendingFetch) {
       this._pendingFetch = this._pendingFetch.then(() => {

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -327,8 +327,7 @@ export class Chart {
       setPendingIndicatorDataUpdate: (v) => {
         this.dataManager.pendingIndicatorDataUpdate = v
       },
-      getRenderContext: (paneId) =>
-        this.renderer?.getPaneCtxMap()?.get(paneId) ?? null,
+      getRenderContext: (paneId) => this.renderer?.getPaneCtxMap()?.get(paneId) ?? null,
       addLayer: (layer) => this.renderer?.getScene()?.addLayer(layer),
       removeLayer: (id) => this.renderer?.getScene()?.removeLayer(id) ?? false,
       getLayer: (id) => this.renderer?.getScene()?.getLayer(id) ?? null,

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -1,7 +1,7 @@
 import type { KLineData } from '../types/price'
 import type { ChartSettings } from '../config/chartSettings'
 import { createSignal, type Signal, type Computed } from '../reactivity/signal'
-import type { SymbolSpec, CustomDataSource } from '../controllers/types'
+import type { SymbolSpec, SymbolInfo, CustomDataSource } from '../controllers/types'
 import { ChartDataManager } from './data/chartDataManager'
 import { ChartPaneLayout } from './layout/chartPaneLayout'
 import { UpdateLevel, type VisibleRange } from './layout/pane'
@@ -1014,6 +1014,16 @@ export class Chart {
   /** 符号信号 */
   get symbols(): Signal<ReadonlyArray<SymbolSpec>> {
     return this.dataManager.symbols
+  }
+
+  /** 可用品种目录信号 — 供 UI 品种选择器消费 */
+  get symbolCatalog(): Signal<ReadonlyArray<SymbolInfo>> {
+    return this.dataManager.symbolCatalog
+  }
+
+  /** 注册品种到可用目录 */
+  registerSymbols(infos: ReadonlyArray<SymbolInfo>): void {
+    this.dataManager.registerSymbols(infos)
   }
 
   /** 比较商品颜色信号 */

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -913,6 +913,15 @@ export class ChartDataManager {
     this.activateBuffer(bufKey(BUF_PRIMARY, spec.symbol, spec.period!))
     if (!this._dataFetcher) return
 
+    // Buffer already has data (e.g. from a previous applyCustomData setInlineData call)
+    // → just update the spec metadata, skip fetch to avoid clearing inline data.
+    if (buf.getRawData().length > 0) {
+      buf.setCurrentSpec(spec)
+      this.deps.resetInteraction()
+      this.scrollToRight()
+      return
+    }
+
     buf.onPrepend = (count: number) => {
       this.pendingPrependedCount = count
       const dpr = this.deps.getEffectiveDpr()

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -1,5 +1,5 @@
 import type { KLineData, TimeShareData } from '../../types/price'
-import type { SymbolSpec, DataFetcher, CustomDataSource } from '../../controllers/types'
+import type { SymbolSpec, SymbolInfo, DataFetcher, CustomDataSource } from '../../controllers/types'
 import { createSignal, type Signal } from '../../reactivity/signal'
 import { DataBuffer } from '../../data-fetchers/dataBuffer'
 import { getPeriodDays } from '../../data-fetchers/dataBuffer.effects'
@@ -56,6 +56,8 @@ export class ChartDataManager {
   private _dataSignal = createSignal<ReadonlyArray<unknown>>([])
   private _loadingSignal = createSignal<boolean>(false)
   private _symbolsSignal = createSignal<ReadonlyArray<SymbolSpec>>([])
+  /** Available symbol catalog — consumed by UI pickers (e.g. TopToolbar) */
+  private _symbolCatalog = createSignal<ReadonlyArray<SymbolInfo>>([])
 
   private _currentSpec: SymbolSpec | null = null
 
@@ -365,6 +367,28 @@ export class ChartDataManager {
 
   get symbols(): Signal<ReadonlyArray<SymbolSpec>> {
     return this._symbolsSignal
+  }
+
+  get symbolCatalog(): Signal<ReadonlyArray<SymbolInfo>> {
+    return this._symbolCatalog
+  }
+
+  /**
+   * Register symbols into the available catalog.
+   * Deduplicates by symbol code: newer entries replace older ones.
+   */
+  registerSymbols(infos: ReadonlyArray<SymbolInfo>): void {
+    const current = new Map(this._symbolCatalog.peek().map((s) => [s.code, s]))
+    for (const info of infos) current.set(info.code, info)
+    this._symbolCatalog.set(Array.from(current.values()))
+  }
+
+  /** Remove a symbol from the catalog by code. */
+  unregisterSymbol(code: string): void {
+    const next = this._symbolCatalog.peek().filter((s) => s.code !== code)
+    if (next.length < this._symbolCatalog.peek().length) {
+      this._symbolCatalog.set(next)
+    }
   }
 
   get currentPeriod(): string {
@@ -791,16 +815,23 @@ export class ChartDataManager {
   }
 
   applyCustomData(source: CustomDataSource): void {
-    if (source.symbol) this.setCurrentSymbol(source.symbol)
-    if (source.period) this.setCurrentPeriod(source.period)
+    const spec: SymbolSpec = {
+      symbol: source.symbol ?? this._currentSpec?.symbol ?? '',
+      period: source.period ?? this._currentSpec?.period ?? 'daily',
+    }
+    this.setSymbols([spec, ...this._comparisonSpecs])
 
-    const specs = this._symbolsSignal.peek()
-    if (specs.length === 0 && source.symbol) {
-      const mainSpec: SymbolSpec = {
-        symbol: source.symbol,
-        period: source.period ?? 'daily',
-      }
-      this._symbolsSignal.set([mainSpec])
+    // Auto-register the custom symbol into the available catalog so it appears in UI pickers.
+    const symbolCode = spec.symbol
+    if (symbolCode) {
+      this.registerSymbols([
+        {
+          code: symbolCode,
+          description: source.description ?? symbolCode,
+          exchange: source.exchange ?? '',
+          source: source.source ?? 'custom',
+        },
+      ])
     }
 
     const plainData = source.data.map((d) => ({ ...d }))

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -818,6 +818,7 @@ export class ChartDataManager {
     const spec: SymbolSpec = {
       symbol: source.symbol ?? this._currentSpec?.symbol ?? '',
       period: source.period ?? this._currentSpec?.period ?? 'daily',
+      incremental: false,
     }
     this.setSymbols([spec, ...this._comparisonSpecs])
 
@@ -911,12 +912,20 @@ export class ChartDataManager {
 
     const buf = this.getPrimaryDataBuffer(spec.symbol, spec.period!)
     this.activateBuffer(bufKey(BUF_PRIMARY, spec.symbol, spec.period!))
-    if (!this._dataFetcher) return
+    if (!this._dataFetcher) {
+      buf.setCurrentSpec(spec)
+      return
+    }
 
     // Buffer already has data (e.g. from a previous applyCustomData setInlineData call)
     // → just update the spec metadata, skip fetch to avoid clearing inline data.
+    // Preserve the buffer's existing incremental flag so inline data sources
+    // (which use incremental:false) remain non-fetching even after a symbol switch.
     if (buf.getRawData().length > 0) {
-      buf.setCurrentSpec(spec)
+      buf.setCurrentSpec({
+        ...spec,
+        incremental: spec.incremental ?? buf.currentSpec?.incremental ?? true,
+      })
       this.deps.resetInteraction()
       this.scrollToRight()
       return

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -374,7 +374,9 @@ export class ChartDataManager {
   /** Internal KLine data for indicator scheduler (empty in timeshare mode) */
   getInternalData(): KLineData[] {
     const buf = this.getActiveDataBuffer()
-    return buf ? buf.getRawData() : []
+    if (buf) return buf.getRawData()
+    const peek = this._dataSignal.peek()
+    return peek.length > 0 ? (peek as KLineData[]) : []
   }
 
   getRenderData(): unknown[] {
@@ -875,10 +877,10 @@ export class ChartDataManager {
   private loadKLineSymbols(specs: ReadonlyArray<SymbolSpec>): void {
     const spec = specs[0]!
     this.syncComparisonBuffers(specs.slice(1))
-    if (!this._dataFetcher) return
 
     const buf = this.getPrimaryDataBuffer(spec.symbol, spec.period!)
     this.activateBuffer(bufKey(BUF_PRIMARY, spec.symbol, spec.period!))
+    if (!this._dataFetcher) return
 
     buf.onPrepend = (count: number) => {
       this.pendingPrependedCount = count

--- a/packages/core/src/engine/indicators/chartIndicatorManager.ts
+++ b/packages/core/src/engine/indicators/chartIndicatorManager.ts
@@ -9,7 +9,12 @@ import { getRegisteredIndicatorDefinitions } from './indicatorDefinitionRegistry
 import { SubPaneManager, type SubPaneEntry, type SubPaneContext } from '../subPaneManager'
 import { createSubIndicatorRenderer, type SubIndicatorType } from '../renderers/Indicator'
 import { createMainIndicatorLegendRendererPlugin } from '../renderers/Indicator/mainIndicatorLegend'
-import type { PluginHostImpl, RendererPlugin, RendererPluginWithHost, RenderContext } from '../../plugin'
+import type {
+  PluginHostImpl,
+  RendererPlugin,
+  RendererPluginWithHost,
+  RenderContext,
+} from '../../plugin'
 import type { Layer } from '../../scene/types'
 import { createLayerFromPlugin } from '../../scene/createLayerFromPlugin'
 
@@ -351,11 +356,7 @@ export class ChartIndicatorManager {
       // disable old rendering to avoid double rendering (scene handles it)
       this.deps.setRendererEnabled(rendererName, false)
       // create bridge layer and add to scene
-      const layer = createLayerFromPlugin(
-        plugin,
-        () => this.deps.getRenderContext('main'),
-        'main',
-      )
+      const layer = createLayerFromPlugin(plugin, () => this.deps.getRenderContext('main'), 'main')
       this.deps.addLayer(layer)
     }
 
@@ -445,11 +446,7 @@ export class ChartIndicatorManager {
 
     this.deps.useRenderer(renderer, params)
     this.deps.setRendererEnabled(rendererName, false)
-    const layer = createLayerFromPlugin(
-      renderer,
-      () => this.deps.getRenderContext(paneId),
-      paneId,
-    )
+    const layer = createLayerFromPlugin(renderer, () => this.deps.getRenderContext(paneId), paneId)
     this.deps.addLayer(layer)
   }
 

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -145,11 +145,7 @@ export class ChartRenderer {
           return null
         },
       })
-      this.timeAxisLayer = createLayerFromPlugin(
-        plugin,
-        () => this.timeAxisCtx,
-        'global',
-      )
+      this.timeAxisLayer = createLayerFromPlugin(plugin, () => this.timeAxisCtx, 'global')
     }
 
     const getCtx = (paneId: string) => () => this.paneCtxMap.get(paneId) ?? null
@@ -858,5 +854,4 @@ export class ChartRenderer {
     this.scene.dispose()
     this.paneCtxMap.clear()
   }
-
 }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -859,7 +859,4 @@ export class ChartRenderer {
     this.paneCtxMap.clear()
   }
 
-  getScene(): Scene {
-    return this.scene
-  }
 }

--- a/packages/core/src/engine/render/layers/candleLayer.ts
+++ b/packages/core/src/engine/render/layers/candleLayer.ts
@@ -3,9 +3,7 @@ import type { Layer } from '../../../scene/types'
 import type { RenderContext } from '../../../plugin'
 import { createCandleRenderer } from '../../renderers/candle'
 
-export function createCandleLayer(
-  getContext: () => RenderContext | null,
-): Layer {
+export function createCandleLayer(getContext: () => RenderContext | null): Layer {
   const plugin = createCandleRenderer()
   return createLayerFromPlugin(plugin, getContext, 'main')
 }

--- a/packages/core/src/engine/render/layers/comparisonLineLayer.ts
+++ b/packages/core/src/engine/render/layers/comparisonLineLayer.ts
@@ -3,9 +3,7 @@ import type { Layer } from '../../../scene/types'
 import type { RenderContext } from '../../../plugin'
 import { createComparisonLineRenderer } from '../../renderers/comparisonLine'
 
-export function createComparisonLineLayer(
-  getContext: () => RenderContext | null,
-): Layer {
+export function createComparisonLineLayer(getContext: () => RenderContext | null): Layer {
   const plugin = createComparisonLineRenderer()
   return createLayerFromPlugin(plugin, getContext, 'main')
 }

--- a/packages/core/src/engine/render/layers/customMarkersLayer.ts
+++ b/packages/core/src/engine/render/layers/customMarkersLayer.ts
@@ -3,8 +3,6 @@ import type { Layer } from '../../../scene/types'
 import type { RenderContext } from '../../../plugin'
 import { createCustomMarkersRenderer } from '../../renderers/customMarkers'
 
-export function createCustomMarkersLayer(
-  getContext: () => RenderContext | null,
-): Layer {
+export function createCustomMarkersLayer(getContext: () => RenderContext | null): Layer {
   return createLayerFromPlugin(createCustomMarkersRenderer(), getContext, 'global')
 }

--- a/packages/core/src/engine/render/layers/extremaMarkersLayer.ts
+++ b/packages/core/src/engine/render/layers/extremaMarkersLayer.ts
@@ -3,8 +3,6 @@ import type { Layer } from '../../../scene/types'
 import type { RenderContext } from '../../../plugin'
 import { createExtremaMarkersRendererPlugin } from '../../renderers/extremaMarkers'
 
-export function createExtremaMarkersLayer(
-  getContext: () => RenderContext | null,
-): Layer {
+export function createExtremaMarkersLayer(getContext: () => RenderContext | null): Layer {
   return createLayerFromPlugin(createExtremaMarkersRendererPlugin(), getContext, 'global')
 }

--- a/packages/core/src/engine/render/layers/gridLinesLayer.ts
+++ b/packages/core/src/engine/render/layers/gridLinesLayer.ts
@@ -3,8 +3,6 @@ import type { Layer } from '../../../scene/types'
 import type { RenderContext } from '../../../plugin'
 import { createGridLinesRendererPlugin } from '../../renderers/gridLines'
 
-export function createGridLinesLayer(
-  getContext: () => RenderContext | null,
-): Layer {
+export function createGridLinesLayer(getContext: () => RenderContext | null): Layer {
   return createLayerFromPlugin(createGridLinesRendererPlugin(), getContext, 'global')
 }

--- a/packages/core/src/engine/render/layers/lastPriceLabelLayer.ts
+++ b/packages/core/src/engine/render/layers/lastPriceLabelLayer.ts
@@ -3,8 +3,6 @@ import type { Layer } from '../../../scene/types'
 import type { RenderContext } from '../../../plugin'
 import { createLastPriceLabelRegistrarPlugin } from '../../renderers/lastPrice'
 
-export function createLastPriceLabelLayer(
-  getContext: () => RenderContext | null,
-): Layer {
+export function createLastPriceLabelLayer(getContext: () => RenderContext | null): Layer {
   return createLayerFromPlugin(createLastPriceLabelRegistrarPlugin(), getContext, 'main')
 }

--- a/packages/core/src/engine/render/layers/lastPriceLineLayer.ts
+++ b/packages/core/src/engine/render/layers/lastPriceLineLayer.ts
@@ -3,9 +3,7 @@ import type { Layer } from '../../../scene/types'
 import type { RenderContext } from '../../../plugin'
 import { createLastPriceLineRendererPlugin } from '../../renderers/lastPrice'
 
-export function createLastPriceLineLayer(
-  getContext: () => RenderContext | null,
-): Layer {
+export function createLastPriceLineLayer(getContext: () => RenderContext | null): Layer {
   const plugin = createLastPriceLineRendererPlugin()
   return createLayerFromPlugin(plugin, getContext, 'main')
 }

--- a/packages/core/src/engine/renderers/extremaMarkers.ts
+++ b/packages/core/src/engine/renderers/extremaMarkers.ts
@@ -124,6 +124,7 @@ export function createExtremaMarkersRendererPlugin(): RendererPlugin {
       const klineData = data as KLineData[]
       if (!klineData.length) return
       if (pane.role !== 'price') return
+      if (!ctx) return
 
       const start = Math.max(0, range.start)
       const end = Math.min(klineData.length, range.end)

--- a/packages/core/src/engine/subPaneManager.ts
+++ b/packages/core/src/engine/subPaneManager.ts
@@ -87,11 +87,7 @@ export class SubPaneManager {
     if (!existingRenderer) {
       ctx.useRenderer(renderer, params as Record<string, number | boolean | string>)
       ctx.setRendererEnabled(rendererName, false)
-      const layer = createLayerFromPlugin(
-        renderer,
-        () => ctx.getRenderContext(paneId),
-        paneId,
-      )
+      const layer = createLayerFromPlugin(renderer, () => ctx.getRenderContext(paneId), paneId)
       ctx.addLayer(layer)
     }
 
@@ -169,11 +165,7 @@ export class SubPaneManager {
 
     ctx.useRenderer(renderer, newParams as Record<string, number | boolean | string>)
     ctx.setRendererEnabled(newRendererName, false)
-    const layer = createLayerFromPlugin(
-      renderer,
-      () => ctx.getRenderContext(paneId),
-      paneId,
-    )
+    const layer = createLayerFromPlugin(renderer, () => ctx.getRenderContext(paneId), paneId)
     ctx.addLayer(layer)
 
     this.mountScaleRenderer(ctx, paneId, newIndicatorId, newScaleRendererName)
@@ -298,11 +290,7 @@ export class SubPaneManager {
       const plugin = definition.scaleRendererFactory({ ...opts, indicatorId })
       ctx.useRenderer(plugin)
       ctx.setRendererEnabled(scaleRendererName, false)
-      const layer = createLayerFromPlugin(
-        plugin,
-        () => ctx.getRenderContext(paneId),
-        paneId,
-      )
+      const layer = createLayerFromPlugin(plugin, () => ctx.getRenderContext(paneId), paneId)
       ctx.addLayer(layer)
       return
     }
@@ -316,11 +304,7 @@ export class SubPaneManager {
       })
       ctx.useRenderer(plugin)
       ctx.setRendererEnabled(scaleRendererName, false)
-      const layer = createLayerFromPlugin(
-        plugin,
-        () => ctx.getRenderContext(paneId),
-        paneId,
-      )
+      const layer = createLayerFromPlugin(plugin, () => ctx.getRenderContext(paneId), paneId)
       ctx.addLayer(layer)
       return
     }
@@ -348,11 +332,7 @@ export class SubPaneManager {
     })
     ctx.useRenderer(renderer)
     ctx.setRendererEnabled(rendererName, false)
-    const layer = createLayerFromPlugin(
-      renderer,
-      () => ctx.getRenderContext(paneId),
-      paneId,
-    )
+    const layer = createLayerFromPlugin(renderer, () => ctx.getRenderContext(paneId), paneId)
     ctx.addLayer(layer)
   }
 }

--- a/packages/core/src/render/__tests__/webglRenderer.fallback.test.ts
+++ b/packages/core/src/render/__tests__/webglRenderer.fallback.test.ts
@@ -43,7 +43,7 @@ function createMockSharedWebGLSurface() {
   return {
     isAvailable: vi.fn(() => false),
     getGL: vi.fn(() => null),
-    getCanvas: vi.fn(() => ({ width: 0, height: 0 } as HTMLCanvasElement)),
+    getCanvas: vi.fn(() => ({ width: 0, height: 0 }) as HTMLCanvasElement),
     resize: vi.fn(),
     bindRegion: vi.fn(() => false),
     clearRegion: vi.fn(),
@@ -149,9 +149,7 @@ describe('Canvas2D fallback', () => {
 
       const pipeline = renderer.createPipeline({ type: 'fill' })
       const vertexBuf = renderer.createBuffer('vertex', 256)
-      const verts = new Float32Array([
-        0, 100, 0, 50, 100, 100, 100, 50, 200, 100, 200, 50,
-      ])
+      const verts = new Float32Array([0, 100, 0, 50, 100, 100, 100, 50, 200, 100, 200, 50])
       renderer.writeBuffer(vertexBuf, verts)
 
       renderer.drawLines({

--- a/packages/core/src/render/__tests__/webglRenderer.test.ts
+++ b/packages/core/src/render/__tests__/webglRenderer.test.ts
@@ -57,7 +57,7 @@ function createMockSharedWebGLSurface() {
   return {
     isAvailable: vi.fn(() => true),
     getGL: vi.fn(() => null),
-    getCanvas: vi.fn(() => ({ width: 0, height: 0 } as HTMLCanvasElement)),
+    getCanvas: vi.fn(() => ({ width: 0, height: 0 }) as HTMLCanvasElement),
     resize: vi.fn(),
     bindRegion: vi.fn(() => true),
     clearRegion: vi.fn(),
@@ -281,9 +281,7 @@ describe('createWebGLRenderer', () => {
       const pipeline = renderer.createPipeline({ type: 'fill' })
       const vertexBuf = renderer.createBuffer('vertex', 256)
       // [upper0_x, upper0_y, lower0_x, lower0_y, upper1_x, upper1_y, ...]
-      const verts = new Float32Array([
-        0, 100, 0, 50, 100, 100, 100, 50, 200, 100, 200, 50,
-      ])
+      const verts = new Float32Array([0, 100, 0, 50, 100, 100, 100, 50, 200, 100, 200, 50])
       renderer.writeBuffer(vertexBuf, verts)
 
       renderer.drawLines({
@@ -339,7 +337,9 @@ describe('createWebGLRenderer', () => {
 
       renderer.dispose()
 
-      expect(() => renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })).not.toThrow()
+      expect(() =>
+        renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 }),
+      ).not.toThrow()
       expect(() =>
         renderer.drawInstances({
           pipeline,
@@ -349,11 +349,13 @@ describe('createWebGLRenderer', () => {
           vertexCount: 6,
         }),
       ).not.toThrow()
-      expect(() => renderer.drawLines({
-        pipeline,
-        vertices: buf,
-        vertexCount: 2,
-      })).not.toThrow()
+      expect(() =>
+        renderer.drawLines({
+          pipeline,
+          vertices: buf,
+          vertexCount: 2,
+        }),
+      ).not.toThrow()
       expect(() => renderer.endFrame()).not.toThrow()
       expect(mocks.mockDrawRectBuffer).not.toHaveBeenCalled()
     })

--- a/packages/core/src/render/createWebGLRenderer.ts
+++ b/packages/core/src/render/createWebGLRenderer.ts
@@ -4,6 +4,7 @@ import type {
   RendererCapabilities,
   BufferHandle,
   PipelineHandle,
+  ComputePipelineHandle,
   BufferUsage,
   DrawInstancesParams,
   DrawLinesParams,

--- a/packages/core/src/render/createWebGLRenderer.ts
+++ b/packages/core/src/render/createWebGLRenderer.ts
@@ -45,10 +45,7 @@ function toWebGLRegion(r: SurfaceRegion) {
   return r as { x: number; y: number; width: number; height: number; dpr: number }
 }
 
-export function createWebGLRenderer(
-  surface: SurfaceBackend,
-  gl: SharedWebGLSurface,
-): Renderer {
+export function createWebGLRenderer(surface: SurfaceBackend, gl: SharedWebGLSurface): Renderer {
   let disposed = false
   let candleSurface: CandleWebGLSurface | null = null
   let lineSurface: LineWebGLSurface | null = null
@@ -137,9 +134,7 @@ export function createWebGLRenderer(
     },
 
     createComputePipeline(_descriptor: unknown): ComputePipelineHandle {
-      throw new Error(
-        'compute not supported on WebGL backend (caps.compute === false)',
-      )
+      throw new Error('compute not supported on WebGL backend (caps.compute === false)')
     },
 
     destroyComputePipeline(_handle: ComputePipelineHandle): void {
@@ -273,9 +268,7 @@ export function createWebGLRenderer(
 
     dispatchCompute(_params: DispatchComputeParams): void {
       if (!disposed) {
-        throw new Error(
-          'dispatchCompute requires a backend with caps.compute === true',
-        )
+        throw new Error('dispatchCompute requires a backend with caps.compute === true')
       }
     },
 

--- a/packages/core/src/scene/createLayerFromPlugin.ts
+++ b/packages/core/src/scene/createLayerFromPlugin.ts
@@ -7,7 +7,8 @@ export function createLayerFromPlugin(
   getContext: () => RenderContext | null,
   targetPaneId: string,
 ): Layer {
-  const paneRole: PaneRole = targetPaneId === 'main' ? 'main' : targetPaneId === 'global' ? 'global' : 'sub'
+  const paneRole: PaneRole =
+    targetPaneId === 'main' ? 'main' : targetPaneId === 'global' ? 'global' : 'sub'
   let visible = plugin.enabled !== false
 
   return {
@@ -37,11 +38,7 @@ export function createLayerFromPlugin(
 
 function pluginPriorityToRole(priority: number, plugin: RendererPlugin): LayerRole {
   if (plugin.layer === 'overlay') return 'overlay'
-  if (
-    priority <= RENDERER_PRIORITY.GRID ||
-    plugin.name === 'gridLines' ||
-    plugin.name === 'grid'
-  )
+  if (priority <= RENDERER_PRIORITY.GRID || plugin.name === 'gridLines' || plugin.name === 'grid')
     return 'background'
   if (priority <= RENDERER_PRIORITY.INDICATOR && plugin.name !== 'candle') return 'indicator'
   if (plugin.name === 'candle' || plugin.name === 'comparisonLine') return 'primary'

--- a/packages/desktop-electron/src/App.vue
+++ b/packages/desktop-electron/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <KLineChart :data-fetcher="dataFetcher" />
+  <KlineChart :data-fetcher="dataFetcher" />
 </template>
 
 <script setup lang="ts">

--- a/packages/react/src/__tests__/_mockController.ts
+++ b/packages/react/src/__tests__/_mockController.ts
@@ -20,6 +20,7 @@ import type {
   PaneSpec,
   SubPaneInfo,
   SymbolSpec,
+  SymbolInfo,
 } from '@363045841yyt/klinechart-core'
 
 export interface MockControllerHandle {
@@ -78,6 +79,7 @@ export function createMockChartController(
     }),
     comparisonColors: createSignal<ReadonlyMap<string, string>>(new Map()),
     comparisonLoading: createSignal(false),
+    symbolCatalog: createSignal([] as ReadonlyArray<SymbolInfo>),
     catalog: [],
 
     setData(next: ReadonlyArray<KLineData>) {
@@ -96,6 +98,9 @@ export function createMockChartController(
       return 10
     },
     setSymbols() {
+      /* no-op */
+    },
+    registerSymbols() {
       /* no-op */
     },
     addComparisonSymbol() {

--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -120,7 +120,7 @@
       :class="{ 'is-fullscreen': isFullscreen }"
       :style="{ width: embedWidth, height: embedHeight }"
     >
-      <KLineChart
+      <KlineChart
         ref="chartRef"
         :mcp="mcpConfig"
         :left-axis-width="60"
@@ -141,7 +141,7 @@
               <button class="close-btn" @click="showModal = false">×</button>
             </header>
             <div class="modal-body">
-              <KLineChart @theme-change="onThemeChange" />
+              <KlineChart @theme-change="onThemeChange" />
             </div>
           </div>
         </div>
@@ -152,7 +152,7 @@
 
 <script setup lang="ts">
   import { ref, computed, provide, inject, type Ref, type InjectionKey } from 'vue'
-  import KLineChart from '../src/components/KLineChart.vue'
+  import { KlineChart } from '../src/index'
   import { VERSION, CORE_VERSION } from '../src/version'
   import {
     type KLineData,
@@ -595,7 +595,7 @@
     })
   }
 
-  const chartRef = ref<InstanceType<typeof KLineChart> | null>(null)
+  const chartRef = ref<InstanceType<typeof KlineChart> | null>(null)
   const mcpConfig = {
     wsUrl: 'ws://localhost:8081',
     autoReconnect: true,

--- a/packages/vue/src/__tests__/_mockController.ts
+++ b/packages/vue/src/__tests__/_mockController.ts
@@ -24,6 +24,7 @@ import type {
   PaneSpec,
   SubPaneInfo,
   SymbolSpec,
+  SymbolInfo,
 } from '@363045841yyt/klinechart-core'
 
 // ---------------------------------------------------------------------------
@@ -115,6 +116,7 @@ export function createMockChartController(
     }),
     comparisonColors: createSignal<ReadonlyMap<string, string>>(new Map()),
     comparisonLoading: createSignal(false),
+    symbolCatalog: createSignal([] as ReadonlyArray<SymbolInfo>),
     catalog: [],
 
     setData: (next) => data.set(next),
@@ -123,6 +125,7 @@ export function createMockChartController(
     getData: () => data.peek(),
     getZoomLevelCount: () => 10,
     setSymbols: () => {},
+    registerSymbols: () => {},
     addComparisonSymbol: () => {},
     removeComparisonSymbol: () => {},
     setComparisonData: () => {},

--- a/packages/vue/src/__tests__/contract.test.ts
+++ b/packages/vue/src/__tests__/contract.test.ts
@@ -30,7 +30,7 @@ describe('@363045841yyt/klinechart —public API surface', () => {
       },
     } as unknown as Parameters<typeof VueAdapter.KMapPlugin.install>[0]
     VueAdapter.KMapPlugin.install(mockApp)
-    expect(registered.KLineChart).toBe(VueAdapter.KLineChart)
+    expect(registered.KLineChart).toBe(VueAdapter.KlineChart)
   })
 })
 

--- a/packages/vue/src/__tests__/internalize.test.ts
+++ b/packages/vue/src/__tests__/internalize.test.ts
@@ -27,7 +27,7 @@ vi.mock('@363045841yyt/klinechart-core/controllers', async () => {
   }
 })
 
-import KLineChart from '../components/KLineChart.vue'
+import { KlineChart } from '../components/index'
 import { loadBuiltinIndicators, routerDataFetcher } from '@363045841yyt/klinechart-core/controllers'
 
 // ── Pre-load builtin indicators so IndicatorSelector mounted hook doesn't
@@ -114,7 +114,7 @@ async function flushMount() {
 
 describe('KLineChart internalization — dataFetcher default', () => {
   it('applies the built-in routerDataFetcher when no prop is bound', async () => {
-    const wrapper = mount(KLineChart, { attachTo: document.body })
+    const wrapper = mount(KlineChart, { attachTo: document.body })
     await flushMount()
 
     const calls = mockController.setDataFetcherCalls()
@@ -126,7 +126,7 @@ describe('KLineChart internalization — dataFetcher default', () => {
 
   it('uses the caller-provided dataFetcher when the prop is bound', async () => {
     const customFetcher = vi.fn(async () => [])
-    const wrapper = mount(KLineChart, {
+    const wrapper = mount(KlineChart, {
       attachTo: document.body,
       props: { dataFetcher: customFetcher },
     })
@@ -143,7 +143,7 @@ describe('KLineChart internalization — dataFetcher default', () => {
 
 describe('KLineChart internalization — theme prop', () => {
   it('applies a controlled theme on mount instead of settings', async () => {
-    const wrapper = mount(KLineChart, {
+    const wrapper = mount(KlineChart, {
       attachTo: document.body,
       props: { theme: 'dark' },
     })
@@ -155,7 +155,7 @@ describe('KLineChart internalization — theme prop', () => {
   })
 
   it('applies theme changes via watcher', async () => {
-    const wrapper = mount(KLineChart, {
+    const wrapper = mount(KlineChart, {
       attachTo: document.body,
       props: { theme: 'light' },
     })
@@ -170,7 +170,7 @@ describe('KLineChart internalization — theme prop', () => {
   })
 
   it('still emits themeChange when the controller theme changes', async () => {
-    const wrapper = mount(KLineChart, { attachTo: document.body })
+    const wrapper = mount(KlineChart, { attachTo: document.body })
     await flushMount()
 
     mockController._emitTheme('dark')
@@ -186,7 +186,7 @@ describe('KLineChart internalization — theme prop', () => {
 
 describe('KLineChart internalization — fullscreen (uncontrolled)', () => {
   it('requests fullscreen on the wrapper when toggled with no isFullscreen prop', async () => {
-    const wrapper = mount(KLineChart, { attachTo: document.body })
+    const wrapper = mount(KlineChart, { attachTo: document.body })
     await flushMount()
 
     wrapper.findComponent({ name: 'LeftToolbar' }).vm.$emit('toggleFullscreen')
@@ -203,7 +203,7 @@ describe('KLineChart internalization — fullscreen (uncontrolled)', () => {
   })
 
   it('fullscreenchange updates internal state, emits update:isFullscreen, flips icon', async () => {
-    const wrapper = mount(KLineChart, { attachTo: document.body })
+    const wrapper = mount(KlineChart, { attachTo: document.body })
     await flushMount()
 
     // simulate entering fullscreen
@@ -224,7 +224,7 @@ describe('KLineChart internalization — fullscreen (uncontrolled)', () => {
 
   it('removes the fullscreenchange listener on unmount', async () => {
     const removeSpy = vi.spyOn(document, 'removeEventListener')
-    const wrapper = mount(KLineChart, { attachTo: document.body })
+    const wrapper = mount(KlineChart, { attachTo: document.body })
     await flushMount()
 
     wrapper.unmount()
@@ -237,7 +237,7 @@ describe('KLineChart internalization — fullscreen (uncontrolled)', () => {
 
 describe('KLineChart internalization — fullscreen (controlled)', () => {
   it('does NOT touch the Fullscreen DOM API when isFullscreen prop is set', async () => {
-    const wrapper = mount(KLineChart, {
+    const wrapper = mount(KlineChart, {
       attachTo: document.body,
       props: { isFullscreen: false },
     })

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -2,6 +2,7 @@
   <div ref="chartWrapperRef" class="chart-wrapper" :data-theme="chartTheme" :style="themeCssVars">
     <TopToolbar
       :symbol="currentSymbol"
+      :symbols="symbolPool"
       :k-line-level="kLineLevel"
       :k-line-adjust="kLineAdjust"
       :symbol-loading="symbolStatus === 'loading'"
@@ -201,6 +202,7 @@
     type ChartController,
     type InteractionSnapshot,
     type SymbolSpec,
+    type SymbolInfo,
     type CustomDataSource,
   } from '@363045841yyt/klinechart-core/controllers'
   import { useChartState } from '../composables/chart/useChartState'
@@ -287,6 +289,40 @@
   }>()
 
   // ── Symbol / Comparison State ──
+
+  // Default symbol catalog — registered into the controller on mount so the
+  // dropdown picker shows a meaningful list out of the box. Consumers can
+  // replace/extend via ctrl.registerSymbols() after mount.
+  const DEFAULT_SYMBOLS: SymbolInfo[] = [
+    // TradingView global
+    { code: 'XAUUSD', description: '现货黄金', exchange: 'OANDA', source: 'tradingview' },
+    {
+      code: 'BTCUSDT',
+      description: 'Bitcoin / Tether',
+      exchange: 'BINANCE',
+      source: 'tradingview',
+    },
+    {
+      code: 'ETHUSDT',
+      description: 'Ethereum / Tether',
+      exchange: 'BINANCE',
+      source: 'tradingview',
+    },
+    { code: 'EURUSD', description: '欧元/美元', exchange: 'OANDA', source: 'tradingview' },
+    { code: 'SPX', description: '标普 500 指数', exchange: 'SP', source: 'tradingview' },
+    { code: 'AAPL', description: 'Apple Inc.', exchange: 'NASDAQ', source: 'tradingview' },
+    { code: 'TSLA', description: 'Tesla, Inc.', exchange: 'NASDAQ', source: 'tradingview' },
+    { code: '1810', description: '小米集团', exchange: 'HKEX', source: 'tradingview' },
+    // gotdx A shares
+    { code: '600519', description: '贵州茅台', exchange: 'SSE', source: 'gotdx' },
+    { code: '601360', description: '三六零', exchange: 'SSE', source: 'gotdx' },
+    { code: '000858', description: '五 粮 液', exchange: 'SZSE', source: 'gotdx' },
+    { code: '000001', description: '平安银行', exchange: 'SZSE', source: 'gotdx' },
+    // Mock
+    { code: 'MOCK-100', description: 'Mock 100 条', exchange: 'MOCK', source: 'mock-100' },
+    { code: 'MOCK-10000', description: 'Mock 10000 条', exchange: 'MOCK', source: 'mock-10000' },
+  ]
+
   const kLineLevel = ref<string>(props.semanticConfig?.data?.period ?? 'daily')
   const previousKLineLevel = ref<string>('daily')
   const kLineAdjust = ref(props.semanticConfig?.data?.adjust ?? 'none')
@@ -295,6 +331,7 @@
   const currentSymbolItem = ref<SymbolItem | null>(null)
   const overlaySymbols = ref<string[]>([])
   const overlaySymbolItems = ref<SymbolItem[]>([])
+  const symbolPool = ref<SymbolItem[]>([])
 
   function onKLineLevelChange(level: string) {
     if (level === 'timeshare') {
@@ -934,6 +971,24 @@
       comparisonLoading.value = ctrl.comparisonLoading.peek()
     })
 
+    // Sync symbol catalog from controller to dropdown pool.
+    const unsubscribeSymbolCatalog = ctrl.symbolCatalog.subscribe(() => {
+      symbolPool.value = ctrl.symbolCatalog.peek().map((info) => ({
+        code: info.code,
+        description: info.description ?? info.code,
+        exchange: info.exchange ?? '',
+        source: info.source ?? '',
+      }))
+    })
+    // 立即同步当前值，确保 dropdown 在 subscribe 创建后立即拿到数据，
+    // 不依赖 registerSymbols 在 subscribe 之前还是之后调用。
+    symbolPool.value = ctrl.symbolCatalog.peek().map((info) => ({
+      code: info.code,
+      description: info.description ?? info.code,
+      exchange: info.exchange ?? '',
+      source: info.source ?? '',
+    }))
+
     const unsubscribeSymbols = ctrl.symbols.subscribe(() => {
       const specs = ctrl.symbols.peek()
       if (specs.length === 0) return
@@ -968,6 +1023,7 @@
       unsubscribeIndicators()
       unsubscribeComparisonColors()
       unsubscribeComparisonLoading()
+      unsubscribeSymbolCatalog()
       unsubscribeSymbols()
     }
   }
@@ -1057,8 +1113,11 @@
     if (!containerRef.value || !chartMainRef.value) return // 组件已卸载
     controller.value = ctrl
 
-    // 3) 信号回调
+    // 3) 信号回调（必须在 registerSymbols 之前建立，否则订阅收不到初始通知）
     cleanupChartCallbacks = setupChartCallbacks(ctrl)
+
+    // Seed the default symbol catalog — subscribe 已建立, set 会触发回调刷新 dropdown
+    ctrl.registerSymbols(DEFAULT_SYMBOLS)
 
     // 3.5) 在任何 draw 之前注册主图指标（BOLL/MA 等）
     //      initIndicatorsFromConfig 是同步的，读 props.semanticConfig 即可注册，

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -1171,7 +1171,6 @@
   .chart-main {
     flex: 1 1 auto;
     min-width: 0;
-    height: 100%;
     display: flex;
     align-items: stretch;
     gap: 0;
@@ -1228,7 +1227,6 @@
     flex: 1 1 auto;
     overflow-x: auto;
     overflow-y: hidden;
-    height: 100%;
     min-height: inherit;
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -1252,7 +1250,6 @@
   .right-axis-host {
     position: relative;
     flex: 0 0 auto;
-    height: 100%;
     min-height: inherit;
     box-sizing: border-box;
     background: var(--chart-bg);
@@ -1270,7 +1267,6 @@
   .left-axis-host {
     position: relative;
     flex: 0 0 auto;
-    height: 100%;
     min-height: inherit;
     box-sizing: border-box;
     background: var(--chart-bg);
@@ -1286,7 +1282,6 @@
   }
 
   .scroll-content {
-    height: 100%;
     min-height: inherit;
     position: relative;
   }

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -284,6 +284,7 @@
     (e: 'toggleFullscreen'): void
     (e: 'update:isFullscreen', value: boolean): void
     (e: 'themeChange', theme: 'light' | 'dark'): void
+    (e: 'update:theme', theme: 'light' | 'dark'): void
     (e: 'kLineLevelChange', level: string): void
     (e: 'kLineAdjustChange', adjust: 'qfq' | 'hfq' | 'splits' | 'none'): void
   }>()
@@ -357,9 +358,12 @@
 
   function onSymbolChange(item: SymbolItem) {
     symbolStatus.value = 'loading'
-    const current = controller.value?.symbols.peek() ?? []
+    const ctrl = controller.value
+    if (!ctrl) return
+    ctrl.setDataFetcher(effectiveDataFetcher.value)
+    const current = ctrl.symbols.peek() ?? []
     const comparisonSpecs = current.slice(1)
-    controller.value?.setSymbols([toSymbolSpec(item), ...comparisonSpecs])
+    ctrl.setSymbols([toSymbolSpec(item), ...comparisonSpecs])
   }
 
   function onAddOverlaySymbol(item: SymbolItem) {
@@ -959,6 +963,7 @@
       const newTheme = ctrl.theme.peek()
       chartTheme.value = newTheme
       emit('themeChange', newTheme)
+      emit('update:theme', newTheme)
     })
 
     const unsubscribeIndicators = setupIndicatorSubscriptions(ctrl)
@@ -1051,10 +1056,8 @@
   }
 
   function setupSemanticController(ctrl: ChartController): void {
-    // 如果传入了 customData，跳过 fetcher 配置，使用自定义数据
     if (props.customData) {
       ctrl.applyCustomData(props.customData)
-      return
     }
 
     ctrl.setDataFetcher(effectiveDataFetcher.value)

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -124,41 +124,11 @@
     (e: 'back'): void
   }>()
 
-  const MOCK_SYMBOLS: SymbolItem[] = [
-    // ── TradingView 全球品种 ──
-    { code: 'XAUUSD', description: '现货黄金', exchange: 'OANDA', source: 'tradingview' },
-    {
-      code: 'BTCUSDT',
-      description: 'Bitcoin / Tether',
-      exchange: 'BINANCE',
-      source: 'tradingview',
-    },
-    {
-      code: 'ETHUSDT',
-      description: 'Ethereum / Tether',
-      exchange: 'BINANCE',
-      source: 'tradingview',
-    },
-    { code: 'EURUSD', description: '欧元/美元', exchange: 'OANDA', source: 'tradingview' },
-    { code: 'SPX', description: '标普 500 指数', exchange: 'SP', source: 'tradingview' },
-    { code: 'AAPL', description: 'Apple Inc.', exchange: 'NASDAQ', source: 'tradingview' },
-    { code: 'TSLA', description: 'Tesla, Inc.', exchange: 'NASDAQ', source: 'tradingview' },
-    { code: '1810', description: '小米集团', exchange: 'HKEX', source: 'tradingview' },
-    // ── gotdx A 股 ──
-    { code: '600519', description: '贵州茅台', exchange: 'SSE', source: 'gotdx' },
-    { code: '601360', description: '三六零', exchange: 'SSE', source: 'gotdx' },
-    { code: '000858', description: '五 粮 液', exchange: 'SZSE', source: 'gotdx' },
-    { code: '000001', description: '平安银行', exchange: 'SZSE', source: 'gotdx' },
-    // ── Mock ──
-    { code: 'MOCK-100', description: 'Mock 100 条', exchange: 'MOCK', source: 'mock-100' },
-    { code: 'MOCK-10000', description: 'Mock 10000 条', exchange: 'MOCK', source: 'mock-10000' },
-  ]
-
   const displaySymbol = computed(() => props.symbol?.trim() ?? '')
 
-  const symbolPool = computed<SymbolItem[]>(() =>
-    props.symbols && props.symbols.length ? props.symbols : MOCK_SYMBOLS,
-  )
+  // Symbol pool comes exclusively from props — driven by the controller's symbolCatalog.
+  // If no symbols are provided, the picker displays an empty list (no hardcoded fallback).
+  const symbolPool = computed<SymbolItem[]>(() => props.symbols ?? [])
 
   function onSymbolSelectorChange(item: SymbolItem) {
     emit('symbolChange', item)

--- a/packages/vue/src/components/index.ts
+++ b/packages/vue/src/components/index.ts
@@ -2,6 +2,10 @@ export { default as ColorPresetPanel } from './ColorPresetPanel.vue'
 export { default as DrawingStyleToolbar } from './DrawingStyleToolbar.vue'
 export { default as IndicatorParams } from './IndicatorParams.vue'
 export { default as IndicatorSelector } from './IndicatorSelector.vue'
+export { default as KlineChart } from './KLineChart.vue'
+/**
+ * @deprecated Use `KlineChart` instead. `KLineChartVue` will be removed in a future release.
+ */
 export { default as KLineChartVue } from './KLineChart.vue'
 export { default as KLineTooltip } from './KLineTooltip.vue'
 export { default as LeftToolbar } from './LeftToolbar.vue'

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -35,6 +35,7 @@ import type {
   KLineData,
 } from '@363045841yyt/klinechart-core'
 import { createIndicatorSelectorController } from '@363045841yyt/klinechart-core'
+import { KlineChart } from './components/index'
 
 export type {
   ChartController,
@@ -52,11 +53,14 @@ export {
   DrawingStyleToolbar,
   IndicatorParams,
   IndicatorSelector,
-  KLineChartVue,
+  KlineChart,
   KLineTooltip,
   LeftToolbar,
   MarkerTooltip,
 } from './components/index'
+
+/** @deprecated Use `KlineChart` instead. */
+export { default as KLineChartVue } from './components/KLineChart.vue'
 
 // ---------------------------------------------------------------------------
 // Controller factory injection
@@ -302,14 +306,16 @@ export function useIndicatorSelector(controller: ChartController): {
 }
 
 // ---------------------------------------------------------------------------
-// <KLineChart /> SFC-equivalent component
+// @deprecated <KLineChart /> SFC-equivalent component
 //
 // Implemented with defineComponent + render function rather than a `.vue`
 // SFC to keep the package buildable with plain `tsc` (no SFC compiler in
 // the publishable pipeline). Mirrors the legacy KLineChart.vue prop names
 // that downstream consumers depend on.
+// Deprecated — use the KlineChart (SFC) component instead.
 // ---------------------------------------------------------------------------
 
+/** @deprecated Use `KlineChart` (SFC) instead. */
 export const KLineChart = defineComponent({
   name: 'KLineChart',
   props: {
@@ -443,7 +449,7 @@ export const KLineChart = defineComponent({
 
 export const KMapPlugin = {
   install(app: App): void {
-    app.component('KLineChart', KLineChart)
+    app.component('KLineChart', KlineChart)
   },
 }
 

--- a/packages/vue/src/web-component.ts
+++ b/packages/vue/src/web-component.ts
@@ -1,8 +1,8 @@
 import { defineCustomElement } from 'vue'
-import KLineChartVue from './components/KLineChart.vue'
+import KlineChart from './components/KLineChart.vue'
 import type { SemanticChartConfig, DataFetcher } from '@363045841yyt/klinechart-core/semantic'
 
-const KLineChartElement = defineCustomElement(KLineChartVue, {
+const KLineChartElement = defineCustomElement(KlineChart, {
   shadowRoot: true,
 })
 

--- a/packages/vue/tsconfig.build.json
+++ b/packages/vue/tsconfig.build.json
@@ -6,6 +6,7 @@
     "strict": true,
     "noImplicitOverride": true,
     "declaration": true,
+    "emitDeclarationOnly": true,
     "declarationMap": true,
     "sourceMap": true,
     "esModuleInterop": true,

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         }
       : {
           entry: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
-          name: 'KLineChartVue',
+          name: 'KlineChart',
           formats: ['es', 'cjs'],
           fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'),
         },


### PR DESCRIPTION
## Summary

Rename `KLineChart` → `KlineChart` as the primary Vue SFC export, add `SymbolSpec.incremental` to prevent incremental loading on custom data sources, add symbol catalog for UI pickers, and migrate built-in renderers to the Scene/Layer architecture.

## Changes

### 🏗️ Scene Pipeline Migration
- **feat(render):** Add `createWebGLRenderer` and `SurfaceBackend` adapters wrapping `SharedWebGLSurface`
- **feat(scene):** Add `createLayerFromPlugin` bridge adapter for plugin → layer conversion
- **feat(scene):** Batch migrate 8 built-in renderers, sub-indicators, and remaining plugins to Layer architecture
- **fix(scene):** Remove bridge layers for Canvas2D plugins, fix overlay layer filtering
- **feat(chart):** Connect WebGL Renderer to Scene pipeline

### 🧩 Component API Cleanup
- **Rename `KLineChart` → `KlineChart`** as primary SFC export; deprecate old `defineComponent` wrapper (`packages/vue/src/components/index.ts`, `packages/vue/src/index.ts`)
- **Add `v-model:theme` emit** alongside `themeChange` for proper two-way binding
- **Web component** uses the new SFC internally
- **Vite library name** updated to `KlineChart`
- All test files, preview app, and examples updated to import `{ KlineChart }`

### 📊 Data Layer: Prevent Incremental Loading on Custom Data
- **`SymbolSpec.incremental`** new optional field (`packages/core/src/controllers/types.ts`)
- **`applyCustomData`** sets `incremental: false` on the generated spec
- **`DataBuffer.ensureRange`** and **`fetchRange`** bail when `currentSpec.incremental === false`
- **`loadKLineSymbols`** preserves the incremental flag across symbol switches — when switching back to a custom-data symbol, the buffer retains `incremental: false`
- **`setupSemanticController`** no longer returns early — fetcher is always configured, but inline data buffers refuse to fetch via the `incremental` guard

### 🗂️ Symbol Catalog
- **`SymbolInfo` interface** for registered symbol metadata
- **`symbolCatalog` signal + `registerSymbols`/`unregisterSymbol`** on `ChartDataManager` and `ChartController`
- **`CustomDataSource`** gains `description`, `exchange`, `source` fields for auto-registration
- **Default symbol pool** with ~15 common symbols (XAUUSD, BTCUSDT, A-shares, etc.) seeded on mount
- **`TopToolbar`** receives `symbols` prop for dropdown picker

### 📝 README Updates
- All 5 README files updated with the correct component usage pattern:
  - `import { KlineChart }` (named import, lowercase 'l')
  - `:custom-data` with `ref<CustomDataSource>` and external JSON import
  - `app-container` wrapper with `data-theme` dark mode CSS
  - MCP examples also fixed (was using default import)

### 🐛 Bug Fixes
- Fix flex layout height collapse (remove redundant `height: 100%` on scroll-content/axis hosts)
- Fix custom data source triggering Y-axis auto-adjustment
- Fix TS errors in depth pipeline tests, order book heatmap tests
- Fix `getInternalData` fallback for non-buffer data