### PR TITLE
fix(vue): resolve theme synchronously to eliminate light-dark flicker on mount

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,5 @@ dist/
 node_modules/
 coverage/
 *.config.*
-examples/
-preview/
 packages/desktop-electron/out/
 packages/*/dist/

--- a/examples/vue-test/src/App.vue
+++ b/examples/vue-test/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="app-container" :data-theme="currentTheme">
-    <KlineChart v-model:theme="currentTheme" :custom-data="customData">
+    <KlineChart :settings="chartSettings" :custom-data="customData" @theme-change="(t: 'light' | 'dark') => currentTheme = t">
       <template #kline-tooltip="{ hoverData, upColor, downColor }">
     <div class="custom-tooltip">
       <div class="custom-tooltip__title">
@@ -38,14 +38,14 @@ import type { ChartSettings } from '@363045841yyt/klinechart-core'
     showVolumePriceMarkers: false,
     leftAxisType: 'none',
     theme: 'dark',
-    colorPresetSettings: {
+    /* colorPresetSettings: {
       dark: {
         candleUpBody: '#e85d04', // 橙色阳线
         candleDownBody: '#1b4332', // 墨绿阴线
         crosshairLine: '#faa307', // 金色十字线
         gridMajor: '#3e2723', // 主网格线
       },
-    },
+    }, */
   }
 </script>
 

--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -24,7 +24,7 @@
         :mcp="mcpConfig"
         :left-axis-width="60"
         :custom-data="customData"
-        :theme="currentTheme"
+        :settings="chartSettings"
         @update:is-fullscreen="isFullscreen = $event"
         @theme-change="onThemeChange"
       >
@@ -79,7 +79,7 @@
     createHeatmapController,
   } from '@363045841yyt/klinechart-core/controllers'
   import { executeTool } from '@363045841yyt/klinechart-ai-runtime'
-import { formatTimestamp } from '@363045841yyt/klinechart-core'
+  import { formatTimestamp } from '@363045841yyt/klinechart-core'
 
   /** 硬编码演示数据：主品种 CUSTOM.DEMO（15 根日 K） */
   const DEMO_MAIN_DATA: KLineData[] = [
@@ -543,15 +543,6 @@ import { formatTimestamp } from '@363045841yyt/klinechart-core'
 
   const isFullscreen = ref(false)
   const embedContainerRef = ref<HTMLElement | null>(null)
-  const currentTheme = ref<'light' | 'dark'>('light')
-
-  function onThemeChange(theme: 'light' | 'dark') {
-    currentTheme.value = theme
-  }
-
-  provideFullscreenTeleportTarget(embedContainerRef)
-
-  const teleportTarget = computed<HTMLElement | string>(() => embedContainerRef.value ?? 'body')
 
   // ── settings prop 演示
   const chartSettings: ChartSettings = {
@@ -560,15 +551,25 @@ import { formatTimestamp } from '@363045841yyt/klinechart-core'
     showVolumePriceMarkers: false,
     leftAxisType: 'none',
     theme: 'dark',
-    colorPresetSettings: {
+    /* colorPresetSettings: {
       dark: {
         candleUpBody: '#e85d04', // 橙色阳线
         candleDownBody: '#1b4332', // 墨绿阴线
         crosshairLine: '#faa307', // 金色十字线
         gridMajor: '#3e2723', // 主网格线
       },
-    },
+    }, */
   }
+
+  const currentTheme = ref<'light' | 'dark'>(chartSettings.theme as 'light' | 'dark')
+
+  function onThemeChange(theme: 'light' | 'dark') {
+    currentTheme.value = theme
+  }
+
+  provideFullscreenTeleportTarget(embedContainerRef)
+
+  const teleportTarget = computed<HTMLElement | string>(() => embedContainerRef.value ?? 'body')
 
   // ── 自定义数据源 Demo ──
   const useCustomData = ref(false)

--- a/packages/vue/src/__tests__/internalize.test.ts
+++ b/packages/vue/src/__tests__/internalize.test.ts
@@ -144,33 +144,6 @@ describe('KLineChart internalization — dataFetcher default', () => {
 })
 
 describe('KLineChart internalization — theme prop', () => {
-  it('applies a controlled theme on mount instead of settings', async () => {
-    const wrapper = mount(KlineChart, {
-      attachTo: document.body,
-      props: { theme: 'dark' },
-    })
-    await flushMount()
-
-    expect(mockController.setThemeCalls()).toContain('dark')
-
-    wrapper.unmount()
-  })
-
-  it('applies theme changes via watcher', async () => {
-    const wrapper = mount(KlineChart, {
-      attachTo: document.body,
-      props: { theme: 'light' },
-    })
-    await flushMount()
-
-    await wrapper.setProps({ theme: 'dark' })
-    await nextTick()
-
-    expect(mockController.setThemeCalls()).toContain('dark')
-
-    wrapper.unmount()
-  })
-
   it('still emits themeChange when the controller theme changes', async () => {
     const wrapper = mount(KlineChart, { attachTo: document.body })
     await flushMount()

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -273,8 +273,6 @@
       initialZoomLevel?: number
       /** 是否全屏（受控）。不绑定时为非受控模式，组件内部接管全屏 DOM 操作 */
       isFullscreen?: boolean
-      /** 主题（受控）。不传时由设置项决定 */
-      theme?: 'light' | 'dark'
       /** 时区，默认 Asia/Shanghai */
       timezone?: string
 
@@ -316,7 +314,6 @@
     (e: 'toggleFullscreen'): void
     (e: 'update:isFullscreen', value: boolean): void
     (e: 'themeChange', theme: 'light' | 'dark'): void
-    (e: 'update:theme', theme: 'light' | 'dark'): void
     (e: 'kLineLevelChange', level: string): void
     (e: 'kLineAdjustChange', adjust: 'qfq' | 'hfq' | 'splits' | 'none'): void
   }>()
@@ -515,6 +512,16 @@
   // ── Controller & Composable Wiring ──
   const controller = shallowRef<ChartController | null>(null)
 
+  // Resolve initial theme synchronously before first render
+  const _initialResolved = resolveSettings(props.settings)
+  const _initialTheme: 'light' | 'dark' = (() => {
+    const theme = _initialResolved.theme as string
+    if (theme === 'auto') {
+      return typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    }
+    return theme as 'light' | 'dark'
+  })()
+
   const {
     chartTheme,
     chartSettings,
@@ -522,7 +529,7 @@
     themeCssVars,
     handleSettingsChange,
     applyThemeFromSettings,
-  } = useChartTheme(controller)
+  } = useChartTheme(controller, _initialTheme)
 
   const semanticController = shallowRef<SemanticChartController | null>(null)
 
@@ -953,6 +960,7 @@
       rightAxisLayer,
       leftAxisLayer,
       xAxisCanvas,
+      theme: _initialTheme,
       initialZoomLevel: props.initialZoomLevel,
       zoomLevels: props.zoomLevels,
       yPaddingPx: props.yPaddingPx,
@@ -1032,7 +1040,6 @@
       const newTheme = ctrl.theme.peek()
       chartTheme.value = newTheme
       emit('themeChange', newTheme)
-      emit('update:theme', newTheme)
     })
 
     const unsubscribeIndicators = setupIndicatorSubscriptions(ctrl)
@@ -1109,12 +1116,7 @@
     chartSettings.value = merged
     const resolved = resolveSettings(merged)
     ctrl.updateSettingsFacade(resolved)
-    // 受控主题优先，否则交由设置项决定
-    if (props.theme) {
-      ctrl.setTheme(props.theme)
-    } else {
-      applyThemeFromSettings(resolved.theme as string)
-    }
+    applyThemeFromSettings(resolved.theme as string)
   }
 
   function setupInteractionCallbacks(ctrl: ChartController): void {
@@ -1280,21 +1282,13 @@
           controller.value.setDataFetcher(effectiveDataFetcher.value)
           controller.value.resetToFetcher({
             ...saved,
-            period: currentPeriod.value,
+            period: kLineLevel.value,
             adjust: kLineAdjust.value,
           })
         }
       }
     },
     { deep: true },
-  )
-
-  // 受控主题：外部 theme 变化时同步到控制器
-  watch(
-    () => props.theme,
-    (t) => {
-      if (t) controller.value?.setTheme(t)
-    },
   )
 
   // 受控设置：外部 settings 变化时 merge 到当前设置并同步到控制器

--- a/packages/vue/src/composables/chart/useChartTheme.ts
+++ b/packages/vue/src/composables/chart/useChartTheme.ts
@@ -15,8 +15,11 @@ import type { ChartController } from '@363045841yyt/klinechart-core/controllers'
 import type { Ref } from 'vue'
 import { ref, computed, watch, onUnmounted } from 'vue'
 
-export function useChartTheme(ctrl: Ref<ChartController | null>) {
-  const chartTheme = ref<'light' | 'dark'>('light')
+export function useChartTheme(
+  ctrl: Ref<ChartController | null>,
+  initialTheme?: 'light' | 'dark',
+) {
+  const chartTheme = ref<'light' | 'dark'>(initialTheme ?? 'light')
   const chartSettings = ref<ChartSettings>({})
 
   const tooltipColors = computed(() => {


### PR DESCRIPTION
Root cause: chartTheme ref was hardcoded to 'light' in useChartTheme,
but DEFAULT_SETTINGS defaults to 'dark'. The correct theme was only
applied asynchronously after controller creation + signal bridge,
causing a visible light-to-dark flash.

Fix:
- Synchronously resolve theme from settings in <script setup> before
  first render (handles 'auto', 'light', 'dark')
- Pass resolved theme to both useChartTheme and createChartController
- Remove redundant chartTheme sync in applyInitialSettings
- Remove deprecated ':theme' prop in favor of ':settings' prop
- Drop outdated tests for the removed theme prop

BREAKING CHANGE: The standalone 'theme' prop on KLineChart is
removed. Use :settings="{ theme: 'dark' }" instead.
