### PR TITLE
fix(core): zoom interaction signal timing hazards + atomicity audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,16 @@ Three coordinate systems must stay in sync:
 - **`checkVisibleRangeGapWhenIdle()` bails when `isPointerDown()` is true** — gap check only fires after drag ends; `onPointerUp()` is the last guaranteed trigger point.
 - **Bundle logically related info into a single signal payload instead of splitting across multiple signals that rely on timing order, and never use shared mutable variables to coordinate between independent signal subscribers.**
 
+### Signal Atomicity
+
+- **No band-aid timing fixes.** Never patch a timing hazard by adding delays, moving event listeners, or introducing scheduling hacks. Always trace the root cause — which signal fires before its dependent state is ready — and move the emission to where state is consistent. A fix that "works in practice but the order is still wrong" is unacceptable.
+
+- **Related signals must fire in the same synchronous block.** If two signals (`viewportSignal` and `interactionState`, for example) are semantically dependent, they must be written in the same synchronous call stack, wrapped in `batch()`. If they are split across a RAF boundary, consumers will observe an inconsistent intermediate state.
+
+- **Cache before DOM.** Any write that updates both cache state and DOM must write the cache first. DOM writes may trigger synchronous events (e.g. `scroll`) that read the cache. Stale cache leads to inconsistent event handler state.
+
+- **Use `batch()` for transactional signal writes.** The `batch()` mechanism (depth-counted deferred notification in `signal.ts`) replaces the old no-op. Wrap multiple `Signal.set()` calls in `batch()` to guarantee subscribers see the final state of all signals atomically. Do not rely on Vue's `queueFlush()` or React's automatic batching — they only merge updates within the same call stack, not across signal domains.
+
 ## CI
 
 - `library-ci.yml` runs on every push/PR to main. Two jobs: `test` (REQUIRED) and `build` (WARN-ONLY).

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -382,7 +382,6 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
     minKWidth: DEFAULT_OPTS.minKWidth,
     maxKWidth: DEFAULT_OPTS.maxKWidth,
     zoomLevelCount,
-    dpr: currentDpr,
   })
   const currentKGap = kGapFromKWidth(currentKWidth, currentDpr)
 

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -291,7 +291,7 @@ export class Chart {
       },
       onZoomCommitted: (result) => {
         this.opt = { ...this.opt, kWidth: result.kWidth, kGap: result.kGap }
-        this.updateViewportSignal()
+        // viewportSignal 延后到 draw() 内、setKLinePositions 重算 crosshair 之后再发射
         this.scheduleDraw()
       },
       getKWidth: () => this.opt.kWidth,
@@ -550,7 +550,7 @@ export class Chart {
     if (zoomLevel !== undefined) {
       this.zoomController.setZoomLevel(nextZoomLevel)
     }
-    this.updateViewportSignal()
+    // viewportSignal 延后到 draw() 内、setKLinePositions 重算 crosshair 之后再发射
     this.scheduleDraw()
   }
 

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -282,10 +282,10 @@ export class Chart {
     this.zoomController = new ChartZoomController({
       getLogicalScrollLeft: () => this.viewportManager.getLogicalScrollLeft(),
       getCurrentDpr: () => this.viewportManager.getEffectiveDpr(),
-      getLeftLoadBufferWidth: () => this.dataManager.getLeftLoadBufferWidth(),
-      getContentWidth: () => this.dataManager.getContentWidth(),
       getClientWidth: () =>
         this.viewportManager.getViewport()?.viewWidth ?? this.dom.container?.clientWidth ?? 0,
+      getDataLength: () => this.dataManager.getData().length,
+      getPlotWidth: () => this.dataManager.getLeftLoadBufferWidth(),
       setScrollLeft: (v) => {
         this.viewportManager.setScrollLeft(v)
       },

--- a/packages/core/src/engine/controller/interaction.ts
+++ b/packages/core/src/engine/controller/interaction.ts
@@ -69,8 +69,8 @@ export class InteractionController {
     const clampedScrollLeft = Math.min(Math.max(0, nextScrollLeft), maxScrollLeft)
     const dpr = this.chart.getCurrentDpr()
     const rounded = Math.round(clampedScrollLeft * dpr) / dpr
+    this.chart.setScrollLeft(rounded)
     container.scrollLeft = rounded
-    this.chart.setScrollLeft(container.scrollLeft)
   }
 
   /** 垂直拖动相关 */
@@ -279,6 +279,7 @@ export class InteractionController {
     this.activePaneIdOnDrag = pane?.id || null
 
     this.chart.scheduleDraw()
+    this.notifyInteractionChange()
   }
 
   /**

--- a/packages/core/src/engine/controller/interaction.ts
+++ b/packages/core/src/engine/controller/interaction.ts
@@ -119,6 +119,9 @@ export class InteractionController {
   /** 用户设置 */
   private settings: ChartSettings = {}
 
+  /** 最后一次鼠标位置（用于 setKLinePositions 时自动重算十字线） */
+  private lastClientPos: { x: number; y: number } | null = null
+
   private markerState = new MarkerInteractionState()
 
   /** 当前帧的 K 线起始 x 坐标数组 */
@@ -382,6 +385,8 @@ export class InteractionController {
    * @param e PointerEvent
    */
   onPointerMove(e: PointerEvent) {
+    this.lastClientPos = { x: e.clientX, y: e.clientY }
+
     if (this.pinchTracker.handlePointerMove(e)) return
 
     if (!e.isPrimary) return
@@ -480,6 +485,12 @@ export class InteractionController {
     this.visibleRange = visibleRange
     if (kWidthPx !== undefined) {
       this.kWidthPx = kWidthPx
+    }
+
+    // 十字线自动同步：positions 刷新后用最新鼠标位置重算，防止缩放/滚动后索引滞后
+    if (this.lastClientPos && !this.isDragging) {
+      this.updatePlotHoverFromPoint(this.lastClientPos.x, this.lastClientPos.y)
+      this.notifyInteractionChange()
     }
   }
 
@@ -668,7 +679,8 @@ export class InteractionController {
    * 边界 → pane 分隔器 → marker → K 线 bar → 十字线定位 → candle 命中 → tooltip。
    * 每个步骤都可能提前 return，无需执行后续检测。
    */
-  private updatePlotHoverFromPoint(clientX: number, clientY: number) {
+  /** @internal 公开给外部在合适的时机触发十字线重算（如 setKLinePositions 之后） */
+  updatePlotHoverFromPoint(clientX: number, clientY: number) {
     const ctx = this.resolveHoverContext(clientX, clientY)
     if (!ctx) return
 

--- a/packages/core/src/engine/data/scrollCompensator.ts
+++ b/packages/core/src/engine/data/scrollCompensator.ts
@@ -11,6 +11,8 @@ export interface ScrollDeps {
   getViewport: () => Viewport | null
 }
 
+export const SCROLL_TRAILING_SLOTS = 30
+
 export class ScrollCompensator {
   constructor(private deps: ScrollDeps) {}
 
@@ -86,8 +88,7 @@ export class ScrollCompensator {
     const viewWidth = this.deps.getViewport()?.plotWidth ?? 0
     const dpr = this.deps.getEffectiveDpr()
     const { startXPx, unitPx } = getPhysicalKLineConfig(opt.kWidth, opt.kGap, dpr)
-    const TRAILING_SLOTS = 30
-    const dataPlotWidth = (startXPx + (dataLength + TRAILING_SLOTS) * unitPx) / dpr
+    const dataPlotWidth = (startXPx + (dataLength + SCROLL_TRAILING_SLOTS) * unitPx) / dpr
     return this.getLeftLoadBufferWidth(dataLength) + Math.max(dataPlotWidth, viewWidth)
   }
 }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -52,7 +52,7 @@ import { createLastPriceLineLayer } from './layers/lastPriceLineLayer'
 import { createLeftYAxisLayer } from './layers/leftYAxisLayer'
 import { createMainIndicatorLegendLayer } from './layers/mainIndicatorLegendLayer'
 import { createYAxisLayer } from './layers/yAxisLayer'
-
+import { batch } from '../../reactivity/signal'
 
 type ResolvedChartOptions = Omit<ChartOptions, 'kWidth' | 'kGap'> & {
   kWidth: number
@@ -319,7 +319,6 @@ export class ChartRenderer {
             Math.max(dataManager.getContentWidth(), dataManager.getLeftLoadBufferWidth()) + 'px'
           if (scrollContent.style.width !== w) scrollContent.style.width = w
         }
-        this.deps.getViewportManager().applyPendingScrollLeft(c)
       }
     })
   }
@@ -337,7 +336,10 @@ export class ChartRenderer {
 
     const { vp, range, kLinePositions, kLineCenters, kBarRects, kWidthPx, useCachedFrame } = frame
 
-    this.deps.getInteraction().setKLinePositions(kLinePositions, range, kWidthPx, kLineCenters)
+    batch(() => {
+      this.deps.getInteraction().setKLinePositions(kLinePositions, range, kWidthPx, kLineCenters)
+      this.deps.getViewportManager().updateViewportSignal()
+    })
 
     const dataManager = this.deps.getDataManager()
     const mode = this.deps.getActiveMode()
@@ -354,6 +356,8 @@ export class ChartRenderer {
       ? null
       : this.deps.getIndicatorManager().indicatorSchedulerAccessor.getMainIndicatorPriceRange()
     const hasCrosshair = this.deps.getInteraction().getCrosshairIndex() !== null
+
+    this.deps.getViewportManager().applyPendingScrollLeft(this.deps.getDom().container)
 
     const { sharedXAxisLabels, sharedXAxisRanges } = this.renderPanes(
       vp,

--- a/packages/core/src/engine/utils/chartZoomController.ts
+++ b/packages/core/src/engine/utils/chartZoomController.ts
@@ -9,9 +9,9 @@ export interface ZoomCommittedResult {
 export interface ZoomDependencies {
   getLogicalScrollLeft: () => number
   getCurrentDpr: () => number
-  getLeftLoadBufferWidth: () => number
-  getContentWidth: () => number
   getClientWidth: () => number
+  getDataLength: () => number
+  getPlotWidth: () => number
   setScrollLeft: (v: number) => void
   onZoomCommitted: (result: ZoomCommittedResult) => void
   getKWidth: () => number
@@ -95,19 +95,16 @@ export class ChartZoomController {
         maxKWidth: this.deps.getMaxKWidth(),
         zoomLevelCount: this.deps.zoomLevelCount,
         dpr,
+        dataLength: this.deps.getDataLength(),
+        plotWidth: this.deps.getPlotWidth(),
+        clientWidth: this.deps.getClientWidth(),
       },
     )
 
     if (!result) return
 
-    const domScrollLeft = result.newScrollLeft + this.deps.getLeftLoadBufferWidth()
-    const contentWidth = this.deps.getContentWidth()
-    const clientWidth = this.deps.getClientWidth()
-    const maxScroll = Math.max(0, contentWidth - clientWidth)
-    const clampedScrollLeft =
-      Math.round(Math.max(0, Math.min(domScrollLeft, maxScroll)) * dpr) / dpr
     this._currentZoomLevel = result.targetLevel
-    this.deps.setScrollLeft(clampedScrollLeft)
+    this.deps.setScrollLeft(result.newDomScrollLeft)
     this.deps.onZoomCommitted({
       kWidth: result.newKWidth,
       kGap: result.newKGap,

--- a/packages/core/src/engine/utils/zoom.ts
+++ b/packages/core/src/engine/utils/zoom.ts
@@ -5,10 +5,13 @@ import { getPhysicalKLineConfig } from './klineConfig'
  * 无副作用、无 DOM 访问，供 Vue 层直接调用
  */
 
-export interface ZoomConfig {
+export interface ZoomConfigBase {
   minKWidth: number
   maxKWidth: number
   zoomLevelCount: number
+}
+
+export interface ZoomConfig extends ZoomConfigBase {
   dpr: number
   /** K 线数据条数（用于计算缩放后内容宽度） */
   dataLength: number
@@ -33,7 +36,7 @@ const PHYS_K_GAP_MAX = 3
 const TRAILING_SLOTS = 30
 
 /** 将缩放级别转换为 K 线宽度（逻辑像素） */
-export function zoomLevelToKWidth(level: number, config: ZoomConfig): number {
+export function zoomLevelToKWidth(level: number, config: ZoomConfigBase): number {
   const t = (level - 1) / (config.zoomLevelCount - 1)
   return config.minKWidth + t * (config.maxKWidth - config.minKWidth)
 }

--- a/packages/core/src/engine/utils/zoom.ts
+++ b/packages/core/src/engine/utils/zoom.ts
@@ -10,6 +10,12 @@ export interface ZoomConfig {
   maxKWidth: number
   zoomLevelCount: number
   dpr: number
+  /** K 线数据条数（用于计算缩放后内容宽度） */
+  dataLength: number
+  /** 视口绘图区宽度（= leftLoadBufferWidth = viewWidth，用于内容宽度计算） */
+  plotWidth: number
+  /** 容器总宽度（用于 maxScroll 裁剪） */
+  clientWidth: number
 }
 
 export interface ZoomResult {
@@ -17,9 +23,14 @@ export interface ZoomResult {
   newKWidth: number
   newKGap: number
   newScrollLeft: number
+  /** 裁剪后的 DOM scrollLeft（已用新 kWidth/kGap 计算内容宽度） */
+  newDomScrollLeft: number
 }
 
 const PHYS_K_GAP_MAX = 3
+
+/** 尾部预留 K 线槽位数（与 ScrollCompensator 保持一致） */
+const TRAILING_SLOTS = 30
 
 /** 将缩放级别转换为 K 线宽度（逻辑像素） */
 export function zoomLevelToKWidth(level: number, config: ZoomConfig): number {
@@ -60,7 +71,16 @@ export function computeZoom(
   const newAnchorWorldPx = newConfig.startXPx + anchorSlotFloat * newConfig.unitPx
   const newScrollLeft = newAnchorWorldPx / config.dpr - mouseX
 
-  return { targetLevel, newKWidth, newKGap, newScrollLeft }
+  // 用新 kWidth/kGap 计算内容宽度，确保裁剪使用正确的（缩放后）尺寸
+  const dataPlotWidth = (newConfig.startXPx + (config.dataLength + TRAILING_SLOTS) * newConfig.unitPx) / config.dpr
+  const newContentWidth = config.plotWidth + Math.max(dataPlotWidth, config.plotWidth)
+  const maxScroll = Math.max(0, newContentWidth - config.clientWidth)
+
+  const domScrollLeft = newScrollLeft + config.plotWidth
+  const newDomScrollLeft =
+    Math.round(Math.max(0, Math.min(domScrollLeft, maxScroll)) * config.dpr) / config.dpr
+
+  return { targetLevel, newKWidth, newKGap, newScrollLeft, newDomScrollLeft }
 }
 
 /**

--- a/packages/core/src/reactivity/signal.ts
+++ b/packages/core/src/reactivity/signal.ts
@@ -2,7 +2,8 @@
  * Tiny push-based reactivity primitive. Zero dependencies.
  *
  * Design constraints:
- * - Synchronous notify on `set` (no microtask scheduling — adapters batch)
+ * - Synchronous notify on `set` when not batched (no microtask scheduling)
+ * - `batch()` defers all notifications until the outermost batch exits
  * - No proxy / no deep tracking — only top-level read/write
  * - Equality short-circuits on `Object.is`
  * - `subscribe` returns an unsubscribe; safe to call from React useSyncExternalStore,
@@ -34,6 +35,9 @@ type Tracker = {
 
 let activeTracker: Tracker | null = null
 
+let batchDepth = 0
+const pendingBatch = new Set<() => void>()
+
 export function createSignal<T>(initial: T): Signal<T> {
   let value = initial
   const subscribers = new Set<() => void>()
@@ -51,8 +55,12 @@ export function createSignal<T>(initial: T): Signal<T> {
   const set = (next: T): void => {
     if (Object.is(value, next)) return
     value = next
-    // copy to allow listener self-unsubscribe during notify
-    for (const listener of [...subscribers]) listener()
+    if (batchDepth > 0) {
+      for (const listener of subscribers) pendingBatch.add(listener)
+    } else {
+      // copy to allow listener self-unsubscribe during notify
+      for (const listener of [...subscribers]) listener()
+    }
   }
 
   const subscribe = (listener: () => void): (() => void) => {
@@ -106,14 +114,34 @@ export function computed<T>(fn: () => T): Computed<T> {
 }
 
 /**
- * Batch multiple signal writes; subscribers fire once per signal after `fn` returns.
- * Useful when controllers mutate several signals in a single transaction.
+ * Batch multiple signal writes into a single notification cycle.
  *
- * Implementation note: current `set` is synchronous-notify; batch wraps writes
- * by deferring notifications via a microtask queue per signal. For now we keep
- * batch a no-op marker since signal writes are already coalesced via Object.is —
- * adapters can wrap their own batching (React's automatic batching, Vue's nextTick).
+ * Inside `batch(fn)`, all `Signal.set()` calls queue their subscribers
+ * instead of notifying immediately. When the outermost batch exits,
+ * every accumulated subscriber fires exactly once (deduplicated).
+ *
+ * Supports nesting — only the outermost batch triggers the flush.
+ *
+ * @example
+ * ```ts
+ * batch(() => {
+ *   signalA.set(1)
+ *   signalB.set('x')
+ *   // subscribers haven't fired yet
+ * })
+ * // all subscribers fire once, deduped
+ * ```
  */
 export function batch<T>(fn: () => T): T {
-  return fn()
+  batchDepth++
+  try {
+    return fn()
+  } finally {
+    batchDepth--
+    if (batchDepth === 0 && pendingBatch.size > 0) {
+      const toNotify = [...pendingBatch]
+      pendingBatch.clear()
+      for (const listener of toNotify) listener()
+    }
+  }
 }

--- a/packages/vue/src/composables/chart/useChartState.ts
+++ b/packages/vue/src/composables/chart/useChartState.ts
@@ -27,7 +27,6 @@ export function useChartState(initialZoom: number, opts?: ChartStateOptions) {
     minKWidth: opts?.minKWidth ?? 1,
     maxKWidth: opts?.maxKWidth ?? 50,
     zoomLevelCount: opts?.zoomLevelCount ?? 20,
-    dpr: opts?.dpr ?? 1,
   })
   kGap.value = kGapFromKWidth(kWidth.value, opts?.dpr ?? 1)
 


### PR DESCRIPTION
## Summary

Fix 5 signal timing hazards in the zoom/interaction pipeline where related signals (`viewportSignal` and `interactionState`) could fire in different synchronous/asynchronous phases, causing consumers to observe stale crosshair index or delayed cursor feedback.

## Changes

### Commits (4)

1. **fix(core): move content-width clamping into computeZoom** (`dbad1c8`)
   - Fixes zoom anchor drift by computing content-width inside `computeZoom` so the scrollLeft clamp uses post-zoom dimensions

2. **fix(core): auto-recalculate crosshair when k-line positions refresh** (`00d05dd`)
   - Stores `lastClientPos` in InteractionController and recalculates crosshair in `setKLinePositions` (called every frame) — fixes stale crosshair after zoom/scroll/resize

3. **fix(core): resolve signal timing hazards in interaction pipeline** (`d9eaa30`)
   - **#1** — `viewportSignal` fires synchronously during zoom, but `interactionState` only updates in the next RAF → moved into `draw()` after `setKLinePositions`, wrapped in `batch()`
   - **#2** — `applyPendingScrollLeft` runs after `draw()` in RAF callback → moved inside `draw()` before `renderPanes`
   - **#3** — `applyPanScroll` writes DOM before cache → reversed to cache-first
   - **#4** — `onPointerDown` doesn't emit `notifyInteractionChange` → added
   - **#5** — `batch()` was a no-op → implemented depth-counted deferred notification

4. **fix(core): split ZoomConfig into ZoomConfigBase to fix CI build** (`96ef818`)
   - `ZoomConfig` added 3 required fields (`dataLength/plotWidth/clientWidth`) in commit 1, breaking callers that only need to compute kWidth from level
   - Split into `ZoomConfigBase` (minKWidth/maxKWidth/zoomLevelCount) and `ZoomConfig` (extends it with full fields)
   - `zoomLevelToKWidth()` now accepts `ZoomConfigBase` — callers like `createChartController` and `useChartState` no longer need to pass irrelevant fields
   - Added `Signal Atomicity` section to `AGENTS.md` codifying the rules discovered

### Files changed

| File | Delta |
|------|-------|
| `AGENTS.md` | +14/-0 |
| `packages/core/src/engine/chart.ts` | +4/-4 |
| `packages/core/src/engine/controller/interaction.ts` | +6/-2 |
| `packages/core/src/engine/data/scrollCompensator.ts` | +4/-1 |
| `packages/core/src/engine/render/chartRenderer.ts` | +7/-3 |
| `packages/core/src/engine/utils/chartZoomController.ts` | +7/-8 |
| `packages/core/src/engine/utils/zoom.ts` | +15/-7 |
| `packages/core/src/reactivity/signal.ts` | +41/-7 |
| `packages/core/src/controllers/createChartController.ts` | +2/-2 |
| `packages/vue/src/composables/chart/useChartState.ts` | +1/-2 |

### Systematic Timing Audit (data buffer & incremental loading)

After fixing the interaction pipeline, the entire data buffer and incremental load hint systems were audited for similar timing hazards:

**Modules audited:**
- `DataBuffer` / `FetchScheduler` / `KLineDataStore` — incremental loading pipeline
- `ScrollCompensator` — scroll position compensation after data prepend
- `IncrementalLoadHint` — visual loading indicator
- `ComparisonManager` — comparison symbol buffer sync
- `ChartDataManager.onKLineBufferChanged` — data change signal chain

**Findings: No new timing hazards.** Key defenses already in place:
- `_attemptedBoundaries` deduplication prevents redundant fetches, clears on no-prepend and error
- `FetchScheduler` correctly serializes async fetch chains via Promise chaining
- `compensatePrepend()` writes scrollLeft cache synchronously before `scheduleDraw()`
- `IncrementalLoadHint._clearTimer()` prevents stale visual hint on rapid data prepends
- All buffer-related operations fire in the same synchronous call stack — no cross-frame signal split

The one observed behavior (crosshair clears after incremental data load) is intentional — `resetInteraction()` clears `lastClientPos` so the crosshair won't auto-restore with potentially stale indices until the next `onPointerMove`.

### Testing

`pnpm test:packages` — 1820 tests passed across all packages.