### PR TITLE
feat: single-path scene renderer + WebGPU backend + FrameTransaction reactivity

### DIFF
--- a/.opencode/plans/2026-07-15-render-compat-layer-PRD.md
+++ b/.opencode/plans/2026-07-15-render-compat-layer-PRD.md
@@ -331,7 +331,8 @@ pnpm type-check
 - [x] Phase 0 — 单路径调度（2026-07-15：删 `renderPanes` 内 Manager.render；`useRenderer` 挂 Scene；去掉 drawing/指标/副图 `setEnabled(false)` 双注册；`setRendererEnabled` 驱动 Layer 显隐；审查修复：paint 隔离 / onUninstall 单点 / useRenderer 幂等）
 - [x] Phase 1 — candle 经 sceneRenderer.drawInstances（2026-07-15：注入 sceneRenderer；drawCandlesViaRenderer；legacy surface 兜底；beginFrame clear；fail-closed）
 - [x] Phase 1.1 样板 — MA 经 drawLinesViaRenderer（2026-07-15：drawLines boolean fail-closed；linesViaRenderer helper；MA 优先 sceneRenderer）
-- [x] Phase 1.1 批量 — 纯折线指标 `tryDrawLinesGpu`（dema/tema/hma/…/rsi/macd-lines/ichimoku 等；BOLL/ENE 含 fill band 仍 legacy）
+- [x] Phase 1.1 批量 — 纯折线指标 `tryDrawLinesGpu`（dema/tema/hma/…/rsi/macd-lines/ichimoku 等）
+- [x] Phase 1.1 fill — BOLL/ENE 经 tryDrawFilledBandGpu + tryDrawLinesGpu（2026-07-15）
 - [ ] Phase 2 — 清理与文档
 - [ ] Phase 3 — WebGPU（可选）
 

--- a/.opencode/plans/2026-07-15-render-compat-layer-PRD.md
+++ b/.opencode/plans/2026-07-15-render-compat-layer-PRD.md
@@ -1,0 +1,350 @@
+# PRD: 渲染管线兼容层拆除 — 单路径 Scene + Renderer
+
+**日期：** 2026-07-15  
+**状态：** Draft  
+**前置：** StateKernel A/B/C 已收口（见 `2026-07-15-statekernel-remaining-PRD.md`）  
+**关联调研：** 同日兼容层问题调研（双路径 / Manager 边界 / Renderer 闲置）
+
+---
+
+## 1. 背景
+
+StateKernel 业务 SSOT 迁移已基本完成。渲染侧仍处在 **新旧双路径并存** 的过渡态：
+
+```
+chartRenderer.renderPanes()
+  ├─ rendererPluginManager.render(paneId, ctx)   // 旧：RendererPlugin.draw(RenderContext)
+  └─ scene.paintPane({ renderer, region, ... }) // 新：Layer.paint(PaintContext)
+```
+
+内置绘制（candle / grid / crosshair / markers / drawing / 主副图指标）已通过 `createLayerFromPlugin` 挂到 Scene，并在 Manager 侧 `setEnabled(false)` 避免双画。但：
+
+1. **每帧仍跑两套调度循环**（复杂度税）
+2. **enabled 双写**（Manager + Layer visibility）
+3. **外部 `chart.useRenderer()` 仍只走旧路径**
+4. **生产代码几乎不调用 `Renderer.drawInstances` / `drawLines`**，真实 WebGL 走 `RenderContext.candleWebGLSurface` / `lineWebGLSurface`，`PaintContext.renderer` 闲置
+5. **WebGPU 迁移路径尚未兑现**
+
+兼容层抽象本身的帧开销可忽略；真正问题是 **架构未闭环** 与 **边界混乱**。
+
+---
+
+## 2. 目标
+
+### 2.1 产品 / 架构目标
+
+1. **单路径绘制调度**：每帧只走 `Scene.paintPane`；不再存在与之并行的 `RendererPluginManager.render` 主路径。
+2. **职责边界清晰**：
+   - StateKernel = 业务 SSOT
+   - Managers = 投影器 / 帧 runtime / 副作用（无影子业务状态）
+   - ChartRenderer = 帧编排（prepare → clear → context → scene → composite）
+   - Scene / Layer = 绘制模块组合与 z-order 调度
+   - Renderer backend = GPU/Canvas 原语（WebGL 现役，WebGPU 可替换）
+3. **Renderer 抽象落地**：新 Layer（至少 candle / line 类）经 `PaintContext.renderer` 发令，不再绑 `RenderContext.*WebGLSurface`。
+4. **外部插件 API 不破坏语义**：`useRenderer` / `removeRenderer` / `setRendererEnabled` 仍可用，内部实现改为 Scene 桥接。
+
+### 2.2 非目标
+
+- 本 PRD **不** 实现完整 WebGPU backend（只保证接口与路径可承载）。
+- **不** 把 canvas / yAxis / RAF 等渲染基础设施塞进 kernel。
+- **不** 重做指标计算 / DataManager / Viewport 业务逻辑。
+- **不** 改动 StateKernel 子模块划分（SSOT 已收口）。
+- Interaction 瞬态（dragStart 等）继续 plain field。
+
+---
+
+## 3. 现状审计（2026-07-15 代码事实）
+
+### 3.1 双路径事实
+
+| 类别 | 注册 | 实际绘制 |
+|------|------|----------|
+| core layers（grid/candle/markers/crosshair/yAxis…） | 仅 `scene.addLayer` | Scene |
+| drawing / drawingLabel | Manager + Scene，Manager `enabled=false` | Scene |
+| 主图/副图指标 | `useRenderer` + `setEnabled(false)` + Layer | Scene |
+| 外部 `chart.useRenderer()` | 仅 Manager | **旧路径** |
+
+结论：内置 **不双画**；旧路径对内置多是 **空转 filter**；外部插件仍依赖旧路径。
+
+### 3.2 兼容层开销
+
+| 层 | 判定 | 说明 |
+|----|------|------|
+| `SurfaceBackend` | 零额外 | 1:1 委托 `SharedWebGLSurface` |
+| `createLayerFromPlugin` | 零额外 | `plugin.draw(getContext())` |
+| Scene filter+sort | 可忽略 | ~15 layers |
+| 双 dispatch | 复杂度为主 | 绘制不双倍，维护成本高 |
+| `createWebGLRenderer` ArrayBuffer 中转 | 潜在 | 当前生产几乎不触发 writeBuffer |
+| `setFallbackContext` | 接口缺口 | `(as any)` 每帧注入；降级 fillRect 很慢 |
+| `buildJoinedPolylineGeometry` | legacy surface 热点 | 厚线无 geometry cache |
+
+### 3.3 Renderer 闲置
+
+- 全仓库生产路径：`drawInstances` / `writeBuffer` **仅** 出现在 `createWebGLRenderer` + 测试。
+- candle / volume / 多数 indicator 直接：`context.candleWebGLSurface.drawRectBuffer` / `lineWebGLSurface.drawLineStrips`。
+
+---
+
+## 4. 目标架构
+
+```
+UI / Public API
+      │ actions / useRenderer
+      ▼
+ StateKernel ──────────────────► readonly signals
+      │                                │
+      │ reconcile                      │ read
+      ▼                                ▼
+ IndicatorManager / SubPaneManager    MarkerManager / DrawingStore
+      │ add|remove|visibility Layer         │ 帧 runtime 投影
+      ▼                                     ▼
+ Scene.layers  ── paintPane ──►  Layer.paint(PaintContext)
+                                        │
+                                        ▼
+                                 Renderer (WebGL → 将来 WebGPU)
+                                        │
+ ChartRenderer：唯一帧循环入口
+   prepareFrame → clear canvases → build context → scene.paintPane → axes / composite
+```
+
+**删除：** 每帧 `rendererPluginManager.render(...)` 作为主绘制入口。
+
+---
+
+## 5. Manager / 组件职责边界（契约）
+
+### 5.1 总原则
+
+| 层 | 做 | 不做 |
+|----|----|------|
+| **StateKernel** | 业务状态 SSOT；actions 写入；readonly 读 | DOM、WebGL、帧缓存 |
+| **Managers** | 读 kernel → 投影到 runtime / Layer 生命周期 | 影子业务数组 / Map 当 SSOT |
+| **ChartRenderer** | 帧编排、context 组装、清屏、调 Scene | 业务状态 |
+| **Scene** | Layer 注册、z-order、`paintPane` | 知道具体 GL 实现 |
+| **Layer** | `paint` 发绘制命令；可有私有 buffer 缓存 | 写 kernel；跨帧业务状态 |
+| **Renderer** | buffer/pipeline/draw* / fallback | 图表业务语义 |
+
+### 5.2 各组件目标职责
+
+| 组件 | 目标职责 | 明确不负责 |
+|------|----------|------------|
+| **ChartDataManager** | 数据源、缓冲、增量加载、对比序列；对齐 kernel data | 绘制调度 |
+| **ChartViewportManager** | 尺寸/DPR/scroll 与 DOM；对齐 kernel viewport | 指标 / settings |
+| **ChartIndicatorManager** | 读 `indicatorState` → 主图 Layer 挂卸 + scheduler 配置 | 自持 active 列表 |
+| **SubPaneManager** | 读 `subPaneState` → pane DOM + Layer reconcile | 自持 subPane SSOT |
+| **MarkerManager** | 帧 runtime：positions / ephemeral / hover / hit-test；读 `customMarkers$` | customMarkers 实体存储 |
+| **DrawingStore** | 读 kernel drawings / selection；供 drawing Layer 与交互 | 本地 drawings 数组 SSOT |
+| **ChartZoomController** | 纯计算（clamp / computeKWidthKGap） | 持有 zoom plain field |
+| **ChartRenderer** | 单路径帧循环 + context 工厂 | 双 dispatch |
+| **Scene / Layer** | 组合与 paint | 业务 SSOT |
+| **RendererPluginManager** | **变形或删除**（见 Phase 0） | 每帧主绘制循环 |
+
+### 5.3 跨帧 vs 帧内
+
+| 跨帧（kernel） | 帧内 / 瞬时（Manager / Renderer plain OK） |
+|----------------|--------------------------------------------|
+| markers 实体、drawings、selection、settings、mode、indicators、pane ratios、zoom | marker positions、hover、dragStart、RAF pending、本帧 kLinePositions 缓存 |
+
+---
+
+## 6. 分阶段实施
+
+### Phase 0 — 单路径调度（P0，必做）
+
+**目标：** 消灭双 dispatch；内置与外部插件统一经 Scene 绘制。
+
+**方案（推荐 A）：**
+
+1. `Chart.useRenderer(plugin)`：
+   - 注册元数据（name / config / enabled）
+   - `createLayerFromPlugin(plugin, getCtx, paneId)` → `scene.addLayer`
+   - **不再**依赖 `RendererPluginManager.render` 画任何东西
+2. `setRendererEnabled` / `removeRenderer` 只驱动 Layer visibility / remove + 元数据
+3. `renderPanes` 删除 `rendererPluginManager.render` 调用
+4. 去掉 drawing / indicator 上的 `setEnabled(false)` 双注册套路（只加 Layer）
+5. `RendererPluginManager` 二选一：
+   - **A1（推荐）：** 降为「插件注册表 + enabled 元数据」，删除 `render()` / `getRenderers` 绘制语义
+   - **A2：** 直接删除，逻辑并入 ChartRenderer / 薄 `PluginLayerRegistry`
+
+**验收：**
+
+- [ ] `renderPanes` 内无 `rendererPluginManager.render`
+- [ ] 内置插件无 `setEnabled(false)` 仅为了防双画
+- [ ] 外部 `useRenderer` 插件在 Scene 路径可见
+- [ ] `pnpm -r test` 相关 suite 全绿
+- [ ] 手动：主图 / 副图 / drawing / crosshair / 外部 mock 插件无回归
+
+**风险：**
+
+- system 渲染器（timeAxis 等）当前走 `renderPlugin` / 独立 Layer —— 需统一清单，避免漏挂
+- UpdateLevel Main/Overlay 过滤现由 Manager 做；Scene 需等价策略（role 过滤已部分存在）
+
+---
+
+### Phase 1 — Renderer API 落地（P1）
+
+**目标：** 至少一条生产绘制路径经 `PaintContext.renderer`，证明后端可替换。
+
+**范围（建议顺序）：**
+
+1. **Candle Layer 真用 Renderer**
+   - `drawInstances` 画 body/wick（或等价 batch）
+   - 不再在 candle 路径读 `context.candleWebGLSurface`（可暂留 fallback 分支）
+2. **Line 类指标抽公共 helper**
+   - `drawLines` / fill band 走 Renderer
+3. **RenderContext 瘦身计划**
+   - 标记 `candleWebGLSurface` / `lineWebGLSurface` 为 deprecated
+   - 新代码禁止新增 surface 直调
+
+**可选同步：**
+
+- `writeBuffer` 直写 `WebGLBuffer`，去掉 JS `ArrayBuffer` 中转（仅当 Phase 1 真走 writeBuffer 时有收益）
+- `setFallbackContext` 升为 `Renderer` 正式可选 API 或内建 Canvas2D backend
+
+**验收：**
+
+- [ ] candle 生产路径调用 `renderer.drawInstances`（或文档化的等价 Renderer API）
+- [ ] WebGL 不可用时 fallback 仍正确（测试：`webglRenderer.fallback.test.ts` 扩展）
+- [ ] 无视觉回归（对比截图或关键 e2e 可选）
+
+---
+
+### Phase 2 — 清理与性能（P2）
+
+1. 删除 / 收口 `createLayerFromPlugin` 中「永远忽略 `ctx.renderer`」的旧插件（已迁完的 Layer 改为 native Layer）
+2. 移除 `RenderContext` 上 WebGL surface 字段（或仅内部测试保留）
+3. `buildJoinedPolylineGeometry` geometry cache（legacy 或 Renderer 路径均可）
+4. 文档：更新 `docs/rendering-engine-architecture.md` 与 `docs/architecture.md`，标明单路径 + 职责边界
+5. 删除死代码：`RendererPluginManager.render` 若已无调用、双写 visibility 辅助等
+
+**验收：**
+
+- [ ] `git grep candleWebGLSurface packages/core/src/engine/renderers` → 零（或仅 fallback 白名单）
+- [ ] 无 `setFallbackContext` 的 `(as any)` 调用
+- [ ] 架构文档与代码一致
+
+---
+
+### Phase 3 — WebGPU 预备（P3，可选 / 后续 PR）
+
+- 实现 `createWebGPURenderer` 满足 `Renderer` 契约
+- feature detect + 运行时切换
+- compute 路径留给 volume profile / footprint 等
+
+**本 PRD 不要求交付 WebGPU 实现。**
+
+---
+
+## 7. 外部 API 兼容
+
+| API | 行为保持 | 内部变化 |
+|-----|----------|----------|
+| `chart.useRenderer(plugin, config?)` | 插件参与绘制 | 进 Scene Layer，不进 Manager.render |
+| `chart.removeRenderer(name)` | 移除 | `scene.removeLayer` + 注销元数据 |
+| `chart.setRendererEnabled(name, bool)` | 显隐 | Layer.visible（+ 元数据） |
+| `chart.getRenderer(name)` | 取插件实例 | 注册表查询 |
+| `chart.updateRendererConfig` | 改配置并重绘 | 不变语义 |
+| RendererPlugin 形状（`draw(RenderContext)`） | Phase 0 仍支持 | Phase 1+ 鼓励 native Layer |
+
+Breaking 仅在：**依赖「插件只注册到 Manager、且自己调用 render」的非常规用法** —— 仓库内无此用法则无需 major；若有公开文档写 Manager 内部细节需同步。
+
+---
+
+## 8. 测试策略
+
+| 层级 | 内容 |
+|------|------|
+| 单元 | Scene paint 顺序；useRenderer → Layer 存在；setEnabled → visible；无 Manager.render 调用（spy） |
+| 回归 | 现有 `layerFromPlugin` / `webglRenderer` / indicator / subPane / drawing 测试 |
+| 集成（可选） | 一帧内启用插件列表快照；UpdateLevel Overlay 只 paint overlay roles |
+| 手动 | 主图缩放滚动、副图增删、画线、十字线、主题切换、WebGL 关闭降级 |
+
+命令：
+
+```bash
+pnpm -r test
+pnpm type-check
+```
+
+---
+
+## 9. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| system 渲染器漏挂导致轴/时间轴空白 | Phase 0 前列出全部 system / global 插件清单与挂载点 |
+| UpdateLevel 语义漂移 | Scene 侧用 `roles` + Layer.role/overlay 对齐现有 Main/Overlay 过滤 |
+| 外部插件依赖 RenderContext 全字段 | Phase 0 继续注入完整 RenderContext；Phase 1 再瘦 |
+| 性能回退 | Phase 0 前后用 Performance 面板对比一帧；预期持平或略好（少一次空循环） |
+| 双写 visibility 历史调用残留 | 统一 helper：`setPluginVisible(name, v)` 单入口 |
+
+---
+
+## 10. 成功标准（Definition of Done）
+
+**Phase 0 Done：**
+
+- 单路径调度；双路径结构消除
+- 外部插件走 Scene
+- 测试全绿
+
+**Phase 1 Done：**
+
+- 至少 candle 生产路径经 Renderer API
+- fallback 覆盖
+
+**Phase 2 Done：**
+
+- surface 直调清理；文档更新；无 `(as any).setFallbackContext`
+
+**整体：**
+
+- 兼容层（双路径 + 双注册 + surface 旁路）可声明拆除
+- Manager 职责与本文 §5 一致
+- 具备接入 WebGPU backend 的管线形状
+
+---
+
+## 11. 建议实施顺序与估算
+
+| 阶段 | 内容 | 粗估 |
+|------|------|------|
+| Phase 0 | 单路径 + useRenderer 桥 + 删 Manager.render | 1–2 PR |
+| Phase 1 | Candle（+ 可选 line）迁 Renderer | 1–2 PR |
+| Phase 2 | 清理 / cache / 文档 | 1 PR |
+| Phase 3 | WebGPU | 独立 epic |
+
+**推荐立即开工：Phase 0。** 收益最大、风险可控、不依赖 WebGPU。
+
+---
+
+## 12. 文档与跟踪
+
+- 本 PRD：`.opencode/plans/2026-07-15-render-compat-layer-PRD.md`
+- 后续可拆：
+  - Spec：`docs/superpowers/specs/2026-07-15-render-single-path-design.md`
+  - Plan：`docs/superpowers/plans/2026-07-15-render-single-path.md`
+- 完成后回写 `docs/rendering-engine-architecture.md`
+
+### 状态勾选
+
+- [x] Phase 0 — 单路径调度（2026-07-15：删 `renderPanes` 内 Manager.render；`useRenderer` 挂 Scene；去掉 drawing/指标/副图 `setEnabled(false)` 双注册；`setRendererEnabled` 驱动 Layer 显隐；审查修复：paint 隔离 / onUninstall 单点 / useRenderer 幂等）
+- [x] Phase 1 — candle 经 sceneRenderer.drawInstances（2026-07-15：注入 sceneRenderer；drawCandlesViaRenderer；legacy surface 兜底；beginFrame clear；fail-closed）
+- [x] Phase 1.1 样板 — MA 经 drawLinesViaRenderer（2026-07-15：drawLines boolean fail-closed；linesViaRenderer helper；MA 优先 sceneRenderer）
+- [x] Phase 1.1 批量 — 纯折线指标 `tryDrawLinesGpu`（dema/tema/hma/…/rsi/macd-lines/ichimoku 等；BOLL/ENE 含 fill band 仍 legacy）
+- [ ] Phase 2 — 清理与文档
+- [ ] Phase 3 — WebGPU（可选）
+
+---
+
+## 13. 与 StateKernel PRD 的关系
+
+| 主题 | 归属 |
+|------|------|
+| 业务状态 SSOT、影子 Map/数组 | StateKernel PRD（已基本完成） |
+| 绘制调度双路径、Renderer 闲置、Manager 绘制职责 | **本 PRD** |
+| npm scope 数字开头构建问题 | StateKernel PRD 附录（独立决策，非本 PRD） |
+
+两线正交：SSOT 不阻塞本 PRD；本 PRD 不回退 SSOT。
+
+(End of PRD)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,9 @@ Never guess at Effect patterns - check the guide first.
 - No Markdown symbols: no backticks, bold, or arrows. Use natural language for code references.
 - Prefer JSDoc tags: `@remarks` (detailed explanation), `@param`, `@returns`, `@typeParam`, `@example`.
 - Inline comments: `/** brief */` or `// brief`, no tags needed.
+- **Say what it is, not what to do with it**
+- **Never invent Chinese jargon**
+- **One sentence if possible**
 
 ## ATTENTION
 - You can only commit when I explicitly ask you to do it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,10 @@ Never guess at Effect patterns - check the guide first.
 - **Semantic renderer names** (e.g. `ma`, `boll`) are stringly-typed conventions — renaming requires sync in `semantic/controller.ts`.
 - **Web component build**: `pnpm build:wc` in packages/vue (cross-env BUILD_TARGET=web-component).
 
+## Lessons Learned
+
+- **Do not reuse GPU instance buffers across draw calls in the same frame**. `packages/core/src/engine/renderers/rectsViaRenderer.ts` used to cache instance buffers by slot per renderer. Because `drawRectBatchesViaRenderer` reset the slot counter to 0 on every call, the main pane candle batches and the MACD sub-pane batches shared the same GPU buffers within a single frame. MACD wrote later and overwrote the candle instance data, causing the left-side K-line bodies to disappear. The fix is to create and destroy an instance buffer per batch; only cache the pipeline and unit vertex buffer. See also `packages/core/src/rendering/render/createWebGPURenderer.ts` for the WebGPU backend details.
+
 ## Comment Style
 
 - Language: body in Chinese; technical terms keep English (Signal, batch, computed, Action, etc.)

--- a/docs/superpowers/plans/2026-07-15-render-phase1-candle-renderer.md
+++ b/docs/superpowers/plans/2026-07-15-render-phase1-candle-renderer.md
@@ -1,0 +1,607 @@
+# Phase 1: Candle via Renderer API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让主图蜡烛生产路径经 `PaintContext.renderer.drawInstances` 绘制，证明后端可替换；不再依赖 `RenderContext.candleWebGLSurface` 旁路。
+
+**Architecture:** Phase 0 已单路径 Scene 调度。Phase 1 把 candle 从「plugin.draw → candleWebGLSurface.drawRectBuffer」改为「Layer.paint → renderer.writeBuffer/drawInstances → surface.compositeTo」。几何准备（`prepareCandles`）保持不变；仅换出口。Canvas2D 与 WebGL 不可用时仍走现有 2D 回退。
+
+**Tech Stack:** TypeScript、vitest、WebGL2（`createWebGLRenderer` / `CandleWebGLSurface`）、Scene Layer。
+
+**PRD:** `.opencode/plans/2026-07-15-render-compat-layer-PRD.md` §Phase 1  
+**前置:** Phase 0 已完成（`renderPanes` 无 `Manager.render`；`useRenderer` 挂 Scene）
+
+---
+
+## File map
+
+| File | Role |
+|------|------|
+| `packages/core/src/rendering/render/Renderer.ts` | 可选：正式暴露 composite / setFallbackContext（若需） |
+| `packages/core/src/rendering/render/createWebGLRenderer.ts` | 确保 drawInstances + composite 契约稳定 |
+| `packages/core/src/rendering/scene/createLayerFromPlugin.ts` | 将 `PaintContext.renderer` 注入 draw（最小改动） |
+| `packages/core/src/foundation/plugin/types.ts` | `RenderContext` 增加可选 `sceneRenderer?: Renderer` **或** 扩展 draw 签名 |
+| `packages/core/src/engine/renderers/candle.ts` | 生产 candle 改走 Renderer API |
+| `packages/core/src/engine/render/layers/candleLayer.ts` | 保持工厂；依赖上述注入 |
+| `packages/core/src/engine/render/chartRenderer.ts` | beginFrame 后确保 fallback/composite 目标正确 |
+| `packages/core/src/engine/renderers/candle.ts` 旁测 / 新测 | 单测 drawInstances 被调用 |
+| `packages/core/src/rendering/render/__tests__/webglRenderer*.ts` | 已有；扩展 composite 断言 |
+
+**Out of scope this plan:** 全量 line 指标迁移、删掉所有 `*WebGLSurface` 字段、WebGPU 实现、buffer 去 ArrayBuffer 中转（可作 Task 后续 optional）。
+
+---
+
+## Design decisions (lock before coding)
+
+### D1 — 如何把 Renderer 交给 candle
+
+**选用方案 B（推荐，改动面小）：**
+
+在 `createLayerFromPlugin.paint` 里：
+
+```ts
+const context = getContext()
+if (!context) return
+// 注入本帧 Scene 的 Renderer，供已迁路径使用
+;(context as RenderContext & { sceneRenderer?: Renderer }).sceneRenderer = ctx.renderer
+plugin.draw(context)
+```
+
+Candle 内：
+
+```ts
+const r = context.sceneRenderer
+if (r) drawCandlesViaRenderer(r, ...)
+else /* 旧 surface 或 2D */
+```
+
+**不选 A（改 RendererPlugin.draw 签名）** — 波及全部插件。  
+**不选 C（完全 native candle Layer 重写）** — 可作后续清理，本 plan 不强制。
+
+### D2 — 画到哪块 surface
+
+`chartRenderer` 的 `sceneRenderer = createWebGLRenderer(sharedSurface, sharedSurface)` 内部已有 **自己的** `CandleWebGLSurface`。  
+`drawInstances` 已委托 `candleSurface.drawRectBuffer`。
+
+Composite：candle 成功 drawInstances 后调用：
+
+```ts
+context.sceneRenderer.surface.compositeTo(context.ctx, context 对应 region, { imageSmoothingEnabled: false })
+```
+
+注意：`beginFrame(region)` 已在 `paintPane` 前调用，region 与 pane 对齐。  
+**不要**再用 `context.candleWebGLSurface`（pane 级另一套 surface）画 candle，避免双 surface。
+
+### D3 — 回退顺序
+
+```
+enableWebGLRendering === false  → Canvas2D
+sceneRenderer 缺失 / caps 不可用 → Canvas2D  
+drawInstances 失败（无 pipeline）→ Canvas2D
+成功 → compositeTo main ctx
+```
+
+### D4 — setFallbackContext
+
+现每帧 `(sceneRenderer as any).setFallbackContext(overlayCtx)`。  
+Candle 失败时应画在 **mainCtx**，不是 overlay。  
+Phase 1：candle 成功路径不依赖 fallback；失败走 `drawCandlesWithCanvas2D(mainCtx)`。  
+`setFallbackContext` 正规化可放 Task 6 optional。
+
+---
+
+### Task 1: 抽 `drawCandlesViaRenderer` 纯函数 + 失败测试
+
+**Files:**
+- Create: `packages/core/src/engine/renderers/candleViaRenderer.ts`
+- Create: `packages/core/src/engine/renderers/__tests__/candleViaRenderer.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// packages/core/src/engine/renderers/__tests__/candleViaRenderer.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import { drawCandlesViaRenderer } from '../candleViaRenderer'
+import type { Renderer } from '../../../rendering/render/Renderer'
+
+function mockRenderer(): Renderer & {
+  writeBuffer: ReturnType<typeof vi.fn>
+  drawInstances: ReturnType<typeof vi.fn>
+  createBuffer: ReturnType<typeof vi.fn>
+  createPipeline: ReturnType<typeof vi.fn>
+} {
+  const buffers = new Map<object, ArrayBuffer>()
+  const pipelines = new Map<object, { type: string }>()
+  return {
+    surface: {
+      isAvailable: () => true,
+      resize: () => {},
+      bindRegion: () => true,
+      clearRegion: () => {},
+      compositeTo: vi.fn(),
+      dispose: () => {},
+    },
+    caps: { compute: false, storageBuffer: false, maxInstances: 1e6, name: 'webgl2' },
+    createBuffer: vi.fn((usage, size) => {
+      const h = {}
+      buffers.set(h, new ArrayBuffer(size))
+      return h as never
+    }),
+    writeBuffer: vi.fn((handle, data: ArrayBufferView) => {
+      /* store optional */
+    }),
+    destroyBuffer: vi.fn(),
+    createPipeline: vi.fn((desc: { type: string }) => {
+      const h = {}
+      pipelines.set(h, desc)
+      return h as never
+    }),
+    destroyPipeline: vi.fn(),
+    createComputePipeline: () => {
+      throw new Error('no')
+    },
+    destroyComputePipeline: () => {},
+    beginFrame: vi.fn(),
+    drawInstances: vi.fn(),
+    drawLines: vi.fn(),
+    dispatchCompute: () => {},
+    endFrame: vi.fn(),
+    dispose: vi.fn(),
+  } as never
+}
+
+describe('drawCandlesViaRenderer', () => {
+  it('issues 4 drawInstances for non-empty up/down body and wick', () => {
+    const r = mockRenderer()
+    const prepared = {
+      upBodyCount: 1,
+      downBodyCount: 1,
+      upWickCount: 1,
+      downWickCount: 1,
+      upBodyBuf: new Float32Array([0, 0, 10, 20]),
+      downBodyBuf: new Float32Array([20, 0, 10, 20]),
+      upWickBuf: new Float32Array([5, 0, 1, 30]),
+      downWickBuf: new Float32Array([25, 0, 1, 30]),
+    }
+    const ok = drawCandlesViaRenderer(r, prepared as never, '#0f0', '#f00', 0)
+    expect(ok).toBe(true)
+    expect(r.drawInstances).toHaveBeenCalledTimes(4)
+  })
+
+  it('returns false when instanceCount all zero without calling draw', () => {
+    const r = mockRenderer()
+    const prepared = {
+      upBodyCount: 0,
+      downBodyCount: 0,
+      upWickCount: 0,
+      downWickCount: 0,
+      upBodyBuf: new Float32Array(0),
+      downBodyBuf: new Float32Array(0),
+      upWickBuf: new Float32Array(0),
+      downWickBuf: new Float32Array(0),
+    }
+    const ok = drawCandlesViaRenderer(r, prepared as never, '#0f0', '#f00', 0)
+    expect(ok).toBe(true) // nothing to draw is success
+    expect(r.drawInstances).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL (module missing)**
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/engine/renderers/__tests__/candleViaRenderer.test.ts
+```
+
+Expected: cannot find module / drawCandlesViaRenderer not defined
+
+- [ ] **Step 3: Minimal implementation**
+
+```ts
+// packages/core/src/engine/renderers/candleViaRenderer.ts
+import type { Renderer, BufferHandle, PipelineHandle } from '../../rendering/render/Renderer'
+
+export type CandleRectBatch = {
+  upBodyCount: number
+  downBodyCount: number
+  upWickCount: number
+  downWickCount: number
+  upBodyBuf: Float32Array
+  downBodyBuf: Float32Array
+  upWickBuf: Float32Array
+  downWickBuf: Float32Array
+}
+
+/** 经 Renderer.drawInstances 画 body/wick；不负责 composite */
+export function drawCandlesViaRenderer(
+  renderer: Renderer,
+  prepared: CandleRectBatch,
+  upColor: string,
+  downColor: string,
+  scrollLeft: number,
+): boolean {
+  try {
+    const pipeline = renderer.createPipeline({ type: 'candle' }) as PipelineHandle
+    const unit = renderer.createBuffer('vertex', 64)
+
+    const drawBatch = (buf: Float32Array, count: number, color: string) => {
+      if (count <= 0) return
+      const instances = renderer.createBuffer('instance', count * 4 * 4)
+      renderer.writeBuffer(instances, buf.subarray(0, count * 4))
+      renderer.drawInstances({
+        pipeline,
+        vertices: unit,
+        instances,
+        instanceCount: count,
+        vertexCount: 6,
+        uniforms: { color, scrollLeft },
+      })
+      renderer.destroyBuffer(instances)
+    }
+
+    drawBatch(prepared.upBodyBuf, prepared.upBodyCount, upColor)
+    drawBatch(prepared.downBodyBuf, prepared.downBodyCount, downColor)
+    drawBatch(prepared.upWickBuf, prepared.upWickCount, upColor)
+    drawBatch(prepared.downWickBuf, prepared.downWickCount, downColor)
+
+    renderer.destroyBuffer(unit)
+    renderer.destroyPipeline(pipeline)
+    return true
+  } catch {
+    return false
+  }
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/engine/renderers/__tests__/candleViaRenderer.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/engine/renderers/candleViaRenderer.ts packages/core/src/engine/renderers/__tests__/candleViaRenderer.test.ts
+git commit -m "feat(core): add drawCandlesViaRenderer helper for Renderer API"
+```
+
+---
+
+### Task 2: 注入 `sceneRenderer` 到 RenderContext
+
+**Files:**
+- Modify: `packages/core/src/foundation/plugin/types.ts` (`RenderContext`)
+- Modify: `packages/core/src/rendering/scene/createLayerFromPlugin.ts`
+- Modify: `packages/core/src/rendering/scene/__tests__/layerFromPlugin.test.ts`
+
+- [ ] **Step 1: Extend RenderContext type**
+
+In `types.ts` `RenderContext` 增加：
+
+```ts
+/** Phase 1: Scene 本帧 Renderer；candle 等迁出 surface 旁路时使用 */
+sceneRenderer?: import('../../rendering/render/Renderer').Renderer
+```
+
+- [ ] **Step 2: Inject in createLayerFromPlugin**
+
+```ts
+paint(ctx: PaintContext) {
+  if (!visible) return
+  if (paneRole === 'sub' && ctx.paneId !== targetPaneId) return
+  const context = getContext()
+  if (!context) return
+  context.sceneRenderer = ctx.renderer
+  try {
+    plugin.draw(context)
+  } catch (e) {
+    console.error(`[RendererPlugin] ${plugin.name} draw error:`, e)
+  }
+}
+```
+
+- [ ] **Step 3: Test injection**
+
+```ts
+it('assigns PaintContext.renderer to RenderContext.sceneRenderer before draw', () => {
+  const plugin = makeMockPlugin({
+    draw: vi.fn((c: RenderContext) => {
+      expect(c.sceneRenderer).toBe(stubPaintCtx.renderer)
+    }),
+  })
+  const context = makeMockContext()
+  const layer = createLayerFromPlugin(plugin, () => context, 'main')
+  layer.paint(stubPaintCtx)
+  expect(plugin.draw).toHaveBeenCalledOnce()
+})
+```
+
+- [ ] **Step 4: Run**
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/rendering/scene/__tests__/layerFromPlugin.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/foundation/plugin/types.ts packages/core/src/rendering/scene/createLayerFromPlugin.ts packages/core/src/rendering/scene/__tests__/layerFromPlugin.test.ts
+git commit -m "feat(core): inject sceneRenderer into RenderContext for layers"
+```
+
+---
+
+### Task 3: Candle 生产路径改走 Renderer API
+
+**Files:**
+- Modify: `packages/core/src/engine/renderers/candle.ts` (`draw` + `drawCandlesWithWebGL` 替换/旁路)
+- Keep: `prepareCandles`、`drawCandlesWithCanvas2D`、`drawVolumePriceMarkers` 不变
+
+- [ ] **Step 1: Rewrite draw branch**
+
+Replace `draw` 内 WebGL 分支逻辑为：
+
+```ts
+draw(context: RenderContext) {
+  // ... existing prepare ...
+  const prepared = prepareCandles(...)
+  const up = colors.candleUpBody
+  const down = colors.candleDownBody
+
+  let usedGpu = false
+  if (context.settings?.enableWebGLRendering !== false && context.sceneRenderer) {
+    usedGpu = drawCandlesViaRenderer(
+      context.sceneRenderer,
+      prepared,
+      up,
+      down,
+      context.scrollLeft,
+    )
+    if (usedGpu) {
+      context.sceneRenderer.surface.compositeTo(context.ctx, {
+        // region: beginFrame 已 bind；SurfaceBackend.compositeTo 用当前 region
+        // 若 API 需要 region，从 context.viewport + pane 构造
+      } as never)
+      // 实际签名见 SurfaceBackend.compositeTo(targetCtx, region, options)
+      // 必须传入与 beginFrame 相同的 region；若 sceneRenderer 内部持有 lastRegion，可扩展 getLastRegion
+    }
+  }
+  if (!usedGpu) {
+    // 过渡：仍可尝试旧 candleWebGLSurface（一帧双保险 optional）
+    // Phase 1 完成标准：优先 sceneRenderer；旧 surface 仅 fallback
+    const legacy = drawCandlesWithWebGL(context, prepared, up, down)
+    if (!legacy) {
+      drawCandlesWithCanvas2D(ctx, scrollLeft, prepared, up, down)
+    } else {
+      compositeWebGLToMainCanvas(ctx, context)
+    }
+  }
+
+  drawVolumePriceMarkers(...)
+}
+```
+
+**重要：** 查 `SurfaceBackend.compositeTo` 签名（`createWebGLSurfaceBackend`）——需要 `region`。  
+若 `sceneRenderer` 未暴露 lastRegion，二选一：
+
+1. 在 `createWebGLRenderer` 存 `lastRegion`，增加 `getLastRegion(): SurfaceRegion | null`（非公开也可 cast）
+2. 或 candle 从 `context.viewport` + `pane` 重建 region：`{ x:0, y: pane.top, width: plotWidth, height: pane.height, dpr }`
+
+推荐 **方案 2**（不扩接口）：与 `chartRenderer.renderPanes` 构造 region 一致。
+
+```ts
+const region = {
+  x: 0,
+  y: context.pane.top,
+  width: context.viewport?.plotWidth ?? context.paneWidth,
+  height: context.pane.height,
+  dpr: context.dpr,
+}
+context.sceneRenderer.surface.compositeTo(context.ctx, region, {
+  imageSmoothingEnabled: false,
+})
+```
+
+- [ ] **Step 2: Unit test candle prefers sceneRenderer**
+
+```ts
+// packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
+it('uses sceneRenderer.drawInstances when present', () => {
+  const drawInstances = vi.fn()
+  // build minimal RenderContext with sceneRenderer mock + data
+  // call createCandleRenderer().draw(context)
+  // expect drawInstances called; candleWebGLSurface.drawRectBuffer not called
+})
+```
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/engine/renderers/__tests__/candle
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/engine/renderers/candle.ts packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts packages/core/src/engine/renderers/candleViaRenderer.ts
+git commit -m "feat(core): draw candles via PaintContext sceneRenderer"
+```
+
+---
+
+### Task 4: 修正 composite / region 与手动验收脚本
+
+**Files:**
+- Modify: `packages/core/src/engine/renderers/candle.ts`（若 Task 3 composite 有误）
+- Modify: `packages/core/src/rendering/render/createWebGLRenderer.ts`（仅当 composite 需要 lastRegion）
+
+- [ ] **Step 1: Verify SurfaceBackend.compositeTo signature**
+
+Read `packages/core/src/rendering/render/SurfaceBackend.ts` and `createWebGLSurfaceBackend.ts`. Wire exact args.
+
+- [ ] **Step 2: Manual checklist (dev server)**
+
+```
+pnpm dev
+```
+
+1. 主图蜡烛可见、涨跌色正确  
+2. 缩放滚动无花屏  
+3. 分时切 K 线蜡烛显隐正常  
+4. 关闭 WebGL 设置（若有）→ 2D 蜡烛仍在  
+5. 控制台无 draw 风暴错误  
+
+- [ ] **Step 3: Run broader suite**
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/engine src/rendering
+```
+
+Expected: all pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "fix(core): correct candle composite region for sceneRenderer"
+```
+
+---
+
+### Task 5: 废弃 candle 对 pane surface 的依赖（软）
+
+**Files:**
+- Modify: `packages/core/src/engine/renderers/candle.ts`
+- Modify: `packages/core/src/foundation/plugin/types.ts`（JSDoc deprecated on `candleWebGLSurface`）
+
+- [ ] **Step 1: Prefer-only sceneRenderer**
+
+当 `context.sceneRenderer` 存在时，**不要**再调用 `drawCandlesWithWebGL`（旧 surface）。  
+仅 `sceneRenderer` 缺失时才 legacy。
+
+```ts
+if (context.sceneRenderer && settings webgl on) {
+  usedGpu = drawCandlesViaRenderer(...)
+  if (usedGpu) composite...
+} else if (/* legacy */) {
+  drawCandlesWithWebGL(...)
+} else {
+  drawCandlesWithCanvas2D(...)
+}
+```
+
+- [ ] **Step 2: JSDoc**
+
+```ts
+/** @deprecated Phase 1+: prefer context.sceneRenderer; remove after all rect drawers migrate */
+candleWebGLSurface?: CandleWebGLSurface
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -am "chore(core): deprecate candleWebGLSurface for candle path"
+```
+
+---
+
+### Task 6 (optional): `setFallbackContext` 正规化
+
+**Files:**
+- Modify: `packages/core/src/rendering/render/Renderer.ts`
+- Modify: `packages/core/src/rendering/render/createWebGLRenderer.ts`
+- Modify: `packages/core/src/engine/render/chartRenderer.ts`（去掉 `as any`）
+
+Only if Task 3–5 green and time remains.
+
+```ts
+// Renderer.ts optional method
+setFallbackContext?(ctx: CanvasRenderingContext2D | null, dpr: number): void
+```
+
+```ts
+// chartRenderer
+this.sceneRenderer.setFallbackContext?.(mainCtx ?? null, vp.dpr)
+```
+
+Note: candle no longer needs overlay as fallback.
+
+---
+
+### Task 7: 文档与 PRD 勾选
+
+**Files:**
+- Modify: `.opencode/plans/2026-07-15-render-compat-layer-PRD.md` Phase 1 checkbox
+- Optional: `docs/rendering-engine-architecture.md` 一小节「candle 经 Renderer」
+
+- [ ] **Step 1: Update PRD**
+
+```markdown
+- [x] Phase 1 — Renderer API 生产落地（candle drawInstances + sceneRenderer 注入）
+```
+
+- [ ] **Step 2: Final test**
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/engine src/rendering src/foundation/plugin
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .opencode/plans/2026-07-15-render-compat-layer-PRD.md docs/
+git commit -m "docs: mark render Phase 1 candle via Renderer done"
+```
+
+---
+
+## Testing summary
+
+| Level | What |
+|-------|------|
+| Unit | `drawCandlesViaRenderer` 4× drawInstances；layer 注入 sceneRenderer；candle 优先 sceneRenderer |
+| Regression | `chart.dpr`、layerFromPlugin、webglRenderer.fallback |
+| Manual | 见 Task 4 清单 |
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/engine/renderers/__tests__/candleViaRenderer.test.ts src/engine/renderers/__tests__/candle.sceneRenderer.test.ts src/rendering/scene/__tests__/layerFromPlugin.test.ts
+```
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| sceneRenderer 与 pane candleSurface 双 surface 坐标不一致 | candle 只走 sceneRenderer；beginFrame region 与 pane 对齐 |
+| 每帧 createPipeline/createBuffer 开销 | Task 1 可后续改为 Layer 私有缓存 pipeline/buffer（YAGNI 先正确） |
+| composite 区域错误导致空白 | Task 4 手测 + region 与 renderPanes 同构 |
+| 旧测试依赖 candleWebGLSurface | 更新 mock 提供 sceneRenderer |
+
+---
+
+## Self-review vs PRD Phase 1
+
+| PRD 项 | Task |
+|--------|------|
+| candle 经 drawInstances | Task 1 + 3 |
+| 不读 candleWebGLSurface（软废弃） | Task 5 |
+| fallback 正确 | Task 3 Canvas2D + Task 6 optional |
+| 无视觉回归 | Task 4 manual |
+| line helper | **Out of scope** — 记 Phase 1.1 |
+| writeBuffer 去 ArrayBuffer 中转 | **Out of scope** — Phase 2 |
+
+---
+
+## Execution handoff
+
+Plan saved to `docs/superpowers/plans/2026-07-15-render-phase1-candle-renderer.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks  
+2. **Inline Execution** — this session with executing-plans checkpoints  
+
+Which approach?

--- a/docs/superpowers/plans/2026-07-16-drawing-session-ssot.md
+++ b/docs/superpowers/plans/2026-07-16-drawing-session-ssot.md
@@ -1,0 +1,25 @@
+# Drawing Session SSOT Implementation Plan
+
+> Status: implemented in-session (2026-07-16)
+
+**Goal:** Kernel holds only committed drawings; session holds preview/drag; DrawingStore merges for paint.
+
+## Done
+
+1. Spec: `docs/superpowers/specs/2026-07-16-drawing-session-ssot-design.md`
+2. `DrawingState` — no full list; `preview` + `dragOverride`; `mergePaint`; commit on `commitDrag` / CRUD
+3. `DrawingInteractionController` — move uses session only; up commits drag
+4. `DrawingStore` + Chart `getOverlay` from `drawingSession.getPaintOverlay()`
+5. `DrawingChartAdapter.requestDraw` + ChartController wiring
+6. Chart `setDrawings` strips `__preview__`
+7. Vue: stop mirroring session list on pointermove; drop `setDrawings` echo on kernel subscribe
+8. Tests: drawingState / drawingStore / chart.dpr — green
+
+## Verify
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run \
+  src/engine/drawing/__tests__/drawingState.workCopy.test.ts \
+  src/engine/drawing/__tests__/drawingStore.projection.test.ts \
+  src/engine/__tests__/chart.dpr.test.ts
+```

--- a/docs/superpowers/plans/2026-07-16-frame-transaction.md
+++ b/docs/superpowers/plans/2026-07-16-frame-transaction.md
@@ -53,8 +53,9 @@
 
 ### Task 5: Delete legacy high-frequency signals
 
-- [ ] remove kLinePositions/crosshair high-freq dual paths
-- [ ] full core tests + tsc
+- [x] move kLinePositions/centers/kWidthPx off kernel signals into InteractionController private fields
+- [x] crosshairIndex becomes explicit write on flush (not computed from geometry signals)
+- [x] full core tests + tsc
 
 ---
 

--- a/docs/superpowers/plans/2026-07-16-frame-transaction.md
+++ b/docs/superpowers/plans/2026-07-16-frame-transaction.md
@@ -1,0 +1,66 @@
+# Frame Transaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or executing-plans. Steps use checkbox syntax.
+
+**Goal:** Add a single-generation frame transaction primitive, then migrate chart high-frequency state onto it without dual latest/published views.
+
+**Architecture:** Private pending input + capture/derive/seal/render/publish phases; one immutable snapshot signal; re-entrant writes go to next generation.
+
+**Tech Stack:** TypeScript, vitest, existing `createSignal` / `batch` in `packages/core/src/foundation/reactivity`.
+
+---
+
+### Task 1: FrameTransaction primitive
+
+**Files:**
+- Create: `packages/core/src/foundation/reactivity/frameTransaction.ts`
+- Create: `packages/core/src/foundation/reactivity/__tests__/frameTransaction.test.ts`
+- Modify: `packages/core/src/foundation/reactivity/index.ts`
+
+- [ ] Failing tests for coalesce, generation, re-entry isolation, fail-no-publish, selector equality
+- [ ] Implement `createFrameTransaction`
+- [ ] Export from reactivity index
+- [ ] `vitest run` on the new test file
+
+### Task 2: Renderer single snapshot
+
+**Files:**
+- Modify: `packages/core/src/engine/render/chartRenderer.ts`
+- Tests around prepareFrameData / draw paths
+
+- [ ] Build immutable frame snapshot in prepare
+- [ ] Pass snapshot into draw path; no reverse write of positions into interaction during paint
+- [ ] Keep visual parity for existing chart.dpr / render tests
+
+### Task 3: Interaction writeInput
+
+**Files:**
+- Modify: `packages/core/src/engine/controller/interaction.ts`
+- Modify: `packages/core/src/engine/state/interactionState.ts`
+
+- [ ] pointermove writes pending frame input only
+- [ ] flush derives crosshair/hover/tooltip once per frame
+- [ ] keep isDragging / dragMode as committed signals
+
+### Task 4: Scroll + selectors
+
+**Files:**
+- Modify: viewport scroll path
+- Modify: Vue interaction bridge
+
+- [ ] scroll writes frame input or commits with published frame field
+- [ ] Vue uses equality selectors off published frame
+
+### Task 5: Delete legacy high-frequency signals
+
+- [ ] remove kLinePositions/crosshair high-freq dual paths
+- [ ] full core tests + tsc
+
+---
+
+## Verification commands
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/foundation/reactivity/__tests__/frameTransaction.test.ts
+pnpm --filter @363045841yyt/klinechart-core exec tsc -p tsconfig.build.json --noEmit
+```

--- a/docs/superpowers/plans/2026-07-16-render-compat-elimination.md
+++ b/docs/superpowers/plans/2026-07-16-render-compat-elimination.md
@@ -1,0 +1,50 @@
+# Render Compat Elimination Implementation Plan
+
+> **For agentic workers:** Execute task-by-task. Steps use checkbox syntax.
+
+**Goal:** Remove legacy WebGL surface ladder, setFallbackContext, and Manager draw APIs.
+
+**Architecture:** Drawers call sceneRenderer only; false → Canvas2D. Manager is registry-only.
+
+**Tech Stack:** TypeScript, Vitest, existing createWebGLRenderer / Scene.
+
+---
+
+### Task 1: Strip legacy ladder from helpers + candle
+
+**Files:**
+- Modify: `packages/core/src/engine/renderers/linesViaRenderer.ts`
+- Modify: `packages/core/src/engine/renderers/rectsViaRenderer.ts`
+- Modify: `packages/core/src/engine/renderers/candle.ts`
+- Modify: `packages/core/src/engine/renderers/Indicator/shared/webglBand.ts`
+- Modify: `packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts`
+
+- [x] Remove surface branches from tryDraw*Gpu
+- [x] Remove drawCandlesWithWebGL path
+- [x] Remove compositeLineSurface
+- [x] Update candle tests (no candleWebGLSurface)
+
+### Task 2: Remove public dual-path APIs
+
+**Files:**
+- Modify: `packages/core/src/foundation/plugin/types.ts`
+- Modify: `packages/core/src/engine/render/chartRenderer.ts`
+- Modify: `packages/core/src/rendering/render/createWebGLRenderer.ts`
+- Modify: `packages/core/src/foundation/plugin/rendererPluginManager.ts`
+- Modify: `packages/core/src/engine/__tests__/renderSinglePath.test.ts`
+- Modify: `packages/core/src/rendering/render/__tests__/webglRenderer.fallback.test.ts`
+- Modify: `packages/core/src/engine/renderers/timeAxis.ts` (comment only if needed)
+
+- [x] Drop surface fields from RenderContext
+- [x] Stop injecting surfaces / setFallbackContext in chartRenderer
+- [x] Delete setFallbackContext implementation
+- [x] Delete Manager.render / renderPlugin
+- [x] Fix tests
+- [x] Remove per-pane Candle/Line WebGL surfaces from PaneRenderer
+
+### Task 3: Verify
+
+- [x] Related vitest suites green (candle/ma/boll/ene/single-path/fallback)
+- [x] core `tsc --noEmit` clean aside pre-existing baseUrl deprecation
+- [x] Grep zero hits for deleted APIs in production packages/core/src
+- [ ] Optional full `pnpm test:packages` + hand-check WebGL on/off

--- a/docs/superpowers/plans/2026-07-16-webgpu-retained-scene.md
+++ b/docs/superpowers/plans/2026-07-16-webgpu-retained-scene.md
@@ -302,12 +302,15 @@ If current code calls endFrame per pane, change to: beginFrame per pane (bind re
 ### Task 6: M2 Hybrid DOM (after M1 green)
 
 **Files:**
-- `createWebGPUSurfaceBackend.ts` — optional getCanvas / style sizing
-- Vue/chart DOM mount for gpu canvas
-- Remove WebGPU `compositeTo` from candle/lines helpers when effective backend is webgpu
-- underlay/overlay role split in ChartRenderer paint
+- `createWebGPUSurfaceBackend.ts` — CSS size on resize; compositeTo no-op
+- `chart.ts` — syncGpuSceneCanvas mount/unmount; z-index underlay/gpu/overlay
+- `chartPaneLayout.ts` — preserve `.gpu-scene-canvas`; main z=0 overlay z=2
+- helpers — skip composite when `caps.name === 'webgpu'`
 
-Checklist from spec §11 M2. Separate commit series.
+- [x] Mount visible WebGPU canvas in plot stack
+- [x] Skip compositeTo on WebGPU path
+- [x] Resize GPU canvas with plot; hide on non-webgpu
+- [x] Unit tests for hybrid path
 
 ---
 

--- a/docs/superpowers/plans/2026-07-16-webgpu-retained-scene.md
+++ b/docs/superpowers/plans/2026-07-16-webgpu-retained-scene.md
@@ -33,7 +33,7 @@
 - Create: `packages/core/src/rendering/render/__tests__/frameMetrics.test.ts`
 - Modify: `packages/core/src/rendering/render/index.ts`
 
-- [ ] **Step 1: Write failing test**
+- [x] **Step 1: Write failing test**
 
 ```ts
 import { createFrameMetrics, resetFrameMetrics, getFrameMetrics } from '../frameMetrics'
@@ -58,13 +58,13 @@ it('counts submits uploads and buffer creates per frame', () => {
 })
 ```
 
-- [ ] **Step 2: Run test — expect FAIL (module missing)**
+- [x] **Step 2: Run test — expect FAIL (module missing)**
 
 ```bash
 pnpm --filter @363045841yyt/klinechart-core exec vitest run src/rendering/render/__tests__/frameMetrics.test.ts
 ```
 
-- [ ] **Step 3: Implement minimal frameMetrics**
+- [x] **Step 3: Implement minimal frameMetrics**
 
 ```ts
 export type FrameMetricsSnapshot = {
@@ -123,9 +123,9 @@ export function createFrameMetrics() {
 }
 ```
 
-- [ ] **Step 4: Export from index; run tests PASS**
+- [x] **Step 4: Export from index; run tests PASS**
 
-- [ ] **Step 5: Commit** (only when user asks)
+- [x] **Step 5: Commit** (only when user asks)
 
 ---
 
@@ -135,7 +135,7 @@ export function createFrameMetrics() {
 - Create: `packages/core/src/rendering/scene/retainedScene.ts`
 - Create: `packages/core/src/rendering/scene/__tests__/retainedScene.test.ts`
 
-- [ ] **Step 1: Failing tests for upsert, scroll-without-revision-change policy helper, prune**
+- [x] **Step 1: Failing tests for upsert, scroll-without-revision-change policy helper, prune**
 
 ```ts
 it('upserts by key and replaces geometry when revision changes', () => {
@@ -183,11 +183,11 @@ it('prunes keys not touched for N frames', () => {
 })
 ```
 
-- [ ] **Step 2: Implement createRetainedScene**
+- [x] **Step 2: Implement createRetainedScene**
 
 Types from spec section 6. Methods: `beginFrame(frameNumber)`, `upsert(node)`, `collectVisible(paneId?)`, `endFrame()`, `prune(): string[]`, `clear()`.
 
-- [ ] **Step 3: Tests PASS**
+- [x] **Step 3: Tests PASS**
 
 ---
 
@@ -197,7 +197,7 @@ Types from spec section 6. Methods: `beginFrame(frameNumber)`, `upsert(node)`, `
 - Create: `packages/core/src/rendering/render/webgpuResourceTable.ts`
 - Create: `packages/core/src/rendering/render/__tests__/webgpuResourceTable.test.ts`
 
-- [ ] **Step 1: Failing test — upload only on revision change; grow capacity**
+- [x] **Step 1: Failing test — upload only on revision change; grow capacity**
 
 Use fake device with `createBuffer` / `queue.writeBuffer` spies.
 
@@ -221,9 +221,9 @@ it('uploads again when revision changes', () => {
 })
 ```
 
-- [ ] **Step 2: Implement ensureUploaded / destroyKey / destroyAll**
+- [x] **Step 2: Implement ensureUploaded / destroyKey / destroyAll**
 
-- [ ] **Step 3: Tests PASS**
+- [x] **Step 3: Tests PASS**
 
 ---
 
@@ -233,7 +233,7 @@ it('uploads again when revision changes', () => {
 - Modify: `packages/core/src/rendering/render/createWebGPURenderer.ts`
 - Modify: `packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts`
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 ```ts
 it('records multiple draws and submits once on endFrame', async () => {
@@ -261,17 +261,18 @@ it('records multiple draws and submits once on endFrame', async () => {
 })
 ```
 
-- [ ] **Step 2: Refactor renderer**
+- [x] **Step 2: Refactor renderer**
 
 Internal pending draw list per frame:
 - `drawInstances` / `drawLines` push commands, return true/false for validation only.
 - `endFrame` builds one encoder, one or more pane passes, single `queue.submit`.
-- Wire frameMetrics.
-- Keep compositeTo available (M1 does not remove it).
+- Wire frameMetrics + ResourceTable (strips) + uniform pool.
+- Keep compositeTo available (M1 does not remove it); mid-frame composite still flushes for 2D interleave.
+- Helpers (`rectsViaRenderer` / `linesViaRenderer`) cache pipeline+buffers per renderer.
 
-- [ ] **Step 3: Update existing tests that expected immediate submit**
+- [x] **Step 3: Update existing tests that expected immediate submit**
 
-- [ ] **Step 4: All webgpuRenderer tests PASS**
+- [x] **Step 4: All webgpuRenderer tests PASS**
 
 ---
 
@@ -281,7 +282,7 @@ Internal pending draw list per frame:
 - Modify: `packages/core/src/engine/render/chartRenderer.ts` (`renderPanes`)
 - Test: extend or add chart/render unit if feasible; otherwise rely on renderer unit tests + manual checklist
 
-- [ ] **Step 1:** After all panes `paintPane`, ensure `sceneRenderer.endFrame()` once per chart draw (not only per pane if multi-pane). Preferred API:
+- [x] **Step 1:** After all panes `paintPane`, ensure `sceneRenderer.endFrame()` once per chart draw (not only per pane if multi-pane). Preferred API:
 
 ```ts
 // per pane
@@ -293,7 +294,8 @@ sceneRenderer.endFrame()
 
 If current code calls endFrame per pane, change to: beginFrame per pane (bind region + queue pane draws), endFrame once after loop.
 
-- [ ] **Step 2:** Multi-pane test or fake renderer asserting single endFrame submit.
+- [x] **Step 2:** Multi-pane test or fake renderer asserting single endFrame submit.
+  Note: true single-submit-per-chart still limited by mid-frame `compositeTo` until M2.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-16-webgpu-retained-scene.md
+++ b/docs/superpowers/plans/2026-07-16-webgpu-retained-scene.md
@@ -1,0 +1,341 @@
+# WebGPU Retained Scene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade WebGPU from per-draw temporary buffers and multi-submit to retained scene nodes with one chart-frame submit, then hybrid DOM composition.
+
+**Architecture:** RetainedScene stores stable SceneNodes; WebGPU ResourceTable reuses GPUBuffers by key/revision; createWebGPURenderer records draws between beginFrame/endFrame and submits once in flushChartFrame. M2 mounts a visible GPU canvas between underlay and overlay and removes compositeTo.
+
+**Tech Stack:** TypeScript, WebGPU, Vitest, existing Renderer/Scene contracts in `packages/core`.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-webgpu-retained-scene-design.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `packages/core/src/rendering/render/frameMetrics.ts` | Dev/test frame counters |
+| `packages/core/src/rendering/scene/retainedScene.ts` | SceneNode store, upsert, prune |
+| `packages/core/src/rendering/render/webgpuResourceTable.ts` | GPUBuffer reuse by key/revision |
+| `packages/core/src/rendering/render/createWebGPURenderer.ts` | Record draws; single submit flush |
+| `packages/core/src/engine/render/chartRenderer.ts` | beginChartFrame / flushChartFrame wiring |
+| `packages/core/src/engine/renderers/*ViaRenderer.ts` | Optional stable keys later |
+| Tests under `packages/core/src/rendering/**/__tests__/` | TDD coverage |
+
+---
+
+### Task 1: Frame metrics harness (M0)
+
+**Files:**
+- Create: `packages/core/src/rendering/render/frameMetrics.ts`
+- Create: `packages/core/src/rendering/render/__tests__/frameMetrics.test.ts`
+- Modify: `packages/core/src/rendering/render/index.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { createFrameMetrics, resetFrameMetrics, getFrameMetrics } from '../frameMetrics'
+
+it('counts submits uploads and buffer creates per frame', () => {
+  resetFrameMetrics()
+  const m = createFrameMetrics()
+  m.beginFrame()
+  m.recordBufferCreate()
+  m.recordUpload(64)
+  m.recordDraw()
+  m.recordSubmit()
+  m.recordComposite()
+  m.endFrame()
+  expect(getFrameMetrics()).toMatchObject({
+    bufferCreateCount: 1,
+    bufferUploadBytes: 64,
+    drawCallCount: 1,
+    queueSubmitCount: 1,
+    compositeCount: 1,
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL (module missing)**
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/rendering/render/__tests__/frameMetrics.test.ts
+```
+
+- [ ] **Step 3: Implement minimal frameMetrics**
+
+```ts
+export type FrameMetricsSnapshot = {
+  bufferCreateCount: number
+  bufferUploadBytes: number
+  drawCallCount: number
+  queueSubmitCount: number
+  compositeCount: number
+}
+
+let snapshot: FrameMetricsSnapshot = empty()
+
+function empty(): FrameMetricsSnapshot {
+  return {
+    bufferCreateCount: 0,
+    bufferUploadBytes: 0,
+    drawCallCount: 0,
+    queueSubmitCount: 0,
+    compositeCount: 0,
+  }
+}
+
+export function resetFrameMetrics(): void {
+  snapshot = empty()
+}
+
+export function getFrameMetrics(): FrameMetricsSnapshot {
+  return { ...snapshot }
+}
+
+export function createFrameMetrics() {
+  let current = empty()
+  return {
+    beginFrame(): void {
+      current = empty()
+    },
+    recordBufferCreate(): void {
+      current.bufferCreateCount += 1
+    },
+    recordUpload(bytes: number): void {
+      current.bufferUploadBytes += bytes
+    },
+    recordDraw(): void {
+      current.drawCallCount += 1
+    },
+    recordSubmit(): void {
+      current.queueSubmitCount += 1
+    },
+    recordComposite(): void {
+      current.compositeCount += 1
+    },
+    endFrame(): void {
+      snapshot = { ...current }
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Export from index; run tests PASS**
+
+- [ ] **Step 5: Commit** (only when user asks)
+
+---
+
+### Task 2: RetainedScene (M1)
+
+**Files:**
+- Create: `packages/core/src/rendering/scene/retainedScene.ts`
+- Create: `packages/core/src/rendering/scene/__tests__/retainedScene.test.ts`
+
+- [ ] **Step 1: Failing tests for upsert, scroll-without-revision-change policy helper, prune**
+
+```ts
+it('upserts by key and replaces geometry when revision changes', () => {
+  const scene = createRetainedScene()
+  scene.beginFrame(1)
+  scene.upsert({
+    kind: 'rects',
+    key: 'main/candle/upBody',
+    revision: 1,
+    instances: new Float32Array([0, 0, 1, 2]),
+    count: 1,
+    color: '#0f0',
+    scrollLeft: 0,
+    z: 10,
+    paneId: 'main',
+  })
+  scene.upsert({
+    kind: 'rects',
+    key: 'main/candle/upBody',
+    revision: 2,
+    instances: new Float32Array([1, 1, 1, 2]),
+    count: 1,
+    color: '#0f0',
+    scrollLeft: 5,
+    z: 10,
+    paneId: 'main',
+  })
+  const nodes = scene.collectVisible('main')
+  expect(nodes).toHaveLength(1)
+  expect(nodes[0]?.revision).toBe(2)
+  expect(nodes[0]?.scrollLeft).toBe(5)
+})
+
+it('prunes keys not touched for N frames', () => {
+  const scene = createRetainedScene({ staleFrames: 2 })
+  scene.beginFrame(1)
+  scene.upsert({ kind: 'rects', key: 'a', revision: 1, instances: new Float32Array(4), count: 1, color: '#fff', scrollLeft: 0, z: 0, paneId: 'main' })
+  scene.endFrame()
+  scene.beginFrame(2)
+  scene.endFrame()
+  scene.beginFrame(3)
+  const removed = scene.prune()
+  expect(removed).toEqual(['a'])
+  expect(scene.collectVisible('main')).toEqual([])
+})
+```
+
+- [ ] **Step 2: Implement createRetainedScene**
+
+Types from spec section 6. Methods: `beginFrame(frameNumber)`, `upsert(node)`, `collectVisible(paneId?)`, `endFrame()`, `prune(): string[]`, `clear()`.
+
+- [ ] **Step 3: Tests PASS**
+
+---
+
+### Task 3: WebGPU ResourceTable (M1)
+
+**Files:**
+- Create: `packages/core/src/rendering/render/webgpuResourceTable.ts`
+- Create: `packages/core/src/rendering/render/__tests__/webgpuResourceTable.test.ts`
+
+- [ ] **Step 1: Failing test — upload only on revision change; grow capacity**
+
+Use fake device with `createBuffer` / `queue.writeBuffer` spies.
+
+```ts
+it('reuses buffer when revision unchanged', () => {
+  const table = createWebGPUResourceTable({ device: fakeDevice, metrics })
+  const data = new Float32Array([1, 2, 3, 4])
+  const a = table.ensureUploaded({ key: 'k', revision: 1, data, usage: 'vertex' })
+  const b = table.ensureUploaded({ key: 'k', revision: 1, data, usage: 'vertex' })
+  expect(a.buffer).toBe(b.buffer)
+  expect(fakeDevice.createBuffer).toHaveBeenCalledTimes(1)
+  expect(fakeDevice.queue.writeBuffer).toHaveBeenCalledTimes(1)
+})
+
+it('uploads again when revision changes', () => {
+  const table = createWebGPUResourceTable({ device: fakeDevice, metrics })
+  table.ensureUploaded({ key: 'k', revision: 1, data: new Float32Array([1, 2, 3, 4]), usage: 'vertex' })
+  table.ensureUploaded({ key: 'k', revision: 2, data: new Float32Array([5, 6, 7, 8]), usage: 'vertex' })
+  expect(fakeDevice.createBuffer).toHaveBeenCalledTimes(1)
+  expect(fakeDevice.queue.writeBuffer).toHaveBeenCalledTimes(2)
+})
+```
+
+- [ ] **Step 2: Implement ensureUploaded / destroyKey / destroyAll**
+
+- [ ] **Step 3: Tests PASS**
+
+---
+
+### Task 4: Deferred submit in createWebGPURenderer (M1)
+
+**Files:**
+- Modify: `packages/core/src/rendering/render/createWebGPURenderer.ts`
+- Modify: `packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+it('records multiple draws and submits once on endFrame', async () => {
+  const fake = makeWebGPU()
+  const renderer = await createWebGPURenderer({ gpu: fake.gpu as GPU, canvas: fake.canvas })
+  renderer.surface.resize(200, 100, 1)
+  renderer.beginFrame({ x: 0, y: 0, width: 200, height: 100, dpr: 1 })
+  const pipeline = renderer.createPipeline({ type: 'candle' })
+  const instances = renderer.createBuffer('instance', 16)
+  renderer.writeBuffer(instances, new Float32Array([0, 0, 10, 20]))
+  const vertices = renderer.createBuffer('vertex', 4)
+  const params = {
+    pipeline,
+    vertices,
+    instances,
+    instanceCount: 1,
+    vertexCount: 6,
+    uniforms: { color: '#f00', scrollLeft: 0 },
+  }
+  expect(renderer.drawInstances(params)).toBe(true)
+  expect(renderer.drawInstances(params)).toBe(true)
+  expect(fake.queue.submit).not.toHaveBeenCalled()
+  renderer.endFrame()
+  expect(fake.queue.submit).toHaveBeenCalledTimes(1)
+})
+```
+
+- [ ] **Step 2: Refactor renderer**
+
+Internal pending draw list per frame:
+- `drawInstances` / `drawLines` push commands, return true/false for validation only.
+- `endFrame` builds one encoder, one or more pane passes, single `queue.submit`.
+- Wire frameMetrics.
+- Keep compositeTo available (M1 does not remove it).
+
+- [ ] **Step 3: Update existing tests that expected immediate submit**
+
+- [ ] **Step 4: All webgpuRenderer tests PASS**
+
+---
+
+### Task 5: ChartRenderer chart-frame flush (M1)
+
+**Files:**
+- Modify: `packages/core/src/engine/render/chartRenderer.ts` (`renderPanes`)
+- Test: extend or add chart/render unit if feasible; otherwise rely on renderer unit tests + manual checklist
+
+- [ ] **Step 1:** After all panes `paintPane`, ensure `sceneRenderer.endFrame()` once per chart draw (not only per pane if multi-pane). Preferred API:
+
+```ts
+// per pane
+sceneRenderer.beginFrame(region)
+scene.paintPane(...)
+// after all panes
+sceneRenderer.endFrame()
+```
+
+If current code calls endFrame per pane, change to: beginFrame per pane (bind region + queue pane draws), endFrame once after loop.
+
+- [ ] **Step 2:** Multi-pane test or fake renderer asserting single endFrame submit.
+
+---
+
+### Task 6: M2 Hybrid DOM (after M1 green)
+
+**Files:**
+- `createWebGPUSurfaceBackend.ts` — optional getCanvas / style sizing
+- Vue/chart DOM mount for gpu canvas
+- Remove WebGPU `compositeTo` from candle/lines helpers when effective backend is webgpu
+- underlay/overlay role split in ChartRenderer paint
+
+Checklist from spec §11 M2. Separate commit series.
+
+---
+
+### Task 7: M3 Hardening
+
+- Host switch clears ResourceTable + RetainedScene
+- device lost path
+- prune + leak tests
+- metrics gate documentation
+
+---
+
+## Verification commands
+
+```bash
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/rendering/render/__tests__/frameMetrics.test.ts
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/rendering/scene/__tests__/retainedScene.test.ts
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/rendering/render/__tests__/webgpuResourceTable.test.ts
+pnpm --filter @363045841yyt/klinechart-core exec vitest run src/rendering/render/__tests__/webgpuRenderer.test.ts
+pnpm --filter @363045841yyt/klinechart-core build
+```
+
+## Spec coverage
+
+| Spec item | Task |
+|-----------|------|
+| Frame metrics M0 | Task 1 |
+| RetainedScene | Task 2 |
+| ResourceTable | Task 3 |
+| Single submit | Task 4–5 |
+| Hybrid DOM | Task 6 |
+| Hardening | Task 7 |
+| Compute excluded | N/A |

--- a/docs/superpowers/specs/2026-07-16-drawing-session-ssot-design.md
+++ b/docs/superpowers/specs/2026-07-16-drawing-session-ssot-design.md
@@ -1,0 +1,37 @@
+# Drawing Session SSOT Design
+
+**Date:** 2026-07-16  
+**Status:** approved for implementation  
+**Scope:** Remove dual `drawings` copy; keep high-frequency session state out of kernel
+
+## Problem
+
+1. `DrawingState` holds a full mutable `drawings[]` while `kernel.drawing.drawings` is the business SSOT (shadow cache).
+2. Preview (`__preview__`) and in-drag geometry are written through `adapter.setDrawings` into kernel on every pointermove.
+
+## Target
+
+| Layer | Owns | Update rate |
+|-------|------|-------------|
+| `kernel.drawing` | committed drawings, tool, selectedId | commit only |
+| session (`DrawingState` / controller) | preview, drag override, pending anchors | pointermove |
+| `DrawingStore` | paint merge: kernel ⊕ session overlay | each frame peek |
+
+## Rules
+
+1. Kernel `drawings` never contains `__preview__`.
+2. pointermove preview / drag must not call `kernel.drawing.actions.setDrawings`.
+3. pointerup / create / style / delete commit once via adapter → kernel.
+4. Session does not keep a full list copy; reads committed list via `adapter.getFullDrawings()`.
+5. Paint: `DrawingStore.getVisibleByPane` merges kernel list with session overlay (drag replaces by id; preview appends).
+
+## API shape
+
+- `DrawingState`: `preview`, `dragOverride` only; `getPaintOverlay()`, `setPreview` / `setDragOverride` / `commitDrag` / committed CRUD via adapter.
+- `DrawingChartAdapter.requestDraw()` for session-only paint (no kernel write).
+- `DrawingStoreDeps.getOverlay?: () => ReadonlyArray<DrawingObject>`.
+- Chart wires `getOverlay` from `drawingSession.getPaintOverlay()`.
+
+## Non-goals
+
+- Undo stack, multi-pane drawing UX, callback → signal migration in Vue.

--- a/docs/superpowers/specs/2026-07-16-frame-transaction-design.md
+++ b/docs/superpowers/specs/2026-07-16-frame-transaction-design.md
@@ -1,0 +1,62 @@
+# Frame Transaction Design
+
+**Date:** 2026-07-16  
+**Status:** approved for phased implementation  
+**Goal:** Centralize high-frequency chart state without per-event reactive broadcasts, with strict single-generation snapshots.
+
+## Problem
+
+1. High-frequency pointer/scroll writes go through ordinary kernel Signals and notify every subscriber.
+2. `batch()` only defers notify within one call stack; notify phase can re-enter and write more state.
+3. Renderer currently writes frame geometry back into interaction state after prepare, creating a reverse write path.
+
+## Solution: Single Frame Transaction
+
+One immutable `ChartFrameSnapshot` per completed frame. No public `latest` dual-view.
+
+### Phases
+
+```
+writeInput → request
+rAF:
+  capture → derive → seal → render → publish → complete
+```
+
+| Phase | Allowed | Forbidden |
+|-------|---------|-----------|
+| writeInput | merge pending input | publish, render |
+| capture | swap pending → sealed input | notify |
+| derive | pure compute snapshot fields | kernel action writes |
+| seal | freeze ownership, bump generation | mutate sealed data |
+| render | read only sealed snapshot | write kernel / published |
+| publish | `published$.set(snapshot)` once | mutate snapshot |
+| complete | schedule next frame if dirty | reuse sealed input |
+
+### Invariants
+
+1. One generation, one snapshot per successful frame.
+2. `pendingInput` is private; no public latest API.
+3. Renderer never writes kernel during paint.
+4. Writes during render/publish go to next generation only.
+5. Failed derive/render does not advance published generation.
+6. Sync `draw()` uses the same flush pipeline as rAF.
+7. Large arrays use structural sharing; no deep clone; optional freeze only in dev.
+
+### State classes
+
+- **Committed Signals:** data, settings, drawings, tool, selectedId, drag mode (pointer down/up).
+- **Frame input:** pointer, scroll intent, hover inputs.
+- **Frame snapshot fields:** viewport, geometry, crosshair, hover, tooltip, marker hover.
+
+## Migration path
+
+1. `createFrameTransaction` primitive + tests  
+2. ChartRenderer builds one snapshot and renders from it  
+3. Interaction pointermove → writeInput only  
+4. Scroll → frame input + selectors  
+5. Delete legacy frame-position / crosshair high-frequency signals  
+
+## Non-goals
+
+- Full reactive topological scheduler rewrite  
+- Moving committed business SSOT out of kernel  

--- a/docs/superpowers/specs/2026-07-16-render-compat-elimination-design.md
+++ b/docs/superpowers/specs/2026-07-16-render-compat-elimination-design.md
@@ -1,0 +1,55 @@
+# Design: Render Compat Layer Elimination
+
+**Date:** 2026-07-16  
+**Status:** Approved (session)  
+**Branch:** `feat/render-single-path-scene-renderer`  
+**Predecessor:** Phase 0+1 (single-path Scene; candle/line/rect via Renderer API)
+
+## Goal
+
+Delete remaining render dual-path debt. Production drawers use only:
+
+```
+context.sceneRenderer  →  success → composite
+                       →  false   → context.ctx Canvas2D
+```
+
+No legacy surface fields, no Manager frame draw entry, no setFallbackContext.
+
+## Non-goals
+
+- WebGPU backend
+- Rewriting createLayerFromPlugin into native Layers
+- Changing indicator math / StateKernel
+
+## Target shape
+
+```
+prepareFrameData
+  → RenderContext { sceneRenderer, ctx, geometry, settings, ... }
+  → scene.paintPane
+      → Layer.paint → plugin.draw
+          → draw*ViaRenderer(sceneRenderer) | 2D
+  → axes
+```
+
+`RendererPluginManager`: register / unregister / enabled / notify* only.  
+`CandleWebGLSurface` / `LineWebGLSurface`: internal to `createWebGLRenderer` only.
+
+## Delete list
+
+| Item | Action |
+|------|--------|
+| `RenderContext.candleWebGLSurface` / `lineWebGLSurface` | Remove fields + injection |
+| `tryDrawLinesGpu` / `tryDrawFilledBandGpu` / `tryDrawRectsGpu` legacy branch | sceneRenderer only |
+| `drawCandlesWithWebGL` / `compositeWebGLToMainCanvas` | Delete |
+| `compositeLineSurface` (surface-typed) | Delete |
+| `setFallbackContext` + chartRenderer `(as any)` calls | Delete |
+| `RendererPluginManager.render` / `renderPlugin` | Delete |
+| Ladder-preferring tests | Assert Renderer-only / fail-closed 2D |
+
+## Done when
+
+- `rg candleWebGLSurface|lineWebGLSurface|setFallbackContext|manager\.render|renderPlugin` in production `packages/core/src` → zero (tests may mock Renderer only)
+- `pnpm test:packages` + `pnpm type-check` green
+- Manual: WebGL on/off × candle / MA / BOLL / volume / MACD / timeShare / crosshair / drawing

--- a/docs/superpowers/specs/2026-07-16-webgpu-renderer-design.md
+++ b/docs/superpowers/specs/2026-07-16-webgpu-renderer-design.md
@@ -1,0 +1,454 @@
+# WebGPU Renderer MVP 设计
+
+日期：2026-07-16
+
+## 1. 目标
+
+在现有 Scene + Renderer 单路径架构上新增 WebGPU 后端，使已经通过 Renderer 原语绘制的 K 线、矩形柱、折线指标和填充带无需修改业务渲染器即可切换到 WebGPU。
+
+首版交付渲染等价 MVP：
+
+- 实现 rectangle instances、line strips、band fill。
+- 支持 WebGPU、WebGL、Canvas 三种用户偏好。
+- 支持运行时原子热切换。
+- WebGPU 初始化失败或 device lost 时自动降级到 WebGL；WebGL 不可用时降级到 Canvas2D。
+- 保留偏好后端与有效后端两个独立状态。
+
+## 2. 非目标
+
+首版不包含：
+
+- compute shader、storage buffer ring buffer 或 GPU 聚合。
+- Volume Profile、Order Book Heatmap、Footprint 的 compute 接入。
+- 把 grid、crosshair、坐标轴、分时、对比线、drawing、marker、legend 等 Canvas2D 内容迁移到 GPU。
+- direct-to-screen WebGPU 合成；首版继续使用 GPU canvas 到 2D canvas 的合成模型。
+- 通用材质、shader graph 或 3D 渲染抽象。
+- WebGPU buffer arena/pool 性能优化。
+
+## 3. 现状与约束
+
+当前生产 GPU 路径已经统一为：
+
+```text
+Scene.paintPane
+  -> Layer.paint
+  -> RendererPlugin.draw
+  -> context.sceneRenderer
+  -> drawInstances / drawLines
+  -> surface.compositeTo
+```
+
+业务侧通过以下 helper 使用原语：
+
+- drawCandlesViaRenderer：K 线 body/wick。
+- tryDrawRectsGpu：volume、MACD bar。
+- tryDrawLinesGpu：多数折线指标。
+- tryDrawFilledBandGpu：BOLL、ENE band。
+
+Canvas2D 是业务层 fail-closed fallback。Renderer 返回 false 时，业务渲染器执行现有 2D 绘制。
+
+现有 ChartRenderer 在构造函数中直接创建 WebGL Renderer。WebGPU 初始化需要异步 requestAdapter/requestDevice，但 createChartController 已经是 async，Vue mount API 也接受 Promise，因此不需要破坏公开挂载 API。
+
+## 4. 总体架构
+
+采用 RendererHost 原子热切换方案。
+
+```text
+settings.rendererBackend (preference)
+              |
+              v
+        RendererHost.switchTo()
+              |
+       prepare backend async
+              |
+      atomic active swap + redraw
+              |
+              v
+ChartRenderer -> RendererHost.renderer -> WebGPU | WebGL2 | Canvas fallback
+```
+
+RendererHost 是后端资源生命周期的唯一所有者。后端偏好仍以 StateKernel 的 settings.rendererBackend 为唯一真源，host 只接收切换命令并发布运行态。ChartRenderer 不再构造具体后端，只从 host 获取当前 Renderer。Scene、Layer 和指标只依赖 Renderer 契约。
+
+### 4.1 组件边界
+
+#### RendererHost
+
+职责：
+
+- 持有当前有效 Renderer。
+- 根据传入偏好创建 WebGPU、WebGL 或 Canvas fallback，不保存第二份持久偏好。
+- 管理异步初始化、并发切换、原子替换和资源销毁。
+- 监听 WebGPU device lost。
+- 更新有效后端、状态和错误信息。
+- 切换完成后请求完整重绘。
+
+RendererHost 不负责业务绘制、不维护 Scene、不解释 indicator 配置。
+
+建议公开形状：
+
+```ts
+export type RendererBackend = 'webgpu' | 'webgl' | 'canvas'
+
+export type RendererBackendStatus =
+  | 'initializing'
+  | 'ready'
+  | 'switching'
+  | 'degraded'
+  | 'failed'
+
+export type RendererBackendRuntime = {
+  preference: RendererBackend
+  effective: RendererBackend
+  status: RendererBackendStatus
+  error: string | null
+}
+
+export interface RendererHost {
+  readonly renderer: Renderer
+  readonly runtime: Omit<RendererBackendRuntime, 'preference'>
+  switchTo(preference: RendererBackend): Promise<void>
+  dispose(): void
+}
+```
+
+preference 由 settings Signal 提供；runtime 的实际外部暴露应通过 StateKernel readonly Signal。上面的同步结构用于说明 host 内部契约，不允许形成第二个偏好状态源。
+
+#### createWebGPURenderer
+
+职责：
+
+- 实现 Renderer 契约。
+- 管理 GPUDevice、GPUQueue、GPUCanvasContext、GPUBuffer、GPURenderPipeline、bind group 和 command encoder。
+- 实现 candle、line、fill 三类 pipeline。
+- 维护 pipeline cache 和 device-lost 通知。
+
+它不复用 CandleWebGLSurface 或 LineWebGLSurface，也不把 WebGPU 细节暴露给业务渲染器。
+
+#### createWebGPUSurfaceBackend
+
+职责：
+
+- 管理隐藏共享 canvas 与 GPUCanvasContext。
+- 配置 preferred canvas format 和 premultiplied alpha。
+- 维护逻辑尺寸、DPR、pane region、viewport 和 scissor。
+- 把 GPU canvas 指定 region 合成到目标 2D canvas。
+
+#### createCanvas2DRenderer
+
+这是 Renderer 契约的 fail-closed 实现，而不是第二套 Canvas2D 原语系统：
+
+- caps.name 为 canvas2d。
+- surface.isAvailable 返回 false。
+- drawInstances 和 drawLines 返回 false。
+- 业务渲染器因此自然进入现有 Canvas2D fallback。
+
+## 5. 初始化与后端选择
+
+### 5.1 初始挂载
+
+createChartController 在构造 Chart 前读取 settings.rendererBackend，并等待 RendererHost 初始化：
+
+```text
+preference=webgpu
+  requestAdapter
+  requestDevice
+  configure WebGPU surface
+  success -> effective=webgpu
+  failure -> create WebGL2
+             success -> effective=webgl, status=degraded
+             failure -> effective=canvas, status=degraded
+
+preference=webgl
+  create WebGL2
+  success -> effective=webgl
+  failure -> effective=canvas, status=degraded
+
+preference=canvas
+  create Canvas fallback -> effective=canvas
+```
+
+host 准备完成后才构造 Chart，避免首帧拿到未初始化 Renderer。
+
+### 5.2 运行时热切换
+
+每个切换请求分配递增 generation：
+
+1. 保存新的 preference，状态设为 switching。
+2. 旧 Renderer 继续绘制。
+3. 后台创建目标 Renderer。
+4. 只有最新 generation 可以提交替换。
+5. 过期创建结果立即 dispose。
+6. 成功时原子替换 active Renderer，更新 effective/status/error。
+7. 请求 UpdateLevel.All。
+8. 销毁旧 Renderer。
+
+切换失败时：
+
+- 如果旧 Renderer 仍可用，继续使用旧 Renderer，并记录 degraded/error。
+- 如果旧 Renderer 不可用，按 WebGPU -> WebGL -> Canvas 顺序降级。
+
+### 5.3 Device lost
+
+- 仅当前 active generation 对应的 device lost 事件有效。
+- device lost 后创建 WebGL Renderer；成功则原子替换并完整重绘。
+- WebGL 也不可用时切换到 Canvas fallback。
+- preference 保持 webgpu，不自动循环重试，避免失败风暴。
+- 用户重新选择 WebGPU或下次挂载时可以再次尝试。
+
+### 5.4 Dispose
+
+- 标记 host disposed 并推进 generation，使所有待完成任务失效。
+- 销毁当前 Renderer。
+- 异步迟到的 Renderer 创建完成后必须立即 dispose。
+- device lost callback 在 disposed 后不得更新状态或触发重绘。
+
+## 6. 状态设计
+
+偏好与运行态分开：
+
+- settings.rendererBackend：用户持久偏好，取值 webgl | webgpu | canvas。
+- renderer runtime state：effectiveBackend、backendStatus、backendError。
+
+所有写入通过 StateKernel Action；外部只获得 ReadonlySignal。降级不改写 preference。
+
+设置 UI 的后端下拉显示 preference。旁边显示 effective backend 和 switching/degraded 状态。例如 preference 为 WebGPU、effective 为 WebGL 时，用户能看到当前实际使用 WebGL，但下次仍会尝试 WebGPU。
+
+## 7. 设置迁移
+
+删除运行时 ChartSettings.enableWebGLRendering，替换为 rendererBackend，默认 webgl，以保持现有默认行为。
+
+仅对已持久化 localStorage 做一次迁移：
+
+- enableWebGLRendering === true -> rendererBackend = webgl
+- enableWebGLRendering === false -> rendererBackend = canvas
+- rendererBackend 已存在时以新字段为准
+
+迁移后保存新结构；生产运行时代码不保留旧字段或双重判断。
+
+tryDrawLinesGpu、tryDrawRectsGpu 和 tryDrawFilledBandGpu 删除 enableWebGLRendering 分支，只根据当前 Renderer 的返回值决定是否走 Canvas2D。
+
+## 8. WebGPU Surface 与合成
+
+每个 Chart 使用一个隐藏共享 WebGPU canvas：
+
+- format：navigator.gpu.getPreferredCanvasFormat()。
+- alphaMode：premultiplied。
+- usage 至少包含 RENDER_ATTACHMENT；若浏览器合成路径需要，再加入 COPY_SRC。
+- canvas backing size 由逻辑尺寸和 DPR 决定。
+
+每个 pane 使用物理像素 viewport/scissor。首版保持当前即时合成语义：业务原语成功提交后立刻 surface.compositeTo 对应 2D canvas。这样可以保持 GPU 内容与 Canvas2D Layer 的既有 z-order。
+
+不采用 direct-to-screen canvas，因为当前每个 pane 的 GPU 与 2D 内容存在交错顺序，直接放置一个 WebGPU DOM canvas 会改变合成语义。
+
+## 9. WebGPU 原语映射
+
+### 9.1 Rectangle instances
+
+对应 Renderer.drawInstances，首版仅接受 candle pipeline：
+
+- vertex shader 使用 vertex_index 生成六个 unit-quad 顶点。
+- instance buffer 布局为 x、y、width、height，均为 f32。
+- uniform 包含 logical resolution、scrollLeft 和 color。
+- fragment shader 输出 premultiplied alpha 兼容颜色。
+
+服务对象包括 K 线 body/wick、volume bar 和 MACD bar。
+
+### 9.2 Line strips
+
+对应 Renderer.drawLines 的 strips：
+
+- 所有 strips 在同一个 render pass 中提交，render pass 只 clear 一次。
+- 每条 strip 可有独立 color 和 width。
+- 1px 线使用 line-strip topology。
+- 宽线抽取并复用现有 joined-polyline CPU tessellation，使用 triangle-list 绘制。
+- 首版保持 round/join 视觉与 WebGL2 现状一致，不引入几何 shader 假设。
+
+### 9.3 Filled band
+
+对应 fill pipeline：
+
+- 输入为交错 upper/lower 顶点。
+- 使用 triangle-strip。
+- color 由 uniform 提供。
+- alpha 仍通过 composite options 应用，保持 BOLL/ENE 当前行为。
+
+### 9.4 MSAA
+
+- 默认请求 4x MSAA。
+- 根据设备支持选择有效 sample count。
+- 每个 region 使用 multisampled color texture，resolve 到当前 canvas texture。
+- line strips 必须在单 render pass 内完成，避免逐条 clear 覆盖。
+
+### 9.5 Compute
+
+MVP 中：
+
+- caps.compute = false。
+- caps.storageBuffer = false。
+- createComputePipeline 和 dispatchCompute 抛出明确不支持错误。
+
+第二阶段实现 compute 后再修改 capability，避免声明未交付能力。
+
+## 10. 资源生命周期
+
+### 10.1 Pipeline
+
+pipeline 按 canvas format、sample count 和 type(candle | line | fill) 缓存。业务 helper 当前每帧调用 createPipeline/destroyPipeline，因此 WebGPU createPipeline 返回引用缓存实体的轻量 handle，destroyPipeline 只释放 handle，不重复编译 WGSL。
+
+### 10.2 Buffer
+
+MVP 中 BufferHandle 对应真实 GPUBuffer：
+
+- createBuffer 根据 usage 和 size 创建 GPUBuffer。
+- writeBuffer 使用 queue.writeBuffer。
+- destroyBuffer 在相关提交完成后延迟销毁，不能在 GPU 尚未消费时立即使资源失效。
+
+现有 helper 每帧创建资源会造成分配压力。MVP 先记录 buffer allocation、uploaded bytes 和 draw submissions，验收正确性。frame arena、pool 或持久业务 buffer 作为后续性能任务，不在首版同时解决，以免引入 reuse race。
+
+### 10.3 Pipeline/Buffer handle 校验
+
+所有 handle 由创建它的 Renderer 实例拥有。后端切换后，旧 handle 不得用于新 Renderer。当前业务 helper 的资源只在单次调用内存活，因此天然满足该约束。
+
+## 11. 错误语义
+
+Renderer.drawInstances/drawLines 返回 boolean 的语义保持 fail-closed：
+
+- 参数无效、handle 不匹配、region 未绑定、device 已 lost 或命令无法记录时返回 false。
+- 同步异常在后端内捕获并返回 false。
+- queue.submit 后的异步设备故障不能伪装成同步 false，统一由 device.lost 流程处理。
+- adapter/device/context/pipeline 初始化错误标准化为 renderer backend error，进入 host 降级流程。
+
+单个 Layer 不负责捕获后端生命周期错误。Layer 只根据 draw 返回值选择 Canvas2D fallback。
+
+## 12. Chart 与 UI 接线
+
+### 12.1 Core
+
+- createChartController 异步创建 RendererHost，再构造 Chart。
+- Chart 和 ChartRenderer 接收 host/renderer 依赖，不再直接创建 SharedWebGLSurface 或 createWebGLRenderer。
+- ChartRenderer 每帧读取 host.renderer；切换后下一帧自然使用新后端。
+- RendererHost 的状态变化通过 StateKernel Action 发布。
+
+### 12.2 Vue 设置
+
+- 把“启用 WebGL 硬件加速渲染”toggle 替换为 renderer backend Dropdown。
+- 选项：WebGL、WebGPU、Canvas。
+- confirm settings 后立即触发切换。
+- 显示有效后端以及 switching/degraded 状态。
+- React/Angular 继续通过 core controller 状态与设置协议获得相同行为，不在框架包内实现后端逻辑。
+
+## 13. 测试策略
+
+### 13.1 Contract tests
+
+共享 Renderer contract tests 验证：
+
+- buffer/pipeline handle 生命周期。
+- drawInstances、drawLines 成功与 fail-closed。
+- dispose 幂等。
+- compute capability 与抛错行为一致。
+
+WebGL2 和 WebGPU fake device 均执行适用的 contract tests。
+
+### 13.2 WebGPU unit tests
+
+使用 fake navigator.gpu、GPUAdapter、GPUDevice、GPUQueue 和 GPUCanvasContext，覆盖：
+
+- adapter/device/context 初始化。
+- rectangle instance pipeline 和 WGSL/bindings。
+- batched strips 单 pass、单 clear。
+- fill triangle-strip。
+- MSAA resolve。
+- region、viewport、scissor 和 DPR。
+- pipeline cache。
+- 延迟 buffer 销毁。
+- device lost 通知和 dispose。
+
+### 13.3 RendererHost tests
+
+覆盖：
+
+- 三种偏好的正常初始化。
+- WebGPU -> WebGL -> Canvas 降级。
+- 热切换时旧后端继续可用。
+- generation 竞态与 stale result dispose。
+- device lost 仅影响当前 generation。
+- dispose 期间异步初始化迟到。
+- preference 与 effective 分离。
+
+### 13.4 State/UI tests
+
+覆盖：
+
+- 旧 enableWebGLRendering 持久设置迁移。
+- rendererBackend 默认值与三选项。
+- 设置确认触发热切换。
+- preference/effective/status/error 展示。
+
+### 13.5 浏览器验收
+
+在支持 WebGPU 的 Chromium 上验证 WebGPU、WebGL、Canvas 三档：
+
+- candle。
+- MA/多周期折线。
+- BOLL/ENE band。
+- volume。
+- MACD bar + DIF/DEA。
+- 多 pane、不同 DPR、resize、缩放和滚动。
+- 连续快速切换后端无空白帧或资源泄漏。
+- 模拟 device lost 后继续通过 WebGL/Canvas 绘制。
+
+截图/像素比较以 WebGL2 为基准设置合理容差，不要求不同抗锯齿实现逐像素完全相同。
+
+## 14. 依赖与类型
+
+- 使用原生 WebGPU API。
+- 增加 @webgpu/types 作为开发依赖并接入 core tsconfig。
+- MVP 不引入 webgpu-utils；当 compute/uniform schema 复杂度实际出现时再评估。
+- 不引入 Three.js 或通用 3D 引擎。
+
+## 15. 交付分段
+
+### A. 契约与状态
+
+- renderer backend preference/runtime 类型。
+- Canvas fallback Renderer。
+- RendererHost 生命周期与 fake backend tests。
+- 设置持久化迁移。
+
+### B. WebGPU Surface
+
+- adapter/device/context 初始化。
+- shared canvas、DPR、region、compositeTo。
+- device lost 和 dispose。
+
+### C. WebGPU 绘制原语
+
+- rectangle instances。
+- line strips + MSAA。
+- filled band。
+- contract/unit tests。
+
+### D. Chart 与 UI 接线
+
+- createChartController/ChartRenderer 注入。
+- runtime hot switch。
+- Vue dropdown 与 effective state。
+- WebGPU -> WebGL -> Canvas 降级。
+
+### E. 验收与性能基线
+
+- package tests、type-check、build。
+- 三后端浏览器视觉验收。
+- buffer allocation、uploaded bytes、submission count 基线。
+- 记录后续 buffer arena 和 compute 工作，不在 MVP 内扩 scope。
+
+## 16. 完成标准
+
+- 用户可以在设置中选择 WebGL、WebGPU 或 Canvas，并在当前图表立即生效。
+- 已迁 Renderer 原语的业务渲染器无需按后端分支。
+- WebGPU 下 candle、line、fill、volume、MACD 与 WebGL2 视觉等价。
+- WebGPU 不可用、初始化失败或 device lost 时图表不中断并自动降级。
+- preference 与 effective backend 可观察且不会互相覆盖。
+- 无旧 enableWebGLRendering 运行时分支。
+- 单元、包级、类型和构建验证通过。

--- a/docs/superpowers/specs/2026-07-16-webgpu-retained-scene-design.md
+++ b/docs/superpowers/specs/2026-07-16-webgpu-retained-scene-design.md
@@ -1,0 +1,427 @@
+# WebGPU Retained Scene 与性能优化设计
+
+日期：2026-07-16
+
+## 1. 目标
+
+在 WebGPU 渲染等价 MVP 已可用的前提下，将当前“每原语临时 buffer + 多次 submit + GPU→2D drawImage”路径升级为 chart 级 Retained Scene + 混合 DOM 分层，使 WebGPU 在标准与重载两档负载下先达到不慢于 WebGL，再把 p95 渲染耗时相对 WebGL 降低约 30%。
+
+交付目标：
+
+- 业务 layer 以稳定 key 更新 SceneNode，不再每帧创建/销毁 GPU handle。
+- 每 RAF 每个 chart 原则上只 `queue.submit` 一次。
+- WebGPU 可见 DOM canvas 直接覆盖 plot 区；取消 GPU canvas 到 pane mainCanvas 的 `drawImage`。
+- 保留 Canvas2D underlay / overlay 与现有 fail-closed 语义。
+- 保留 RendererHost 热切换、preference/effective 分离与 WebGPU→WebGL→Canvas 降级。
+
+## 2. 非目标
+
+本设计不包含：
+
+- compute shader、storage buffer ring、GPU 聚合或 downsampling。
+- Volume Profile / Order Book Heatmap / Footprint 的 GPU compute 接入。
+- 文字、坐标轴、legend、marker、drawing、crosshair 迁移到 WebGPU。
+- 第一阶段强制 WebGL 同步改为 RetainedScene 消费者。
+- 跨 chart 共享 GPU 资源。
+- 通用材质系统、shader graph 或 3D 抽象。
+
+## 3. 背景与问题
+
+当前 WebGPU MVP 正确性路径为：
+
+```text
+Scene.paintPane
+  -> Layer.paint
+  -> drawInstances / drawLines
+  -> 每调用 createBuffer / writeBuffer / createUniform
+  -> 每调用 beginRenderPass + queue.submit
+  -> surface.compositeTo (drawImage 到 2D)
+```
+
+相对 WebGL 的结构性开销：
+
+1. 每 batch 独立 command encoder 与 submit。
+2. 每帧临时 GPUBuffer 与延迟 destroy。
+3. 每 draw 新建 uniform buffer / bind group。
+4. 4x MSAA resolve 后仍 `drawImage` 回 2D。
+5. 宽线几何仍由 CPU 每帧生成。
+
+MVP 设计文档已明确 buffer arena、direct-to-screen、compute 属于后续阶段。本设计承接该后续阶段中的 retained scene 与混合分层部分。
+
+## 4. 决策摘要
+
+| 项 | 决策 |
+|---|---|
+| 目标策略 | 分阶段提升：先持平 WebGL，再冲击 p95 -30% |
+| 验收负载 | 标准档 + 重载档 |
+| 主线架构 | Retained Scene + FrameGraph + 混合 DOM 分层 |
+| 合成边界 | Canvas2D underlay / WebGPU scene / Canvas2D overlay |
+| WebGL 同步 | 第一阶段不强制；可继续即时合成 |
+| API 兼容 | 保留 `drawInstances/drawLines` thin adapter，内部 upsert SceneNode |
+| Compute | 明确排除 |
+
+## 5. 总体架构
+
+### 5.1 DOM 分层
+
+每个 chart plot 区域采用三层：
+
+```text
+Canvas2D underlay   网格、背景分区
+WebGPU scene canvas K 线、volume、MACD bar、均线、band fill
+Canvas2D overlay    legend、marker、drawing、crosshair、标签
+Axis canvases       左右轴、时间轴，保持现状
+```
+
+规则：
+
+- WebGPU canvas 从隐藏共享 surface 变为 chart plot 区域内可见的 DOM canvas。
+- 尺寸与 DPR 跟随 plotWidth × plotHeight；`pointer-events: none`。
+- 多 pane 共用同一 WebGPU canvas，用 viewport/scissor 与 region.y 区分 pane。
+- 不再调用 `surface.compositeTo` 把 GPU 像素复制到各 pane mainCanvas。
+- underlay 画在 GPU 之下；overlay 画在 GPU 之上，保持现有 z-order 语义。
+
+### 5.2 数据流
+
+```text
+Layer.paint
+  -> upsert SceneNode(key, revision, geometry/material)
+  -> FrameGraph.collect(pane)
+  -> endFrame
+       underlay 2D paint
+       WebGPU encode all nodes (1 encoder, 1 submit)
+       overlay 2D paint
+```
+
+### 5.3 组件边界
+
+#### RetainedScene
+
+职责：
+
+- 以 `paneId/layerId/primitiveId` 为稳定 key 保存节点。
+- 记录 revision、lastTouchedFrame、可见性。
+- 提供 upsert / markMissing / collectVisible / prune。
+
+不负责 GPU 资源、DOM、或业务指标计算。
+
+#### FrameGraph
+
+职责：
+
+- 每个 RAF 收集所有 pane 的可见节点。
+- 按 underlay / gpu / overlay 与 z-order 排序。
+- 驱动 underlay/overlay Canvas2D 与 WebGPU encoder。
+- 保证每帧一次 submit（无 draw 时可 0 次）。
+
+#### WebGPU ResourceTable
+
+职责：
+
+- `key -> { buffer, capacity, lastRevision, pipelineKind }`。
+- revision 未变只更新 uniform；变了才 upload 或扩容。
+- stale 节点回收；host dispose / 热切换时整表销毁。
+
+#### Renderer thin adapter
+
+职责：
+
+- 现有 `drawInstances/drawLines` 在 beginFrame/endFrame 之间 upsert 节点，不立即 submit。
+- 使 candle/lines/rects helper 可渐进迁移，不必一次改完业务层。
+
+## 6. Scene 节点模型
+
+```ts
+type SceneNodeKey = string // `${paneId}/${layerId}/${primitiveId}`
+
+type RectsNode = {
+  kind: 'rects'
+  key: SceneNodeKey
+  revision: number
+  instances: Float32Array // x,y,w,h
+  count: number
+  color: string
+  scrollLeft: number
+  z: number
+  paneId: string
+}
+
+type LinesNode = {
+  kind: 'lines'
+  key: SceneNodeKey
+  revision: number
+  strips: ReadonlyArray<{
+    points: ReadonlyArray<{ x: number; y: number }>
+    color: string
+    width?: number
+  }>
+  scrollLeft: number
+  z: number
+  paneId: string
+}
+
+type BandNode = {
+  kind: 'band'
+  key: SceneNodeKey
+  revision: number
+  upper: ReadonlyArray<{ x: number; y: number }>
+  lower: ReadonlyArray<{ x: number; y: number }>
+  color: string
+  alpha: number
+  scrollLeft: number
+  z: number
+  paneId: string
+}
+
+type SceneNode = RectsNode | LinesNode | BandNode
+```
+
+### 6.1 稳定 key 约定
+
+示例：
+
+- `main/candle/upBody`
+- `main/candle/downWick`
+- `main/ma/ma5`
+- `main/boll/band`
+- `MACD_0/macd/histUp`
+
+同一指标同一批次跨帧必须复用同一 key。
+
+### 6.2 revision 规则
+
+- 几何内容变化：revision +1。
+- 颜色 / alpha 变化：revision +1 或 materialRevision +1；实现可合并到 revision。
+- 仅 `scrollLeft`、viewport、region 变化：不改 revision，只更新 uniform。
+- 业务 helper 可用内容 hash 或“输入引用 + 参数签名”生成 revision；不得每帧无条件 +1。
+
+### 6.3 回收规则
+
+- 节点本帧被 upsert：`lastTouchedFrame = currentFrame`。
+- 某 key 本帧未 touch：标记 stale。
+- 连续 N 帧 stale（默认 N=2）或 layer dispose：从 Scene 删除并销毁 GPU 资源。
+- 后端热切换：旧 ResourceTable 全部 destroy；新 backend 按当前 SceneNode 重建。
+
+## 7. FrameGraph 与合成
+
+### 7.1 LayerRole 分流
+
+沿用现有 `LayerRole`：
+
+| Role | 目标层 |
+|---|---|
+| background | underlay 2D |
+| primary | WebGPU |
+| indicator | WebGPU |
+| component | 第一阶段仍 2D 或现有路径；后续可迁 GPU |
+| drawing | overlay 2D |
+| overlay | overlay 2D |
+
+第一阶段 GPU 必迁：candle、volume/MACD rects、MA 类 lines、BOLL/ENE band。
+
+### 7.2 帧生命周期
+
+```text
+ChartRenderer.draw
+  frameGraph.beginChartFrame()
+  for each pane:
+    clear underlay/overlay as needed
+    beginFrame(region)          // bind region, no submit
+    scene.paintPane(...)        // 2D underlay/overlay paint 或 upsert GPU nodes
+    endFrame()                  // pane 结束；仍不 submit
+  frameGraph.flushChartFrame():
+    prune stale nodes
+    encode all GPU nodes once
+    queue.submit once           // 0 或 1
+```
+
+约束：
+
+- `beginFrame` 绑定 region；`drawInstances/drawLines` 只 upsert，禁止 submit。
+- 提交点唯一：`flushChartFrame`（所有 pane paint 之后）。
+- 多 pane 共用一个 encoder；每个 pane 设置自己的 viewport/scissor。
+- MSAA：每个 pane 一个 render pass 可接受；禁止每个原语一个 pass + submit。
+- 每个 pane 的首个 pass clear 该 scissor 区域，同 pane 后续 draw 使用 load。
+
+### 7.3 与现有即时合成语义的关系
+
+当前业务在 GPU 成功后立即 `compositeTo`，是为了与 2D layer 交错兼容。混合 DOM 分层后：
+
+- WebGPU 路径删除即时 `compositeTo`。
+- underlay 先画、GPU 中层、overlay 后画，由 DOM 顺序保证。
+- WebGL 在未实现 retained/DOM 分层前可继续即时合成，避免双后端同时大改。
+
+## 8. WebGPU 资源与编码
+
+### 8.1 ResourceTable
+
+```ts
+type GpuResource = {
+  buffer: GPUBuffer
+  capacity: number
+  lastRevision: number
+  kind: 'rects' | 'lines' | 'band'
+}
+```
+
+- 扩容策略：需要时按 1.5x 或 nextPowerOfTwo 增长，禁止每帧缩到精确大小。
+- uniform：使用 frame ring buffer 或少量可复用 uniform slot；禁止每 draw `createBuffer + deferDestroy`。
+- pipeline cache：继续按 type/format/sampleCount 缓存。
+
+### 8.2 编码顺序
+
+每个 pane 内按 z 升序绘制 GPU 节点：
+
+1. rects（candle body/wick、volume、MACD）
+2. bands
+3. lines
+
+跨 pane 按 pane top 顺序编码。整帧结束后一次 submit。
+
+### 8.3 宽线几何
+
+第一阶段继续 CPU tessellation。可对 `points 引用 + width` 做几何缓存，类似 WebGL `geoCache`，避免滚动时重复生成。
+
+## 9. Chart / Host 接线
+
+### 9.1 Chart DOM
+
+- `ChartDom` 或 plot 容器增加 `gpuCanvas`（或由 RendererHost 拥有并挂到 canvasLayer）。
+- resize 时 `rendererHost.resize(plotWidth, plotHeight, dpr)` 同步 GPU canvas 物理尺寸与 CSS 尺寸。
+- 热切换到非 WebGPU 时隐藏 GPU canvas；切回时显示并重建 ResourceTable。
+
+### 9.2 RendererHost
+
+扩展职责：
+
+- 记录 last surface size（已有）。
+- 切换后端时迁移 size，并清空/重建 retained GPU 资源。
+- 发布 runtime status；不保存第二份 preference。
+
+### 9.3 业务 helper 迁移
+
+渐进顺序：
+
+1. thin adapter：现有 helper 不改签名，内部 upsert。
+2. candle / rects / lines / band 改为显式 SceneNode key。
+3. 删除 WebGPU 路径上的 `compositeSceneRenderer` 调用。
+
+Canvas fallback 与 fail-closed 保持：GPU 节点 upsert/encode 失败时，对应 layer 仍可走 2D。
+
+## 10. 性能基线与验收
+
+### 10.1 负载定义
+
+标准档：
+
+- 约 500–1000 根 K 线
+- 主图 MA + BOLL
+- 2 个副图（如 MACD、RSI）
+- 常见 DPR（1 或 1.25/1.5）
+
+重载档：
+
+- 更大可见区间或更多指标
+- 多 pane
+- 高 DPR
+- 连续拖动 / 缩放
+
+### 10.2 指标
+
+每帧采集：
+
+- `cpuPrepareMs`
+- `gpuSubmitMs` 或 encode 时长
+- `queueSubmitCount`
+- `bufferCreateCount`
+- `bufferUploadBytes`
+- `drawCallCount`
+- `compositeCount`（WebGPU 目标为 0）
+- `jsHeapDelta`（可选）
+
+对比对象：同负载 WebGL 与 WebGPU。
+
+### 10.3 门槛
+
+| 里程碑 | 门槛 |
+|---|---|
+| M0 Baseline | 指标可采集；标准/重载场景可复现 |
+| M1 Retained + single submit | WebGPU 不慢于 WebGL；submit≈1；bufferCreate 接近 0 |
+| M2 Hybrid DOM | WebGPU `compositeCount=0`；视觉等价；p95 相对 WebGL ≤ 0.7 |
+| M3 Hardening | 热切换/device lost/resize/多 pane 无泄漏；回归测试绿 |
+
+“不慢于 WebGL”定义为同负载 p95 帧耗时 ≤ WebGL × 1.05。  
+“p95 -30%”定义为同负载 p95 帧耗时 ≤ WebGL × 0.7。
+
+## 11. 里程碑
+
+### M0 — Baseline harness
+
+- 增加 frame metrics 探针（dev-only 或 test hook）。
+- 固定标准/重载场景脚本或手动 checklist。
+- 记录当前 MVP 的 submit/upload/create 基线。
+
+### M1 — Retained resources + single submit
+
+- 实现 RetainedScene 与 ResourceTable。
+- `drawInstances/drawLines` 改为帧内录制，endFrame 统一 submit。
+- uniform ring / 复用 buffer。
+- 删除每原语 create+destroy 路径。
+- 仍可暂时保留 compositeTo，以保证视觉不回归。
+
+### M2 — Hybrid DOM composition
+
+- 挂载可见 WebGPU canvas 到 plot 容器，位于 underlay 之上、overlay 之下。
+- underlay/overlay 按 LayerRole 分流。
+- 删除 WebGPU 路径 `compositeTo`。
+- pane `mainCanvas` 仅绘制 underlay（background）；GPU 原语不再写入 mainCanvas。
+- overlay 继续使用现有 `overlayCanvas`。
+- 浏览器视觉验收与 p95 门槛。
+
+### M3 — Hardening
+
+- Host 热切换重建资源。
+- device lost 清表并降级。
+- stale 回收与泄漏测试。
+- 文档与 plan 关闭条件核对。
+
+## 12. 测试策略
+
+### 12.1 单元
+
+- RetainedScene upsert / revision / prune。
+- ResourceTable upload-on-revision-only、capacity growth、destroy。
+- FrameGraph 单 submit、多 pane scissor、clear/load 语义。
+- thin adapter 把 drawInstances/drawLines 转为节点。
+
+### 12.2 集成 / 契约
+
+- candle、rects、lines、band 在 retained 路径下 fail-closed。
+- 后端切换后旧 handle/node 不泄漏到新 backend。
+- resize 后 region/DPR 正确。
+
+### 12.3 浏览器验收
+
+- WebGPU 与 WebGL 视觉对比：candle、MA、BOLL、volume、MACD、多 pane。
+- 拖动/缩放时折线跟随 scrollLeft。
+- 快速热切换无空白帧。
+- 标准/重载档 metrics 达标。
+
+## 13. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| DOM 分层改变 z-order | 严格按 role 分流；overlay 保留 2D；视觉对照 WebGL |
+| 多 pane 共用 GPU canvas 坐标错误 | region.y + scissor/viewport 单测与浏览器验收 |
+| revision 每帧抖动导致无收益 | 强制“滚动不改 revision”测试 |
+| WebGL 与 WebGPU 行为分叉 | 契约测试共享；WebGL 暂保留旧路径但 API 兼容 |
+| 一次改动过大 | 严格 M0→M3；每里程碑可回退 |
+
+## 14. 完成标准
+
+- WebGPU 路径每帧 `queueSubmitCount` 在正常绘制时为 1。
+- 稳态滚动时 `bufferCreateCount` 接近 0，upload 仅发生在几何变化。
+- WebGPU 无 GPU→2D `compositeTo`。
+- 标准档与重载档达到第 10 节门槛。
+- 热切换、device lost、dispose 无资源泄漏。
+- 相关 unit/package/build 验证通过；浏览器视觉验收通过。

--- a/packages/angular/src/__tests__/_mockController.ts
+++ b/packages/angular/src/__tests__/_mockController.ts
@@ -78,6 +78,11 @@ export function createMockChartController(
     data,
     theme,
     settings,
+    rendererRuntime: createSignal({
+      effective: 'webgl' as const,
+      status: 'ready' as const,
+      error: null,
+    }),
     chartMode: createSignal('kline' as const),
     interactionState,
     indicators: createSignal<ReadonlyArray<IndicatorInstance>>([]),

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -217,18 +217,24 @@ export class KLineChartComponent implements AfterViewInit, OnChanges, OnDestroy 
       }
     }
 
-    // Bridge viewport
+    // Bridge viewport（引用相等则跳过）
     this._viewport.set(controller.viewport.peek())
     this.destroyRef.onDestroy(
-      controller.viewport.subscribe(() => this._viewport.set(controller.viewport.peek())),
+      controller.viewport.subscribe(() => {
+        const next = controller.viewport.peek()
+        if (this._viewport() === next) return
+        this._viewport.set(next)
+      }),
     )
 
-    // Bridge interactionState
+    // Bridge interactionState（引用相等则跳过）
     this._interactionState.set(controller.interactionState.peek())
     this.destroyRef.onDestroy(
-      controller.interactionState.subscribe(() =>
-        this._interactionState.set(controller.interactionState.peek()),
-      ),
+      controller.interactionState.subscribe(() => {
+        const next = controller.interactionState.peek()
+        if (this._interactionState() === next) return
+        this._interactionState.set(next)
+      }),
     )
 
     // Bridge paneRatios

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -126,6 +126,7 @@
     "@arethetypeswrong/cli": "^0.18.3",
     "@size-limit/preset-small-lib": "^12.1.0",
     "@types/jsdom": "^28.0.0",
+    "@webgpu/types": "^0.1.71",
     "publint": "^0.3.0",
     "size-limit": "^12.1.0",
     "typescript": "~6.0.3",

--- a/packages/core/src/__tests__/signal.test.ts
+++ b/packages/core/src/__tests__/signal.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 
-import { createSignal, effect, computed } from '../foundation/reactivity/signal'
+import { createSignal, effect, computed, selectSignal } from '../foundation/reactivity/signal'
 
 describe('createSignal', () => {
   it('reads initial value', () => {
@@ -120,6 +120,41 @@ describe('computed', () => {
     const listener = vi.fn()
     c.subscribe(listener)
     a.set(2)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('selectSignal', () => {
+  it('notifies only when selected value changes', () => {
+    const source = createSignal({ a: 1, b: 2 })
+    const selected = selectSignal(source, (s) => s.a)
+    const listener = vi.fn()
+    selected.subscribe(listener)
+
+    source.set({ a: 1, b: 9 })
+    expect(listener).not.toHaveBeenCalled()
+    expect(selected.peek()).toBe(1)
+
+    source.set({ a: 3, b: 9 })
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(selected.peek()).toBe(3)
+  })
+
+  it('supports custom equality for structural fields', () => {
+    const source = createSignal({ pos: { x: 1, y: 2 } as { x: number; y: number } | null })
+    const selected = selectSignal(
+      source,
+      (s) => s.pos,
+      (a, b) =>
+        a === b || (a !== null && b !== null && a.x === b.x && a.y === b.y) || (a === null && b === null),
+    )
+    const listener = vi.fn()
+    selected.subscribe(listener)
+
+    source.set({ pos: { x: 1, y: 2 } })
+    expect(listener).not.toHaveBeenCalled()
+
+    source.set({ pos: { x: 2, y: 2 } })
     expect(listener).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/__tests__/signal.test.ts
+++ b/packages/core/src/__tests__/signal.test.ts
@@ -157,4 +157,15 @@ describe('selectSignal', () => {
     source.set({ pos: { x: 2, y: 2 } })
     expect(listener).toHaveBeenCalledTimes(1)
   })
+
+  it('dispose stops following source updates', () => {
+    const source = createSignal({ a: 1, b: 0 })
+    const selected = selectSignal(source, (s) => s.a)
+    const listener = vi.fn()
+    selected.subscribe(listener)
+    selected.dispose()
+    source.set({ a: 9, b: 0 })
+    expect(listener).not.toHaveBeenCalled()
+    expect(selected.peek()).toBe(1)
+  })
 })

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -720,6 +720,11 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
     return chart.drawings() as any[]
   }
 
+  function requestDraw(): void {
+    if (disposed) return
+    chart.scheduleDraw()
+  }
+
   function setSelectedDrawingId(id: string | null): void {
     if (disposed) return
     chart.setSelectedDrawingId(id)
@@ -962,6 +967,7 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
     removeDrawing,
     setDrawings,
     getFullDrawings,
+    requestDraw,
     setSelectedDrawingId,
     getSelectedDrawingId,
     getViewport,

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -355,6 +355,10 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
     { rendererHost, initialSettings },
   )
 
+  if (import.meta.env?.MODE !== 'production' && typeof window !== 'undefined') {
+    ;(window as any).__chart = chart
+  }
+
   const currentDpr =
     typeof window !== 'undefined' && window.devicePixelRatio > 0 ? window.devicePixelRatio : 1
   const currentKWidth = zoomLevelToKWidth(initialZoomLevel, {

--- a/packages/core/src/controllers/createChartController.ts
+++ b/packages/core/src/controllers/createChartController.ts
@@ -28,6 +28,10 @@ import { zoomLevelToKWidth, kGapFromKWidth } from '../engine/utils/zoom'
 import { KLineChartError } from '../errors'
 import { ChartBridge } from '../features/mcp/chartBridge'
 import { computed, type ReadonlySignal } from '../foundation/reactivity/index'
+import {
+  createDefaultRendererHost,
+  type RendererBackend,
+} from '../rendering/render/index'
 
 import type {
   ChartController,
@@ -334,6 +338,10 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
     initialZoomLevel,
   }
 
+  const initialSettings = resolveSettings(opts.settings)
+  const rendererHost = await createDefaultRendererHost(
+    initialSettings.rendererBackend as RendererBackend,
+  )
   const chart = new Chart(
     {
       container: mounted.container,
@@ -344,6 +352,7 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
       xAxisCanvas: mounted.xAxisCanvas,
     },
     chartOptions,
+    { rendererHost, initialSettings },
   )
 
   const currentDpr =
@@ -375,6 +384,7 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
   // Signals from ChartStateKernel — no wrapper needed
   const themeSignal: ReadonlySignal<'light' | 'dark'> = chart.theme
   const settingsSignal = chart.kernel.settings.readonly.settings
+  const rendererRuntimeSignal = chart.kernel.renderer.readonly.runtime
   const chartModeSignal = chart.kernel.mode.readonly.chartMode
   const drawingTool = chart.kernel.drawing.readonly.drawingTool
   // drawings need type mapping (plugin DrawingObject → controller DrawingObject)
@@ -418,15 +428,6 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
   if (opts.theme) {
     try {
       chart.setTheme(opts.theme)
-    } catch {
-      /* tolerate first-paint racing */
-    }
-  }
-
-  // Apply initial settings (partial, merged with defaults)
-  if (opts.settings) {
-    try {
-      chart.updateSettingsFacade(resolveSettings(opts.settings))
     } catch {
       /* tolerate first-paint racing */
     }
@@ -901,6 +902,7 @@ export async function createChartController(opts: ChartMountOptions): Promise<Ch
     symbols,
     theme: themeSignal,
     settings: settingsSignal,
+    rendererRuntime: rendererRuntimeSignal,
     chartMode: chartModeSignal,
     indicators,
     subPanes,

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -31,6 +31,11 @@ export type {
   DataFetcher,
   CustomDataSource,
 } from './types'
+export type {
+  RendererBackend,
+  RendererBackendRuntime,
+  RendererBackendStatus,
+} from '../rendering/render/rendererHost'
 
 export { createChartController } from './createChartController'
 export { createIndicatorSelectorController } from './createIndicatorSelectorController'

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -293,6 +293,10 @@ export interface ChartController extends DrawingChartAdapter {
   readonly settings: ReadonlySignal<
     Readonly<import('../foundation/config/chartSettings').ChartSettings>
   >
+  /** 当前有效 renderer、切换状态和最近错误。 */
+  readonly rendererRuntime: ReadonlySignal<
+    Readonly<import('../rendering/render/rendererHost').RendererBackendRuntime>
+  >
   /** 图表模式 id：kline | timeshare */
   readonly chartMode: ReadonlySignal<'kline' | 'timeshare'>
   readonly indicators: ReadonlySignal<ReadonlyArray<IndicatorInstance>>

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -208,6 +208,11 @@ export interface DrawingChartAdapter {
   setDrawingToolId(toolId: import('../engine/drawing/toolConfig').DrawingToolId): void
   /** read current drawing tool id from kernel */
   getDrawingToolId(): import('../engine/drawing/toolConfig').DrawingToolId
+  /**
+   * 会话态变更后请求重绘（不写 kernel）。
+   * 预览 / 拖拽中间态只改会话层时调用。
+   */
+  requestDraw?(): void
   /** current viewport (nullable if chart not ready) */
   getViewport(): DrawingChartViewport | null
   /** resolved chart options (kWidth, kGap) */

--- a/packages/core/src/engine/__tests__/chart.dpr.test.ts
+++ b/packages/core/src/engine/__tests__/chart.dpr.test.ts
@@ -541,7 +541,7 @@ describe('Chart pane layout regressions', () => {
     await chart.destroy()
   })
 
-  it('removeDrawing with registered session updates work-copy and kernel', async () => {
+  it('removeDrawing with registered session updates kernel only', async () => {
     const { DrawingInteractionController } = await import('../drawing/interaction')
     const chart = new Chart(createDom(1000, 600), defaultOptions)
     const d1 = {
@@ -565,6 +565,7 @@ describe('Chart pane layout regressions', () => {
       setDrawingToolId: (id: import('../drawing/toolConfig').DrawingToolId) =>
         chart.setDrawingTool(id),
       getDrawingToolId: () => chart.kernel.drawing.readonly.drawingTool.peek(),
+      requestDraw: () => chart.scheduleDraw(),
       getViewport: () => null,
       getKWidthKGap: () => ({ kWidth: 6, kGap: 2 }),
       getCurrentDpr: () => 1,
@@ -576,9 +577,7 @@ describe('Chart pane layout regressions', () => {
       getPaneInfo: () => undefined,
     }
     const session = new DrawingInteractionController(adapter)
-    // registerDrawingSession 会 applyToolSession 清选中，先挂会话再 seed 工作副本与选中
     chart.registerDrawingSession(session)
-    session.setDrawings([d1, d2])
     chart.setSelectedDrawingId('d1')
     chart.removeDrawing('d1')
     expect(chart.kernel.drawing.readonly.drawings.peek().map((d) => d.id)).toEqual(['d2'])

--- a/packages/core/src/engine/__tests__/paneRenderer.resize.test.ts
+++ b/packages/core/src/engine/__tests__/paneRenderer.resize.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest'
 
 import { Pane } from '@/core/layout/pane'
 import { PaneRenderer } from '@/core/paneRenderer'
-import { SharedWebGLSurface } from '@/core/renderers/webgl/sharedWebGLSurface'
 
 describe('PaneRenderer resize DPR mapping', () => {
   it('maps logical plot size to physical canvas size and keeps CSS size logical', () => {
@@ -11,7 +10,6 @@ describe('PaneRenderer resize DPR mapping', () => {
     const overlayCanvas = document.createElement('canvas')
     const yAxisCanvas = document.createElement('canvas')
     const pane = new Pane('main')
-    const sharedWebGLSurface = new SharedWebGLSurface()
     const renderer = new PaneRenderer(
       { mainCanvas, overlayCanvas, yAxisCanvas },
       pane,
@@ -21,7 +19,6 @@ describe('PaneRenderer resize DPR mapping', () => {
         yPaddingPx: 0,
         priceLabelWidth: 60,
       },
-      sharedWebGLSurface,
     )
 
     renderer.resize(500, 240, 2)
@@ -40,7 +37,6 @@ describe('PaneRenderer resize DPR mapping', () => {
     const overlayCanvas = document.createElement('canvas')
     const yAxisCanvas = document.createElement('canvas')
     const pane = new Pane('main')
-    const sharedWebGLSurface = new SharedWebGLSurface()
     const renderer = new PaneRenderer(
       { mainCanvas, overlayCanvas, yAxisCanvas },
       pane,
@@ -50,7 +46,6 @@ describe('PaneRenderer resize DPR mapping', () => {
         yPaddingPx: 0,
         priceLabelWidth: 70,
       },
-      sharedWebGLSurface,
     )
 
     renderer.resize(500, 200, 1.5)
@@ -74,7 +69,6 @@ describe('PaneRenderer resize DPR mapping', () => {
     host.appendChild(yAxisCanvas)
 
     const pane = new Pane('main')
-    const sharedWebGLSurface = new SharedWebGLSurface()
     const renderer = new PaneRenderer(
       { mainCanvas, overlayCanvas, yAxisCanvas },
       pane,
@@ -84,7 +78,6 @@ describe('PaneRenderer resize DPR mapping', () => {
         yPaddingPx: 0,
         priceLabelWidth: 70,
       },
-      sharedWebGLSurface,
     )
 
     renderer.resize(500, 200, 1.5)

--- a/packages/core/src/engine/__tests__/renderSinglePath.test.ts
+++ b/packages/core/src/engine/__tests__/renderSinglePath.test.ts
@@ -106,19 +106,15 @@ describe('render single-path (Phase 0)', () => {
     expect(ok).toHaveBeenCalledOnce()
   })
 
-  it('Manager.render is not required for paint (single path)', () => {
+  it('Scene paints without Manager draw API (single path)', () => {
     const draw = vi.fn()
     const plugin = makePlugin('only-scene', draw)
     manager.register(plugin)
     manager.setEnabled(plugin.name, false)
     scene.addLayer(createLayerFromPlugin(plugin, () => ({}) as RenderContext, 'main'))
 
-    // 旧路径：enabled false → Manager 不画
-    const errors = manager.render('main', { pane: { id: 'main' } } as RenderContext)
-    expect(errors).toEqual([])
-    expect(draw).not.toHaveBeenCalled()
-
-    // 新路径：Scene 仍画
+    // Manager 无 render 入口；Scene 仍画
+    expect(typeof (manager as { render?: unknown }).render).toBe('undefined')
     paintMain()
     expect(draw).toHaveBeenCalledOnce()
   })

--- a/packages/core/src/engine/__tests__/renderSinglePath.test.ts
+++ b/packages/core/src/engine/__tests__/renderSinglePath.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { createScene } from '../../rendering/scene/createScene'
+import { createLayerFromPlugin } from '../../rendering/scene/createLayerFromPlugin'
+import { RendererPluginManager } from '../../foundation/plugin/rendererPluginManager'
+import type { RendererPlugin, RenderContext } from '../../foundation/plugin/index'
+import { RENDERER_PRIORITY } from '../../foundation/plugin/index'
+
+/**
+ * Phase 0 契约：绘制只走 Scene；Manager 仅注册表；
+ * useRenderer 桥 = register + addLayer；setRendererEnabled 驱动 Layer 显隐。
+ */
+describe('render single-path (Phase 0)', () => {
+  let scene: ReturnType<typeof createScene>
+  let manager: RendererPluginManager
+  let consoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    scene = createScene()
+    manager = new RendererPluginManager()
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    scene.dispose()
+    manager.clear()
+    consoleError.mockRestore()
+  })
+
+  function makePlugin(name: string, draw = vi.fn()): RendererPlugin {
+    return {
+      name,
+      paneId: 'main',
+      priority: RENDERER_PRIORITY.MAIN,
+      enabled: true,
+      draw,
+    }
+  }
+
+  function paintMain() {
+    scene.paintPane({
+      renderer: {} as never,
+      region: { x: 0, y: 0, width: 100, height: 100, dpr: 1 },
+      paneRole: 'main',
+      paneId: 'main',
+      frameNumber: 1,
+      deltaMs: 0,
+    })
+  }
+
+  it('bridge: register + createLayerFromPlugin paints via scene only', () => {
+    const draw = vi.fn()
+    const plugin = makePlugin('bridge-a', draw)
+    const ctx = { theme: 'dark' } as unknown as RenderContext
+    manager.register(plugin)
+    scene.addLayer(createLayerFromPlugin(plugin, () => ctx, 'main'))
+
+    paintMain()
+    expect(draw).toHaveBeenCalledOnce()
+    expect(draw).toHaveBeenCalledWith(ctx)
+  })
+
+  it('setLayerVisibility false skips paint (timeshare candle path)', () => {
+    const draw = vi.fn()
+    const plugin = makePlugin('candle', draw)
+    scene.addLayer(createLayerFromPlugin(plugin, () => ({}) as RenderContext, 'main'))
+
+    expect(scene.setLayerVisibility('plugin:candle', false)).toBe(true)
+    paintMain()
+    expect(draw).not.toHaveBeenCalled()
+
+    scene.setLayerVisibility('plugin:candle', true)
+    paintMain()
+    expect(draw).toHaveBeenCalledOnce()
+  })
+
+  it('remove path: Manager.unregister owns onUninstall; removeLayer does not dispose-call it', () => {
+    const onUninstall = vi.fn()
+    const plugin = makePlugin('to-remove', vi.fn())
+    plugin.onUninstall = onUninstall
+    manager.register(plugin)
+    scene.addLayer(createLayerFromPlugin(plugin, () => null, 'main'))
+
+    manager.unregister('to-remove')
+    expect(onUninstall).toHaveBeenCalledOnce()
+
+    scene.removeLayer('plugin:to-remove')
+    // layer.dispose empty — no second onUninstall
+    expect(onUninstall).toHaveBeenCalledOnce()
+  })
+
+  it('one layer throw does not abort sibling layers', () => {
+    const ok = vi.fn()
+    const boom = vi.fn(() => {
+      throw new Error('boom')
+    })
+    scene.addLayer(
+      createLayerFromPlugin(makePlugin('boom', boom), () => ({}) as RenderContext, 'main'),
+    )
+    scene.addLayer(
+      createLayerFromPlugin(makePlugin('ok', ok), () => ({}) as RenderContext, 'main'),
+    )
+
+    expect(() => paintMain()).not.toThrow()
+    expect(boom).toHaveBeenCalledOnce()
+    expect(ok).toHaveBeenCalledOnce()
+  })
+
+  it('Manager.render is not required for paint (single path)', () => {
+    const draw = vi.fn()
+    const plugin = makePlugin('only-scene', draw)
+    manager.register(plugin)
+    manager.setEnabled(plugin.name, false)
+    scene.addLayer(createLayerFromPlugin(plugin, () => ({}) as RenderContext, 'main'))
+
+    // 旧路径：enabled false → Manager 不画
+    const errors = manager.render('main', { pane: { id: 'main' } } as RenderContext)
+    expect(errors).toEqual([])
+    expect(draw).not.toHaveBeenCalled()
+
+    // 新路径：Scene 仍画
+    paintMain()
+    expect(draw).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -6,7 +6,6 @@ import {
 } from '../features/alerts/rollingVolume'
 import {
   createPluginHost,
-  GLOBAL_PANE_ID,
   RendererPluginManager,
   wrapPaneInfo,
   type PluginHostImpl,
@@ -589,7 +588,7 @@ export class Chart {
   // ========== 渲染器插件 API（绘制只走 Scene；Manager 仅作注册表） ==========
 
   private resolvePluginLayerTarget(plugin: RendererPlugin): string {
-    if (typeof plugin.paneId === 'symbol' || plugin.paneId === GLOBAL_PANE_ID) {
+    if (typeof plugin.paneId === 'symbol') {
       return 'global'
     }
     return String(plugin.paneId)

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -259,7 +259,6 @@ export class Chart {
         }
       },
       getViewport: () => this.viewportManager.getViewport(),
-      getSharedWebGLSurface: () => this.sharedWebGLSurface,
       setKnownPaneIds: (ids) => this.rendererPluginManager.setKnownPaneIds(ids),
       notifyPaneResize: (paneId, pane) =>
         this.rendererPluginManager.notifyResize(paneId, wrapPaneInfo(pane)),

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -464,6 +464,7 @@ export class Chart {
       customMarkers$: this.kernel.marker.readonly.customMarkers,
       drawings$: this.kernel.drawing.readonly.drawings,
       selectedDrawingId$: this.kernel.drawing.readonly.selectedDrawingId,
+      getOverlay: () => this.drawingSession?.getPaintOverlay() ?? [],
     })
     this.renderer.registerDrawingPlugins()
     this.renderer.initCoreRenderers()
@@ -912,9 +913,10 @@ export class Chart {
     this.indicatorManager.bindIndicatorToPane(paneId, indicatorId, params)
   }
 
-  /** 更新绘图对象（写 kernel + 重绘） */
+  /** 更新绘图对象（写 kernel + 重绘）；剥离会话预览 id */
   setDrawings(drawings: import('../foundation/plugin').DrawingObject[]): void {
-    this.kernel.drawing.actions.setDrawings(drawings)
+    const committed = drawings.filter((d) => d.id !== '__preview__')
+    this.kernel.drawing.actions.setDrawings(committed)
     this.scheduleDraw()
   }
 

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -6,12 +6,14 @@ import {
 } from '../features/alerts/rollingVolume'
 import {
   createPluginHost,
+  GLOBAL_PANE_ID,
   RendererPluginManager,
   wrapPaneInfo,
   type PluginHostImpl,
   type RendererPlugin,
   type RendererPluginWithHost,
 } from '../foundation/plugin/index'
+import { createLayerFromPlugin } from '../rendering/scene/createLayerFromPlugin'
 import {
   computed,
   type Computed,
@@ -585,22 +587,80 @@ export class Chart {
     return this.pluginHost
   }
 
-  // ========== 渲染器插件 API ==========
+  // ========== 渲染器插件 API（绘制只走 Scene；Manager 仅作注册表） ==========
 
-  /** 安装渲染器插件 */
+  private resolvePluginLayerTarget(plugin: RendererPlugin): string {
+    if (typeof plugin.paneId === 'symbol' || plugin.paneId === GLOBAL_PANE_ID) {
+      return 'global'
+    }
+    return String(plugin.paneId)
+  }
+
+  private getContextForPluginLayer(targetPaneId: string) {
+    return () => {
+      if (!this.renderer) return null
+      const map = this.renderer.getPaneCtxMap()
+      if (targetPaneId === 'global') {
+        return map.get(this.renderer.getCurrentPaneId()) ?? null
+      }
+      return map.get(targetPaneId) ?? null
+    }
+  }
+
+  /** 安装渲染器插件：注册元数据 + 挂 Scene Layer（唯一绘制路径；幂等） */
   useRenderer(
     plugin: RendererPlugin | RendererPluginWithHost,
     config?: Record<string, unknown>,
   ): void {
+    const layerId = `plugin:${plugin.name}`
+    const scene = this.renderer?.getScene()
+    const existingPlugin = this.rendererPluginManager.getPlugin(plugin.name)
+    const alreadyLayer = scene?.getLayer(layerId) != null
+
+    if (existingPlugin && alreadyLayer) {
+      if (config && existingPlugin.setConfig) existingPlugin.setConfig(config)
+      return
+    }
+
+    // 仅有注册表：补挂 Layer（不新建 plugin 实例）
+    if (existingPlugin && !alreadyLayer) {
+      if (config && existingPlugin.setConfig) existingPlugin.setConfig(config)
+      const targetPaneId = this.resolvePluginLayerTarget(existingPlugin)
+      scene?.addLayer(
+        createLayerFromPlugin(
+          existingPlugin,
+          this.getContextForPluginLayer(targetPaneId),
+          targetPaneId,
+        ),
+      )
+      return
+    }
+
+    // 仅有 Layer（core 预挂）：不二次 register，避免 Manager 实例 ≠ 绘制实例
+    if (!existingPlugin && alreadyLayer) {
+      return
+    }
+
     this.rendererPluginManager.register(plugin)
     if (config && plugin.setConfig) {
       plugin.setConfig(config)
     }
+    const targetPaneId = this.resolvePluginLayerTarget(plugin)
+    const layer = createLayerFromPlugin(
+      plugin,
+      this.getContextForPluginLayer(targetPaneId),
+      targetPaneId,
+    )
+    scene?.addLayer(layer)
   }
 
-  /** 移除渲染器插件 */
+  /**
+   * 移除渲染器插件。
+   * onUninstall 仅由 Manager.unregister 调用；Scene removeLayer 不 dispose，避免双调。
+   */
   removeRenderer(name: string): void {
     this.rendererPluginManager.unregister(name)
+    this.renderer?.getScene()?.removeLayer(`plugin:${name}`)
   }
 
   /** 获取渲染器插件 */
@@ -613,9 +673,18 @@ export class Chart {
     this.rendererPluginManager.updateConfig(name, config)
   }
 
-  /** 启用/禁用渲染器 */
+  /** 启用/禁用渲染器（Scene Layer 显隐；Manager enabled 仅同步元数据） */
   setRendererEnabled(name: string, enabled: boolean): void {
-    this.rendererPluginManager.setEnabled(name, enabled)
+    const inManager = this.rendererPluginManager.getPlugin(name) != null
+    if (inManager) {
+      // setEnabled → invalidate → scheduleDraw（勿再 schedule 双唤醒）
+      this.rendererPluginManager.setEnabled(name, enabled)
+    }
+    this.renderer?.getScene()?.setLayerVisibility(`plugin:${name}`, enabled)
+    // core-only Layer（如 candle）不在 Manager：需显式重绘
+    if (!inManager) {
+      this.scheduleDraw()
+    }
   }
 
   /** 获取所有渲染器 */
@@ -1169,6 +1238,8 @@ export class Chart {
   /** 销毁图表实例 */
   async destroy() {
     this.indicatorManager.destroy()
+    // onUninstall 由 Manager 单点负责；须在 scene.dispose 之前 clear
+    this.rendererPluginManager.clear()
     this.renderer.destroy()
     this.dataManager.destroy()
     this.viewportManager.destroy()

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -232,10 +232,13 @@ export class Chart {
       scheduleDraw: (level) => this.scheduleDraw(level as UpdateLevel | undefined),
     })
     this.rendererHost.setListeners({
-      onRuntimeChange: (rendererRuntime) =>
-        this.kernel.renderer.actions.setRuntime(rendererRuntime),
+      onRuntimeChange: (rendererRuntime) => {
+        this.kernel.renderer.actions.setRuntime(rendererRuntime)
+        this.syncGpuSceneCanvas()
+      },
       requestRedraw: () => this.scheduleDraw(UpdateLevel.All),
     })
+    this.syncGpuSceneCanvas()
 
     // Inject DOM deps into kernel's viewportState (needed before init)
     this.kernel.setViewportDomDeps({
@@ -771,7 +774,11 @@ export class Chart {
     }
 
     if (prev.rendererBackend !== next.rendererBackend) {
-      void this.rendererHost.switchTo(next.rendererBackend as RendererBackend)
+      void this.rendererHost.switchTo(next.rendererBackend as RendererBackend).then(() => {
+        this.syncGpuSceneCanvas()
+        this.scheduleDraw(UpdateLevel.All)
+      })
+      return
     }
 
     this.scheduleDraw()
@@ -1254,6 +1261,39 @@ export class Chart {
     }
   }
 
+  /**
+   * M2：将 WebGPU canvas 挂到 plot 区（main 与 overlay 之间），非 webgpu 时移除。
+   * 多 pane 共用一张 canvas，region.y + scissor 区分。
+   */
+  private syncGpuSceneCanvas(): void {
+    const layer = this.dom.canvasLayer
+    if (!layer) return
+    const effective = this.rendererHost.runtime.effective
+    const existing = layer.querySelector('canvas.gpu-scene-canvas') as HTMLCanvasElement | null
+
+    if (effective !== 'webgpu') {
+      existing?.remove()
+      return
+    }
+
+    const surface = this.rendererHost.renderer.surface as { canvas?: HTMLCanvasElement }
+    const canvas = surface.canvas
+    if (!canvas) return
+
+    canvas.classList.add('gpu-scene-canvas')
+    canvas.style.position = 'absolute'
+    canvas.style.left = '0'
+    canvas.style.top = '0'
+    canvas.style.pointerEvents = 'none'
+    canvas.style.zIndex = '1'
+    canvas.style.backgroundColor = 'transparent'
+
+    if (existing !== canvas) {
+      existing?.remove()
+      if (!canvas.isConnected) layer.appendChild(canvas)
+    }
+  }
+
   /** 销毁图表实例 */
   async destroy() {
     this.indicatorManager.destroy()
@@ -1263,6 +1303,7 @@ export class Chart {
     this.dataManager.destroy()
     this.viewportManager.destroy()
     this.layoutManager.destroy()
+    this.dom.canvasLayer?.querySelector('canvas.gpu-scene-canvas')?.remove()
     this.rendererHost.dispose()
     this.kernel.dispose()
     this.alertController.dispose()

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -23,6 +23,11 @@ import {
 import { InteractionController, type InteractionSnapshot } from './controller/interaction'
 
 import type { ChartSettings } from '../foundation/config/chartSettings'
+import {
+  createDefaultRendererHostSync,
+  type RendererBackend,
+  type RendererHost,
+} from '../rendering/render/index'
 import type { KLineData } from '../foundation/types/price'
 
 import type { IndicatorScheduler } from './indicators/scheduler'
@@ -42,7 +47,6 @@ import { KLineMode } from './modes/kLineMode'
 import { TimeShareMode } from './modes/timeShareMode'
 import { PaneRenderer } from './paneRenderer'
 import { ChartRenderer } from './render/chartRenderer'
-import { SharedWebGLSurface } from './renderers/webgl/sharedWebGLSurface'
 import { ChartStateKernel } from './state/chartStateKernel'
 import { ChartViewportManager } from './viewport/chartViewportManager'
 import { getVisibleRange } from './viewport/viewport'
@@ -102,8 +106,8 @@ export class Chart {
   /** 渲染器插件管理器 */
   private rendererPluginManager: RendererPluginManager
 
-  /** Chart 级共享 WebGL canvas/context */
-  private sharedWebGLSurface: SharedWebGLSurface
+  /** 具体渲染后端及其生命周期所有者 */
+  private rendererHost: RendererHost
 
   /** 缩放控制器 */
   private zoomController: ChartZoomController
@@ -197,13 +201,17 @@ export class Chart {
    * @param dom 由 Vue 组件传入的 DOM 句柄
    * @param opt 初始配置
    */
-  constructor(dom: ChartDom, opt: ChartOptions) {
+  constructor(
+    dom: ChartDom,
+    opt: ChartOptions,
+    runtime?: { rendererHost?: RendererHost; initialSettings?: Partial<ChartSettings> },
+  ) {
     this.dom = dom
     const { kWidth: _kWidth, kGap: _kGap, ...restOpt } = opt
     this._activeMode = this._kLineMode
     this.pluginHost = createPluginHost()
     this.rendererPluginManager = new RendererPluginManager()
-    this.sharedWebGLSurface = new SharedWebGLSurface()
+    this.rendererHost = runtime?.rendererHost ?? createDefaultRendererHostSync()
 
     // 注入依赖
     this.rendererPluginManager.setPluginHost(this.pluginHost)
@@ -219,14 +227,21 @@ export class Chart {
         zoomLevelCount,
       },
       initialZoomLevel,
+      initialSettings: runtime?.initialSettings,
+      initialRendererRuntime: this.rendererHost.runtime,
       scheduleDraw: (level) => this.scheduleDraw(level as UpdateLevel | undefined),
+    })
+    this.rendererHost.setListeners({
+      onRuntimeChange: (rendererRuntime) =>
+        this.kernel.renderer.actions.setRuntime(rendererRuntime),
+      requestRedraw: () => this.scheduleDraw(UpdateLevel.All),
     })
 
     // Inject DOM deps into kernel's viewportState (needed before init)
     this.kernel.setViewportDomDeps({
       getDom: () => this.dom,
       resizeSharedWebGLSurface: (plotWidth, plotHeight, dpr) =>
-        this.sharedWebGLSurface.resize(plotWidth, plotHeight, dpr),
+        this.rendererHost.resize(plotWidth, plotHeight, dpr),
     })
 
     // ── ViewportManager (DOM lifecycle: ResizeObserver + scroll events) ──
@@ -435,7 +450,7 @@ export class Chart {
       },
       getPaneRenderers: () => this.paneRenderers,
       getInteraction: () => this.interaction,
-      getSharedWebGLSurface: () => this.sharedWebGLSurface,
+      getSceneRenderer: () => this.rendererHost.renderer,
       getPluginHost: () => this.pluginHost,
       getRendererPluginManager: () => this.rendererPluginManager,
       getTheme: () => this.kernel.effectiveTheme$.peek(),
@@ -752,6 +767,10 @@ export class Chart {
 
     if ('rightAxisType' in settings) {
       this.applyRightAxisTypeToKernel(settings.rightAxisType as string)
+    }
+
+    if (prev.rendererBackend !== next.rendererBackend) {
+      void this.rendererHost.switchTo(next.rendererBackend as RendererBackend)
     }
 
     this.scheduleDraw()
@@ -1242,7 +1261,7 @@ export class Chart {
     this.dataManager.destroy()
     this.viewportManager.destroy()
     this.layoutManager.destroy()
-    this.sharedWebGLSurface.destroy()
+    this.rendererHost.dispose()
     this.kernel.dispose()
     this.alertController.dispose()
     await this.pluginHost.destroy()

--- a/packages/core/src/engine/controller/__tests__/interaction.dpr.test.ts
+++ b/packages/core/src/engine/controller/__tests__/interaction.dpr.test.ts
@@ -283,9 +283,11 @@ describe('InteractionController DPR consumption', () => {
     interaction.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
 
     interaction.onPointerMove({ clientX: 50, clientY: 40, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
     expect(interaction.crosshairPos).not.toBeNull()
 
     interaction.onPointerMove({ clientX: 120, clientY: 40, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
     expect(interaction.crosshairPos).toBeNull()
     expect(interaction.crosshairIndex).toBeNull()
   })
@@ -296,6 +298,7 @@ describe('InteractionController DPR consumption', () => {
     interactionDpr1.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
 
     interactionDpr1.onPointerMove({ clientX: 8, clientY: 40, isPrimary: true } as PointerEvent)
+    interactionDpr1.flushPendingHover()
     expect(interactionDpr1.crosshairIndex).toBe(0)
 
     const chartDpr2 = createChartStub({ dpr: 2, plotWidth: 300, plotHeight: 160 })
@@ -303,7 +306,20 @@ describe('InteractionController DPR consumption', () => {
     interactionDpr2.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
 
     interactionDpr2.onPointerMove({ clientX: 8, clientY: 40, isPrimary: true } as PointerEvent)
+    interactionDpr2.flushPendingHover()
     expect(interactionDpr2.crosshairIndex).toBe(1)
+  })
+
+  it('pointermove does not write crosshair until flushPendingHover', () => {
+    const chart = createChartStub({ dpr: 1, plotWidth: 100, plotHeight: 80 })
+    const interaction = new InteractionController(chart as never, createMockInteractionState())
+    interaction.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
+
+    interaction.onPointerMove({ clientX: 50, clientY: 40, isPrimary: true } as PointerEvent)
+    expect(interaction.crosshairPos).toBeNull()
+
+    interaction.flushPendingHover()
+    expect(interaction.crosshairPos).not.toBeNull()
   })
 })
 
@@ -322,6 +338,7 @@ describe('InteractionController pane capability gating', () => {
 
     interaction.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
     interaction.onPointerMove({ clientX: 5, clientY: 140, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
 
     expect(interaction.activePaneId).toBe('sub_MACD')
     expect(interaction.hoveredIndex).toBeNull()
@@ -341,6 +358,7 @@ describe('InteractionController pane capability gating', () => {
 
     interaction.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
     interaction.onPointerMove({ clientX: 5, clientY: 10, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
 
     expect(interaction.activePaneId).toBe('main')
     expect(interaction.crosshairIndex).not.toBeNull()
@@ -361,9 +379,11 @@ describe('InteractionController pane capability gating', () => {
 
     interaction.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
     interaction.onPointerMove({ clientX: 5, clientY: 10, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
     expect(interaction.hoveredIndex).toBe(interaction.crosshairIndex)
 
     interaction.onPointerMove({ clientX: 5, clientY: 140, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
     expect(interaction.activePaneId).toBe('sub_MACD')
     expect(interaction.hoveredIndex).toBeNull()
   })
@@ -386,6 +406,7 @@ describe('InteractionController hover snapshot', () => {
     const interaction = new InteractionController(chart as never, createMockInteractionState())
 
     interaction.onPointerMove({ clientX: 20, clientY: 20, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
     expect(interaction.getInteractionSnapshot().hoveredMarkerData).toBe(marker)
 
     interaction.onScroll()
@@ -414,11 +435,13 @@ describe('InteractionController hover snapshot', () => {
     const interaction = new InteractionController(chart as never, createMockInteractionState())
 
     interaction.onPointerMove({ clientX: 20, clientY: 20, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
     expect(interaction.getInteractionSnapshot().hoveredCustomMarker).toBe(customMarker)
 
     hoveringCustom = false
     interaction.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
     interaction.onPointerMove({ clientX: 20, clientY: 20, isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
 
     expect(interaction.getInteractionSnapshot().hoveredCustomMarker).toBeNull()
   })

--- a/packages/core/src/engine/controller/__tests__/interaction.dpr.test.ts
+++ b/packages/core/src/engine/controller/__tests__/interaction.dpr.test.ts
@@ -321,6 +321,19 @@ describe('InteractionController DPR consumption', () => {
     interaction.flushPendingHover()
     expect(interaction.crosshairPos).not.toBeNull()
   })
+
+  it('pointerleave cancels pending hover so flush does not restore crosshair', () => {
+    const chart = createChartStub({ dpr: 1, plotWidth: 100, plotHeight: 80 })
+    const interaction = new InteractionController(chart as never, createMockInteractionState())
+    interaction.setKLinePositions([0, 10], { start: 0, end: 2 }, 10)
+
+    interaction.onPointerMove({ clientX: 50, clientY: 40, isPrimary: true } as PointerEvent)
+    interaction.onPointerLeave({ isPrimary: true } as PointerEvent)
+    interaction.flushPendingHover()
+
+    expect(interaction.crosshairPos).toBeNull()
+    expect(interaction.crosshairIndex).toBeNull()
+  })
 })
 
 describe('InteractionController pane capability gating', () => {

--- a/packages/core/src/engine/controller/__tests__/interaction.dpr.test.ts
+++ b/packages/core/src/engine/controller/__tests__/interaction.dpr.test.ts
@@ -9,6 +9,7 @@ function createMockInteractionState() {
   const signals = {
     crosshairPos: writableRef<{ x: number; y: number } | null>(null),
     crosshairPrice: writableRef<number | null>(null),
+    crosshairIndex: writableRef<number | null>(null),
     hoveredIndex: writableRef<number | null>(null),
     activePaneId: writableRef<string | null>(null),
     isDragging: writableRef(false),
@@ -20,38 +21,13 @@ function createMockInteractionState() {
     hoveredMarkerData: writableRef<any>(null),
     hoveredCustomMarker: writableRef<any>(null),
     hoveredMarkerId: writableRef<string | null>(null),
-    kLinePositions: writableRef<number[] | null>(null),
-    kLineCenters: writableRef<number[] | null>(null),
-    kWidthPx: writableRef<number | null>(null),
   }
-
-  function computeCrosshairIndex(): number | null {
-    const pos = signals.crosshairPos.peek()
-    const positions = signals.kLinePositions.peek()
-    const kwp = signals.kWidthPx.peek()
-    if (!pos || !positions || !kwp) return null
-    const worldX = pos.x
-    let minDist = Infinity
-    let minIdx = -1
-    for (let i = 0; i < positions.length; i++) {
-      const dist = Math.abs(positions[i]! - worldX)
-      if (dist < minDist) {
-        minDist = dist
-        minIdx = i
-      }
-    }
-    return minIdx >= 0 ? minIdx : null
-  }
-
-  const crosshairIndexSignal = {
-    peek: () => computeCrosshairIndex(),
-    subscribe: () => () => {},
-  } as any
 
   return {
     readonly: {
       crosshairPos: signals.crosshairPos,
       crosshairPrice: signals.crosshairPrice,
+      crosshairIndex: signals.crosshairIndex,
       hoveredIndex: signals.hoveredIndex,
       activePaneId: signals.activePaneId,
       isDragging: signals.isDragging,
@@ -63,14 +39,10 @@ function createMockInteractionState() {
       hoveredMarkerData: signals.hoveredMarkerData,
       hoveredCustomMarker: signals.hoveredCustomMarker,
       hoveredMarkerId: signals.hoveredMarkerId,
-      kLinePositions: signals.kLinePositions,
-      kLineCenters: signals.kLineCenters,
-      kWidthPx: signals.kWidthPx,
-      crosshairIndex: crosshairIndexSignal,
       interactionSnapshot: {
         peek: () => ({
           crosshairPos: signals.crosshairPos.peek(),
-          crosshairIndex: crosshairIndexSignal.peek(),
+          crosshairIndex: signals.crosshairIndex.peek(),
           crosshairPrice: signals.crosshairPrice.peek(),
           hoveredIndex: signals.hoveredIndex.peek(),
           activePaneId: signals.activePaneId.peek(),
@@ -87,9 +59,13 @@ function createMockInteractionState() {
       } as any,
     },
     actions: {
-      updateCrosshair(pos: any, price: any) {
+      updateCrosshair(pos: any, price: any, index?: any) {
         signals.crosshairPos.set(pos)
         signals.crosshairPrice.set(price)
+        if (index !== undefined) signals.crosshairIndex.set(index)
+      },
+      setCrosshairIndex(index: any) {
+        signals.crosshairIndex.set(index)
       },
       setHoveredIndex(index: any) {
         signals.hoveredIndex.set(index)
@@ -100,11 +76,6 @@ function createMockInteractionState() {
       updateHover(index: any, paneId: any) {
         signals.hoveredIndex.set(index)
         signals.activePaneId.set(paneId)
-      },
-      updateFramePositions(positions: any, centers: any, kWidthPxVal: any) {
-        signals.kLinePositions.set(positions)
-        signals.kLineCenters.set(centers)
-        signals.kWidthPx.set(kWidthPxVal)
       },
       startDrag(mode: any) {
         signals.isDragging.set(true)
@@ -135,6 +106,7 @@ function createMockInteractionState() {
       reset() {
         signals.crosshairPos.set(null)
         signals.crosshairPrice.set(null)
+        signals.crosshairIndex.set(null)
         signals.hoveredIndex.set(null)
         signals.activePaneId.set(null)
         signals.isDragging.set(false)
@@ -146,10 +118,6 @@ function createMockInteractionState() {
         signals.hoveredMarkerData.set(null)
         signals.hoveredCustomMarker.set(null)
         signals.hoveredMarkerId.set(null)
-        signals.kLinePositions.set(null)
-        signals.kLineCenters.set(null)
-        signals.kWidthPx.set(null)
-        crosshairIndexSignal.set(null)
       },
     },
     dispose() {},

--- a/packages/core/src/engine/controller/interaction.ts
+++ b/packages/core/src/engine/controller/interaction.ts
@@ -82,6 +82,13 @@ export class InteractionController {
    * pointermove 只置位；flushPendingHover 每帧最多推导一次并写 kernel。
    */
   private hoverFlushPending = false
+  /**
+   * 本帧封存的 K 线几何（非 kernel signal，避免每帧广播大数组）。
+   * 仅 InteractionController hover 读取；绘制走 ChartRenderer FrameContext。
+   */
+  private framePositions: number[] | null = null
+  private frameCenters: number[] | null = null
+  private frameKWidthPx: number | null = null
   private markerState = new MarkerInteractionState()
   private lastHoverRenderKey = ''
   private useTooltipAnchorPositioning = false
@@ -338,7 +345,9 @@ export class InteractionController {
 
   /** 处理滚动事件 */
   onScroll(options: { scheduleDraw?: boolean } = {}) {
-    this._state.actions.updateFramePositions(null, null, null)
+    this.framePositions = null
+    this.frameCenters = null
+    this.frameKWidthPx = null
     this.hoverFlushPending = false
     this.clearHover()
     if (options.scheduleDraw !== false) {
@@ -454,13 +463,13 @@ export class InteractionController {
   }
 
   /**
-   * 封存本帧 K 线几何（由 ChartRenderer 在 paint 前调用）。
-   * 引用未变时不触发 signal 通知；几何变化后用 lastClientPos 重算十字线。
+   * 封存本帧 K 线几何到 controller 私有字段（非 kernel signal）。
+   * ChartRenderer 在 paint 前调用；引用未变则跳过 hover 重算。
    *
    * @param positions K 线起始 x 坐标数组
-   * @param visibleRange 可见 K 线索引范围（hover 用 viewport signal，此处保留兼容签名）
+   * @param visibleRange 保留兼容签名（hover 用 viewport）
    * @param kWidthPx K 线宽度（物理像素）
-   * @param centers K 线中心 x 坐标数组（物理像素对齐后）
+   * @param centers K 线中心 x 坐标数组
    */
   setKLinePositions(
     positions: number[] | null,
@@ -468,15 +477,16 @@ export class InteractionController {
     kWidthPx?: number,
     centers?: number[] | null,
   ) {
-    const prevPositions = this._state.readonly.kLinePositions.peek()
-    const prevCenters = this._state.readonly.kLineCenters.peek()
-    const prevWidth = this._state.readonly.kWidthPx.peek()
     const nextWidth = kWidthPx ?? null
     const nextCenters = centers ?? null
     const unchanged =
-      prevPositions === positions && prevCenters === nextCenters && prevWidth === nextWidth
+      this.framePositions === positions &&
+      this.frameCenters === nextCenters &&
+      this.frameKWidthPx === nextWidth
 
-    this._state.actions.updateFramePositions(positions, nextCenters, nextWidth)
+    this.framePositions = positions
+    this.frameCenters = nextCenters
+    this.frameKWidthPx = nextWidth
 
     // 几何变化时标记 hover 待刷新；由 flushPendingHover 与 paint 同帧完成
     if (!unchanged && this.lastClientPos && !this._state.readonly.isDragging.peek()) {
@@ -603,7 +613,7 @@ export class InteractionController {
     this.activePaneIdOnDrag = pane.id
     this._state.actions.setRightAxisHover(pane.id)
     this._state.actions.setSeparatorHover(null)
-    this._state.actions.updateCrosshair(null, null)
+    this._state.actions.updateCrosshair(null, null, null)
     this._state.actions.updateHover(null, pane.id)
     return true
   }
@@ -612,7 +622,7 @@ export class InteractionController {
     this.hoverFlushPending = false
     this.lastHoverRenderKey = ''
     this._state.actions.setRightAxisHover(null)
-    this._state.actions.updateCrosshair(null, null)
+    this._state.actions.updateCrosshair(null, null, null)
     this._state.actions.updateHover(null, null)
     this._state.actions.updateMarkerHover(null, null, null)
     this.markerState.clearAll(this.chart.getMarkerManager())
@@ -646,7 +656,7 @@ export class InteractionController {
     const pane = this.getPaneByY(mouseY)
     this._state.actions.setRightAxisHover(pane?.id || null)
     this._state.actions.setSeparatorHover(null)
-    this._state.actions.updateCrosshair(null, null)
+    this._state.actions.updateCrosshair(null, null, null)
     this._state.actions.updateHover(null, pane?.id || null)
   }
 
@@ -742,7 +752,7 @@ if (this.tooltipPositionMode === 'adaptive') {
     const separatorUpperPaneId = this.hitTestPaneSeparator(ctx.mouseY)
     this._state.actions.setSeparatorHover(separatorUpperPaneId)
     if (separatorUpperPaneId) {
-      this._state.actions.updateCrosshair(null, null)
+      this._state.actions.updateCrosshair(null, null, null)
       this._state.actions.updateHover(null, null)
       return true
     }
@@ -759,7 +769,7 @@ if (this.tooltipPositionMode === 'adaptive') {
     const result = this.markerState.updateHoverFromPoint(ctx.worldX, ctx.mouseX, ctx.mouseY, markerManager)
     this._state.actions.updateMarkerHover(result.hitMarkerId, result.hitMarkerData, result.hitCustomMarker)
     if (result.hit) {
-      this._state.actions.updateCrosshair(null, null)
+      this._state.actions.updateCrosshair(null, null, null)
       this._state.actions.setHoveredIndex(null)
       return true
     }
@@ -773,8 +783,8 @@ if (this.tooltipPositionMode === 'adaptive') {
    * 若无 kLinePositions、visibleRange 或 kWidthPx，返回 null。
    */
   private findNearestBar(ctx: HoverContext): NearestBar | null {
-    const kLinePositions = this._state.readonly.kLinePositions.peek()
-    const kWidthPx = this._state.readonly.kWidthPx.peek()
+    const kLinePositions = this.framePositions
+    const kWidthPx = this.frameKWidthPx
     const vp = this.chart.viewport.peek()
     const visibleRange = vp ? { start: vp.visibleFrom, end: vp.visibleTo } : null
     if (!kLinePositions || !visibleRange || !kWidthPx) return null
@@ -837,16 +847,16 @@ if (this.tooltipPositionMode === 'adaptive') {
    * 索引无效时清除十字线状态。
    */
   private positionCrosshair(ctx: HoverContext, bar: NearestBar): void {
-    const { mouseX, mouseY, scrollLeft, plotWidth, plotHeight, dpr } = ctx
+    const { mouseY, scrollLeft, plotWidth, plotHeight } = ctx
     const pane = this.getPaneByY(mouseY)
     this._state.actions.setActivePaneId(pane?.id || null)
 
     if (bar.globalIdx < 0 || bar.globalIdx >= this.chart.getInternalData().length) {
-      this._state.actions.updateCrosshair(null, null)
+      this._state.actions.updateCrosshair(null, null, null)
       return
     }
 
-    const kLineCenters = this._state.readonly.kLineCenters.peek()
+    const kLineCenters = this.frameCenters
     const centerX = kLineCenters?.[bar.localIdx] ?? bar.kLineStartX + bar.widthLogical / 2
     const snappedX = centerX - scrollLeft
 
@@ -857,6 +867,7 @@ if (this.tooltipPositionMode === 'adaptive') {
         y: Math.min(Math.max(mouseY, 0), plotHeight),
       },
       price,
+      bar.globalIdx,
     )
   }
 
@@ -976,10 +987,12 @@ if (this.tooltipPositionMode === 'adaptive') {
     this.clearSeparatorState()
     this.isTouchSession = false
     this.pinchTracker.reset()
-    this._state.actions.updateCrosshair(null, null)
+    this._state.actions.updateCrosshair(null, null, null)
     this._state.actions.updateHover(null, null)
     this.markerState.reset()
-    this._state.actions.updateFramePositions(null, null, null)
+    this.framePositions = null
+    this.frameCenters = null
+    this.frameKWidthPx = null
     this.lastHoverRenderKey = ''
   }
 

--- a/packages/core/src/engine/controller/interaction.ts
+++ b/packages/core/src/engine/controller/interaction.ts
@@ -327,6 +327,9 @@ export class InteractionController {
     this.activePaneIdOnDrag = null
     this.clearSeparatorState()
     if (!this.isTouchSession) {
+      // 取消已排队 hover，避免后续帧用 lastClientPos 把十字线刷回来
+      this.hoverFlushPending = false
+      this.lastClientPos = null
       this.clearHover()
       this.chart.scheduleDraw()
     }
@@ -606,6 +609,7 @@ export class InteractionController {
   }
 
   clearHover() {
+    this.hoverFlushPending = false
     this.lastHoverRenderKey = ''
     this._state.actions.setRightAxisHover(null)
     this._state.actions.updateCrosshair(null, null)

--- a/packages/core/src/engine/controller/interaction.ts
+++ b/packages/core/src/engine/controller/interaction.ts
@@ -428,22 +428,32 @@ export class InteractionController {
   }
 
   /**
-   * 设置当前帧的 K 线起始 x 坐标数组和可见范围
+   * 封存本帧 K 线几何（由 ChartRenderer 在 paint 前调用）。
+   * 引用未变时不触发 signal 通知；几何变化后用 lastClientPos 重算十字线。
+   *
    * @param positions K 线起始 x 坐标数组
-   * @param visibleRange 可见 K 线索引范围
+   * @param visibleRange 可见 K 线索引范围（hover 用 viewport signal，此处保留兼容签名）
    * @param kWidthPx K 线宽度（物理像素）
    * @param centers K 线中心 x 坐标数组（物理像素对齐后）
    */
   setKLinePositions(
     positions: number[] | null,
-    visibleRange: { start: number; end: number } | null,
+    _visibleRange: { start: number; end: number } | null,
     kWidthPx?: number,
     centers?: number[] | null,
   ) {
-    this._state.actions.updateFramePositions(positions, centers ?? null, kWidthPx ?? null)
+    const prevPositions = this._state.readonly.kLinePositions.peek()
+    const prevCenters = this._state.readonly.kLineCenters.peek()
+    const prevWidth = this._state.readonly.kWidthPx.peek()
+    const nextWidth = kWidthPx ?? null
+    const nextCenters = centers ?? null
+    const unchanged =
+      prevPositions === positions && prevCenters === nextCenters && prevWidth === nextWidth
 
-    // 十字线自动同步：positions 刷新后用最新鼠标位置重算，防止缩放/滚动后索引滞后
-    if (this.lastClientPos && !this._state.readonly.isDragging.peek()) {
+    this._state.actions.updateFramePositions(positions, nextCenters, nextWidth)
+
+    // 几何未变则不必重算 hover；变化时用最后指针位置对齐十字线索引
+    if (!unchanged && this.lastClientPos && !this._state.readonly.isDragging.peek()) {
       this.updatePlotHoverFromPoint(this.lastClientPos.x, this.lastClientPos.y)
     }
   }

--- a/packages/core/src/engine/controller/interaction.ts
+++ b/packages/core/src/engine/controller/interaction.ts
@@ -77,6 +77,11 @@ export class InteractionController {
   private touchStartY = 0
   private pinchTracker = new PinchTracker()
   private lastClientPos: { x: number; y: number } | null = null
+  /**
+   * 空闲 hover 是否有未推导的指针输入。
+   * pointermove 只置位；flushPendingHover 每帧最多推导一次并写 kernel。
+   */
+  private hoverFlushPending = false
   private markerState = new MarkerInteractionState()
   private lastHoverRenderKey = ''
   private useTooltipAnchorPositioning = false
@@ -331,6 +336,7 @@ export class InteractionController {
   /** 处理滚动事件 */
   onScroll(options: { scheduleDraw?: boolean } = {}) {
     this._state.actions.updateFramePositions(null, null, null)
+    this.hoverFlushPending = false
     this.clearHover()
     if (options.scheduleDraw !== false) {
       this.chart.scheduleDraw()
@@ -382,15 +388,14 @@ export class InteractionController {
         const dy = Math.abs(e.clientY - this.touchStartY)
         if (elapsed >= InteractionController.LONG_PRESS_MS && dx < 10 && dy < 10) {
           this._state.actions.setDragMode('explore')
-          this.updatePlotHoverFromPoint(e.clientX, e.clientY)
-          this.chart.scheduleDraw()
+          this.queueHoverFlush()
           return
         }
       }
 
       if (this._state.readonly.dragMode.peek() === 'explore') {
-        this.updatePlotHoverFromPoint(e.clientX, e.clientY)
-        this.chart.scheduleDraw()
+        // explore 跟手：仍走 pending，由本帧 flush 推导（与空闲 hover 同路径）
+        this.queueHoverFlush()
         return
       }
 
@@ -415,15 +420,33 @@ export class InteractionController {
       return
     }
 
-    const location = this.getPlotPointerLocation(e.clientX, e.clientY)
-    if (!location) return
-    this._state.actions.setSeparatorHover(this.hitTestPaneSeparator(location.mouseY))
+    // 空闲 hover：只记录指针，不写 crosshair/tooltip Signal
+    this.queueHoverFlush()
+  }
 
-    this.updatePlotHoverFromPoint(e.clientX, e.clientY)
+  /**
+   * 标记有待推导的 hover 输入，并申请 Overlay 帧。
+   * 真正的 updatePlotHoverFromPoint 在 flushPendingHover 中执行。
+   */
+  private queueHoverFlush(): void {
+    this.hoverFlushPending = true
+    this.chart.scheduleDraw(UpdateLevel.Overlay)
+  }
+
+  /**
+   * 将 pending 指针推导为 crosshair/hover/tooltip 并写入 kernel。
+   * ChartRenderer 在 seal 几何之后、paint 之前调用，保证与本帧几何同代。
+   * 无 pending 时为 no-op。
+   */
+  flushPendingHover(): void {
+    if (!this.hoverFlushPending) return
+    this.hoverFlushPending = false
+    if (!this.lastClientPos) return
+
+    this.updatePlotHoverFromPoint(this.lastClientPos.x, this.lastClientPos.y)
     const hoverRenderKey = this.getHoverRenderKey()
     if (hoverRenderKey !== this.lastHoverRenderKey) {
       this.lastHoverRenderKey = hoverRenderKey
-      this.chart.scheduleDraw(UpdateLevel.Overlay)
     }
   }
 
@@ -452,9 +475,10 @@ export class InteractionController {
 
     this._state.actions.updateFramePositions(positions, nextCenters, nextWidth)
 
-    // 几何未变则不必重算 hover；变化时用最后指针位置对齐十字线索引
+    // 几何变化时标记 hover 待刷新；由 flushPendingHover 与 paint 同帧完成
     if (!unchanged && this.lastClientPos && !this._state.readonly.isDragging.peek()) {
-      this.updatePlotHoverFromPoint(this.lastClientPos.x, this.lastClientPos.y)
+      this.hoverFlushPending = true
+      this.flushPendingHover()
     }
   }
 

--- a/packages/core/src/engine/drawing/DrawingState.ts
+++ b/packages/core/src/engine/drawing/DrawingState.ts
@@ -4,141 +4,168 @@ import type { DrawingObject, DrawingStyle } from '../../foundation/plugin/index'
 const PREVIEW_ID = '__preview__'
 
 /**
- * 交互会话层 CRUD。本地 drawings 数组是工作副本；
- * 持久业务 SSOT 是 kernel.drawing，经 DrawingChartAdapter.setDrawings 同步。
- * 选中 id 只经 adapter 读写 kernel，不持本地 selectedDrawingId。
- * 禁止直接写 DrawingStore。
+ * 交互会话层：只持预览与拖拽覆盖，不持完整图元列表。
+ * 已确认图元唯一 SSOT 是 kernel.drawing，经 adapter 读写。
  */
 export class DrawingState {
-  private drawings: DrawingObject[] = []
+  private preview: DrawingObject | null = null
+  private dragOverride: DrawingObject | null = null
 
   constructor(private adapter: DrawingChartAdapter) {}
 
   // ---- Read ----
 
-  /** 返回全部图元拷贝（含预览）；调用方不得当作 SSOT 长期持有 */
+  /** kernel 已确认图元（不含预览） */
+  private committed(): DrawingObject[] {
+    return this.adapter.getFullDrawings().filter((d) => d.id !== PREVIEW_ID)
+  }
+
+  /** 渲染用：拖拽覆盖 + 预览（顺序：override 先，preview 后） */
+  getPaintOverlay(): DrawingObject[] {
+    const out: DrawingObject[] = []
+    if (this.dragOverride) out.push(this.dragOverride)
+    if (this.preview) out.push(this.preview)
+    return out
+  }
+
+  /** 已确认 ⊕ 会话覆盖（UI / getDrawings） */
   getAll(): DrawingObject[] {
-    return this.drawings.slice()
+    return mergePaint(this.committed(), this.getPaintOverlay())
   }
 
-  /** 返回非预览图元（用于命中检测） */
+  /** 命中检测用：已确认 + 拖拽覆盖，不含预览 */
   getNonPreview(): DrawingObject[] {
-    return this.drawings.filter((d) => d.id !== PREVIEW_ID)
+    return mergePaint(this.committed(), this.dragOverride ? [this.dragOverride] : [])
   }
 
-  /** 按 ID 查找图元 */
   getById(id: string): DrawingObject | undefined {
-    return this.drawings.find((d) => d.id === id)
+    if (this.dragOverride?.id === id) return this.dragOverride
+    if (this.preview?.id === id) return this.preview
+    return this.committed().find((d) => d.id === id)
   }
 
-  /** 是否有预览图元 */
   hasPreview(): boolean {
-    return this.drawings.some((d) => d.id === PREVIEW_ID)
+    return this.preview !== null
   }
 
-  /** 返回当前选中图元（选中 id 读 kernel） */
   getSelected(): DrawingObject | null {
     const id = this.getSelectedId()
     if (!id) return null
-    return this.drawings.find((d) => d.id === id) ?? null
+    return this.getById(id) ?? null
   }
 
-  /** 返回当前选中图元的 ID（读 kernel） */
   getSelectedId(): string | null {
     return this.adapter.getSelectedDrawingId()
   }
 
-  // ---- Write ----
+  // ---- Session (no kernel write) ----
 
-  /**
-   * 工作副本必须可变：kernel deepFreezeSnapshot 会冻结数组与元素。
-   */
-  private adoptWorkCopy(drawings: ReadonlyArray<DrawingObject>): DrawingObject[] {
-    return drawings.map((d) => ({
-      ...d,
-      anchors: d.anchors.map((a) => ({ ...a })),
-      params: { ...d.params },
-      style: { ...d.style },
-    }))
+  setPreview(preview: DrawingObject): void {
+    this.preview = preview
+    this.adapter.requestDraw?.()
   }
 
-  private clearSelectionIfMissing(): void {
-    const selected = this.adapter.getSelectedDrawingId()
-    if (selected && !this.drawings.some((d) => d.id === selected)) {
-      this.adapter.setSelectedDrawingId(null)
-    }
+  removePreview(): void {
+    if (!this.preview) return
+    this.preview = null
+    this.adapter.requestDraw?.()
   }
 
-  /** 整体替换图元列表；选中 id 不在列表时清 kernel 选中 */
+  setDragOverride(drawing: DrawingObject): void {
+    this.dragOverride = drawing
+    this.adapter.requestDraw?.()
+  }
+
+  clearDragOverride(): void {
+    if (!this.dragOverride) return
+    this.dragOverride = null
+  }
+
+  /** pointerup：把拖拽结果写入 kernel，清会话覆盖 */
+  commitDrag(): void {
+    if (!this.dragOverride) return
+    const next = mergePaint(this.committed(), [this.dragOverride])
+    this.dragOverride = null
+    this.adapter.setDrawings(next)
+  }
+
+  // ---- Committed writes (kernel) ----
+
   setDrawings(drawings: DrawingObject[]): void {
-    this.drawings = this.adoptWorkCopy(drawings)
-    this.clearSelectionIfMissing()
-    this.adapter.setDrawings(this.drawings)
+    this.preview = null
+    this.dragOverride = null
+    const committed = drawings.filter((d) => d.id !== PREVIEW_ID)
+    this.clearSelectionIfMissing(committed)
+    this.adapter.setDrawings(committed)
   }
 
-  /** 替换图元列表，若选中项被移除则清除选中 */
   replaceDrawings(drawings: DrawingObject[]): void {
-    this.drawings = this.adoptWorkCopy(drawings)
-    this.clearSelectionIfMissing()
-    this.adapter.setDrawings(this.drawings)
+    this.setDrawings(drawings)
   }
 
-  /** 添加或更新单个图元（id 相同则替换） */
   addOrUpdate(drawing: DrawingObject): void {
-    const idx = this.drawings.findIndex((d) => d.id === drawing.id)
-    if (idx >= 0) {
-      const next = this.drawings.slice()
-      next[idx] = drawing
-      this.drawings = next
-    } else {
-      this.drawings = [...this.drawings, drawing]
+    if (drawing.id === PREVIEW_ID) {
+      this.setPreview(drawing)
+      return
     }
-    this.adapter.setDrawings(this.drawings)
+    const next = mergePaint(this.committed(), [drawing])
+    this.adapter.setDrawings(next)
   }
 
-  /** 删除图元；kernel setDrawings 会清无效选中 */
   removeDrawing(drawingId: string): void {
-    this.drawings = this.drawings.filter((d) => d.id !== drawingId)
-    this.clearSelectionIfMissing()
-    this.adapter.setDrawings(this.drawings)
+    if (this.dragOverride?.id === drawingId) this.dragOverride = null
+    if (this.preview?.id === drawingId) this.preview = null
+    const next = this.committed().filter((d) => d.id !== drawingId)
+    this.clearSelectionIfMissing(next)
+    this.adapter.setDrawings(next)
   }
 
-  /** 更新图元样式（合并到已有样式） */
   updateDrawingStyle(drawingId: string, style: Partial<DrawingStyle>): void {
-    this.drawings = this.drawings.map((d) =>
+    const next = this.committed().map((d) =>
       d.id === drawingId ? { ...d, style: { ...d.style, ...style } } : d,
     )
-    this.adapter.setDrawings(this.drawings)
+    if (this.dragOverride?.id === drawingId) {
+      this.dragOverride = { ...this.dragOverride, style: { ...this.dragOverride.style, ...style } }
+    }
+    this.adapter.setDrawings(next)
   }
 
-  /**
-   * 设置选中图元。只写 kernel，不持本地字段。
-   */
   setSelected(drawing: DrawingObject | null): void {
     const newId = drawing?.id ?? null
     if (this.adapter.getSelectedDrawingId() === newId) return
     this.adapter.setSelectedDrawingId(newId)
   }
 
-  /** 删除预览图元（__preview__） */
-  removePreview(): void {
-    if (!this.hasPreview()) return
-    this.drawings = this.drawings.filter((d) => d.id !== PREVIEW_ID)
-    this.adapter.setDrawings(this.drawings)
-  }
-
-  /** 设置预览图元（替换已有的 __preview__） */
-  setPreview(preview: DrawingObject): void {
-    this.drawings = [...this.drawings.filter((d) => d.id !== PREVIEW_ID), preview]
-    this.adapter.setDrawings(this.drawings)
-  }
-
-  /** 清空所有图元并清除选中 */
   clear(): void {
-    this.drawings = []
+    this.preview = null
+    this.dragOverride = null
     this.adapter.setDrawings([])
     this.adapter.setSelectedDrawingId(null)
   }
+
+  private clearSelectionIfMissing(list: DrawingObject[]): void {
+    const selected = this.adapter.getSelectedDrawingId()
+    if (selected && !list.some((d) => d.id === selected)) {
+      this.adapter.setSelectedDrawingId(null)
+    }
+  }
+}
+
+/** 以 id 合并；overlay 覆盖同 id；__preview__ 追加在末尾 */
+export function mergePaint(
+  committed: ReadonlyArray<DrawingObject>,
+  overlay: ReadonlyArray<DrawingObject>,
+): DrawingObject[] {
+  const byId = new Map<string, DrawingObject>()
+  for (const d of committed) {
+    if (d.id !== PREVIEW_ID) byId.set(d.id, d)
+  }
+  const previews: DrawingObject[] = []
+  for (const o of overlay) {
+    if (o.id === PREVIEW_ID) previews.push(o)
+    else byId.set(o.id, o)
+  }
+  return [...byId.values(), ...previews]
 }
 
 export { PREVIEW_ID }

--- a/packages/core/src/engine/drawing/__tests__/drawingState.workCopy.test.ts
+++ b/packages/core/src/engine/drawing/__tests__/drawingState.workCopy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { DrawingState } from '../DrawingState'
+import { DrawingState, mergePaint, PREVIEW_ID } from '../DrawingState'
 import type { DrawingChartAdapter } from '../../../controllers/types'
 import type { DrawingObject } from '../../../foundation/plugin/index'
 
@@ -15,17 +15,34 @@ function mk(id: string): DrawingObject {
   }
 }
 
-function mockAdapter(initialSelected: string | null = null): DrawingChartAdapter {
+function mockAdapter(
+  initial: DrawingObject[] = [],
+  initialSelected: string | null = null,
+): DrawingChartAdapter & {
+  kernelList: DrawingObject[]
+  setDrawings: ReturnType<typeof vi.fn>
+  requestDraw: ReturnType<typeof vi.fn>
+} {
   let selected: string | null = initialSelected
+  let kernelList = [...initial]
+  const setDrawings = vi.fn((list: DrawingObject[]) => {
+    kernelList = list.filter((d) => d.id !== PREVIEW_ID).map((d) => ({ ...d }))
+  })
+  const requestDraw = vi.fn()
   return {
-    setDrawings: vi.fn(),
-    getFullDrawings: vi.fn(() => []),
+    kernelList: kernelList as DrawingObject[],
+    get kernel() {
+      return kernelList
+    },
+    setDrawings,
+    getFullDrawings: vi.fn(() => kernelList),
     setSelectedDrawingId: vi.fn((id: string | null) => {
       selected = id
     }),
     getSelectedDrawingId: vi.fn(() => selected),
     setDrawingToolId: vi.fn(),
     getDrawingToolId: vi.fn(() => 'cursor'),
+    requestDraw,
     getViewport: vi.fn(() => null),
     getKWidthKGap: vi.fn(() => ({ kWidth: 6, kGap: 2 })),
     getCurrentDpr: vi.fn(() => 1),
@@ -35,75 +52,86 @@ function mockAdapter(initialSelected: string | null = null): DrawingChartAdapter
     priceToY: vi.fn(() => 0),
     yToPrice: vi.fn(() => 0),
     getPaneInfo: vi.fn(() => undefined),
-  }
+  } as any
 }
 
-describe('DrawingState work copy', () => {
-  it('addOrUpdate works after setDrawings from frozen kernel snapshot', () => {
-    const adapter = mockAdapter()
+describe('DrawingState session SSOT', () => {
+  it('addOrUpdate commits to adapter without local full list', () => {
+    const adapter = mockAdapter([mk('a')])
     const state = new DrawingState(adapter)
-    const frozen = Object.freeze([Object.freeze(mk('a'))]) as DrawingObject[]
-    state.setDrawings(frozen)
-    expect(() => state.addOrUpdate(mk('b'))).not.toThrow()
+    state.addOrUpdate(mk('b'))
+    expect(adapter.setDrawings).toHaveBeenCalled()
+    const last = adapter.setDrawings.mock.calls.at(-1)![0] as DrawingObject[]
+    expect(last.map((d) => d.id).sort()).toEqual(['a', 'b'])
     expect(state.getAll().map((d) => d.id).sort()).toEqual(['a', 'b'])
   })
 
-  it('setPreview works after setDrawings from frozen snapshot', () => {
-    const adapter = mockAdapter()
+  it('setPreview does not write kernel; only requestDraw', () => {
+    const adapter = mockAdapter([mk('a')])
     const state = new DrawingState(adapter)
-    state.setDrawings(Object.freeze([Object.freeze(mk('a'))]) as DrawingObject[])
-    expect(() =>
-      state.setPreview({
-        ...mk('__preview__'),
-        id: '__preview__',
-      }),
-    ).not.toThrow()
+    adapter.setDrawings.mockClear()
+    state.setPreview({ ...mk(PREVIEW_ID), id: PREVIEW_ID })
+    expect(adapter.setDrawings).not.toHaveBeenCalled()
+    expect(adapter.requestDraw).toHaveBeenCalled()
     expect(state.hasPreview()).toBe(true)
+    expect(state.getPaintOverlay().map((d) => d.id)).toEqual([PREVIEW_ID])
+    expect(state.getAll().map((d) => d.id)).toEqual(['a', PREVIEW_ID])
   })
 
-  it('getAll returns a copy so push on result does not mutate internal', () => {
+  it('setDrawings strips preview id before kernel write', () => {
     const adapter = mockAdapter()
     const state = new DrawingState(adapter)
-    state.setDrawings([mk('a')])
+    state.setDrawings([mk('a'), { ...mk(PREVIEW_ID), id: PREVIEW_ID }])
+    const last = adapter.setDrawings.mock.calls.at(-1)![0] as DrawingObject[]
+    expect(last.map((d) => d.id)).toEqual(['a'])
+  })
+
+  it('getAll returns merge of kernel + overlay without mutating kernel', () => {
+    const adapter = mockAdapter([mk('a')])
+    const state = new DrawingState(adapter)
+    state.setPreview({ ...mk(PREVIEW_ID), id: PREVIEW_ID })
     const all = state.getAll()
     all.push(mk('hack'))
-    expect(state.getAll()).toHaveLength(1)
+    expect(adapter.getFullDrawings()).toHaveLength(1)
   })
 
   it('setSelected only writes adapter; getSelectedId reads adapter', () => {
-    const adapter = mockAdapter()
+    const adapter = mockAdapter([mk('a')])
     const state = new DrawingState(adapter)
-    state.setDrawings([mk('a')])
     state.setSelected(mk('a'))
     expect(adapter.setSelectedDrawingId).toHaveBeenCalledWith('a')
     expect(state.getSelectedId()).toBe('a')
   })
 
   it('removeDrawing drops id and clears selection via adapter', () => {
-    const adapter = mockAdapter('a')
+    const adapter = mockAdapter([mk('a'), mk('b')], 'a')
     const state = new DrawingState(adapter)
-    state.setDrawings([mk('a'), mk('b')])
     state.removeDrawing('a')
-    expect(state.getAll().map((d) => d.id)).toEqual(['b'])
     expect(adapter.setSelectedDrawingId).toHaveBeenCalledWith(null)
-    expect(adapter.setDrawings).toHaveBeenCalled()
+    const last = adapter.setDrawings.mock.calls.at(-1)![0] as DrawingObject[]
+    expect(last.map((d) => d.id)).toEqual(['b'])
   })
-  it('nested fields from frozen snapshot are mutable after adopt', () => {
-    const adapter = mockAdapter()
+
+  it('setDragOverride does not write kernel; commitDrag writes once', () => {
+    const adapter = mockAdapter([mk('a')])
     const state = new DrawingState(adapter)
-    const frozen = Object.freeze([
-      Object.freeze({
-        ...mk('a'),
-        anchors: Object.freeze([Object.freeze({ id: 'p1', index: 0, price: 1 })]),
-        style: Object.freeze({ stroke: '#f00' }),
-      }),
-    ]) as DrawingObject[]
-    state.setDrawings(frozen)
-    const d = state.getById('a')!
-    expect(() => {
-      d.anchors[0]!.price = 99
-      d.style.stroke = '#0f0'
-    }).not.toThrow()
-    expect(d.anchors[0]!.price).toBe(99)
+    adapter.setDrawings.mockClear()
+    const moved = { ...mk('a'), anchors: [{ id: 'p', index: 1, time: 1, price: 99 }] }
+    state.setDragOverride(moved)
+    expect(adapter.setDrawings).not.toHaveBeenCalled()
+    expect(adapter.requestDraw).toHaveBeenCalled()
+    state.commitDrag()
+    expect(adapter.setDrawings).toHaveBeenCalledTimes(1)
+    const last = adapter.setDrawings.mock.calls.at(-1)![0] as DrawingObject[]
+    expect(last[0]!.anchors[0]!.price).toBe(99)
+    expect(state.getPaintOverlay()).toEqual([])
+  })
+
+  it('mergePaint replaces by id and appends preview', () => {
+    const a = mk('a')
+    const a2 = { ...mk('a'), style: { stroke: '#f00' } }
+    const p = { ...mk(PREVIEW_ID), id: PREVIEW_ID }
+    expect(mergePaint([a], [a2, p]).map((d) => d.id)).toEqual(['a', PREVIEW_ID])
+    expect(mergePaint([a], [a2, p])[0]!.style.stroke).toBe('#f00')
   })
 })

--- a/packages/core/src/engine/drawing/__tests__/drawingStore.projection.test.ts
+++ b/packages/core/src/engine/drawing/__tests__/drawingStore.projection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { DrawingObject } from '../../../foundation/plugin/index'
 import { createDrawingState } from '../../state/drawingState'
 import { DrawingStore } from '../index'
+import { PREVIEW_ID } from '../DrawingState'
 
 function mk(id: string, paneId = 'main'): DrawingObject {
   return {
@@ -34,5 +35,26 @@ describe('DrawingStore projection', () => {
     state.actions.setDrawings([mk('c')])
     expect(store.getAll().map((d) => d.id)).toEqual(['c'])
     expect(store.getSelectedId()).toBeNull()
+  })
+
+  it('merges session overlay for paint without changing kernel signal', () => {
+    const state = createDrawingState()
+    state.actions.setDrawings([mk('a')])
+    let overlay: DrawingObject[] = []
+
+    const store = new DrawingStore({
+      drawings$: state.readonly.drawings,
+      selectedDrawingId$: state.readonly.selectedDrawingId,
+      getOverlay: () => overlay,
+    })
+
+    overlay = [{ ...mk(PREVIEW_ID), id: PREVIEW_ID }]
+    expect(store.getAll().map((d) => d.id)).toEqual(['a', PREVIEW_ID])
+    expect(state.readonly.drawings.peek().map((d) => d.id)).toEqual(['a'])
+
+    const moved = { ...mk('a'), style: { stroke: '#0f0' } }
+    overlay = [moved]
+    expect(store.getAll()).toHaveLength(1)
+    expect(store.getAll()[0]!.style.stroke).toBe('#0f0')
   })
 })

--- a/packages/core/src/engine/drawing/index.ts
+++ b/packages/core/src/engine/drawing/index.ts
@@ -26,14 +26,17 @@ export type {
 }
 
 import type { ReadonlySignal } from '../../foundation/reactivity/signal'
+import { mergePaint } from './DrawingState'
 
 export interface DrawingStoreDeps {
   drawings$: ReadonlySignal<ReadonlyArray<DrawingObject>>
   selectedDrawingId$: ReadonlySignal<string | null>
+  /** 会话层覆盖（拖拽/预览）；缺省为空 */
+  getOverlay?: () => ReadonlyArray<DrawingObject>
 }
 
 /**
- * 绘图投影器 —— 业务态在 kernel.drawing；此类只读 signal 供渲染插件使用。
+ * 绘图投影器 —— kernel 业务 SSOT ⊕ 会话 overlay，供渲染插件读取。
  */
 export class DrawingStore {
   constructor(private readonly deps: DrawingStoreDeps) {}
@@ -42,13 +45,18 @@ export class DrawingStore {
     return this.deps.selectedDrawingId$.peek()
   }
 
+  private paintList(): DrawingObject[] {
+    const committed = this.deps.drawings$.peek()
+    const overlay = this.deps.getOverlay?.() ?? []
+    return mergePaint(committed, overlay)
+  }
+
   getAll(): DrawingObject[] {
-    return [...this.deps.drawings$.peek()]
+    return this.paintList()
   }
 
   getVisibleByPane(paneId: string): DrawingObject[] {
-    return this.deps.drawings$
-      .peek()
+    return this.paintList()
       .filter((drawing) => drawing.visible && drawing.paneId === paneId)
       .slice()
       .sort((a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0))

--- a/packages/core/src/engine/drawing/interaction.ts
+++ b/packages/core/src/engine/drawing/interaction.ts
@@ -1,5 +1,5 @@
 import type { DrawingChartAdapter } from '../../controllers/types'
-import type { DrawingObject, DrawingKind, DrawingStyle } from '../../foundation/plugin/index'
+import type { DrawingObject, DrawingStyle } from '../../foundation/plugin/index'
 
 import { AnchorCollector } from './AnchorCollector'
 import { DragHandler } from './DragHandler'
@@ -22,16 +22,9 @@ export interface DrawingInteractionCallbacks {
 }
 
 /**
- * 绘图交互控制器 v2 — 精简事件路由，组合子模块。
+ * 绘图交互控制器 —— 精简事件路由，组合子模块。
  *
- * ┌─────────────────────────────────────┐
- * │ DrawingInteractionController        │
- * │  ├─ DrawingState     (图元 CRUD)   │
- * │  ├─ AnchorCollector  (锚点累积)    │
- * │  ├─ PreviewRenderer  (预览构建)    │
- * │  ├─ HitTester        (命中检测)    │
- * │  └─ DragHandler      (拖拽管理)    │
- * └─────────────────────────────────────┘
+ * 已确认图元只写 kernel；预览与拖拽覆盖只在 DrawingState 会话层。
  */
 export class DrawingInteractionController {
   private adapter: DrawingChartAdapter
@@ -52,16 +45,19 @@ export class DrawingInteractionController {
     this.dragHandler = new DragHandler()
   }
 
+  /** 渲染合成用：拖拽覆盖 + 预览 */
+  getPaintOverlay(): DrawingObject[] {
+    return this.drawingState.getPaintOverlay()
+  }
+
   // ============ 配置 ============
 
-  /** 注册回调（创建/选中/工具切换事件通知） */
   setCallbacks(callbacks: DrawingInteractionCallbacks) {
     this.callbacks = callbacks
   }
 
   // ============ 工具状态 ============
 
-  /** 返回当前激活的绘图工具 ID（读 kernel SSOT） */
   getActiveTool(): DrawingToolId {
     return this.adapter.getDrawingToolId()
   }
@@ -72,51 +68,48 @@ export class DrawingInteractionController {
   applyToolSession(toolId: DrawingToolId): void {
     this.anchorCollector.reset()
     this.drawingState.removePreview()
-    this.dragHandler.endDrag()
+    if (this.dragHandler.isDragging()) {
+      this.drawingState.clearDragOverride()
+      this.dragHandler.endDrag()
+    }
     this.setSelected(null)
     this.callbacks.onToolChange?.(toolId)
   }
 
-  /**
-   * 切换绘图工具 —— 经 adapter 写 kernel（Chart 单写路径）。
-   */
   setTool(toolId: DrawingToolId) {
     this.adapter.setDrawingToolId(toolId)
   }
 
-  // ============ 图元 CRUD（委托 DrawingState） ============
+  // ============ 图元 CRUD ============
 
-  /** 返回所有图元（含预览） */
   getDrawings(): DrawingObject[] {
     return this.drawingState.getAll()
   }
 
-  /** 整体替换图元列表 */
   setDrawings(drawings: DrawingObject[]) {
     this.drawingState.setDrawings(drawings)
   }
 
-  /** 清空锚点累积、预览、拖拽状态及所有图元 */
   clear() {
     this.anchorCollector.reset()
     this.drawingState.removePreview()
-    this.dragHandler.endDrag()
+    if (this.dragHandler.isDragging()) {
+      this.drawingState.clearDragOverride()
+      this.dragHandler.endDrag()
+    }
     this.drawingState.clear()
   }
 
-  /** 更新指定图元的样式（合并） */
   updateDrawingStyle(drawingId: string, style: Partial<DrawingStyle>): void {
     this.drawingState.updateDrawingStyle(drawingId, style)
   }
 
-  /** 删除指定图元 */
   removeDrawing(drawingId: string): void {
     this.drawingState.removeDrawing(drawingId)
   }
 
   // ============ 选中状态 ============
 
-  /** 返回当前选中的图元 */
   getSelectedDrawing(): DrawingObject | null {
     return this.drawingState.getSelected()
   }
@@ -124,25 +117,23 @@ export class DrawingInteractionController {
   // ============ 事件处理 ============
 
   /**
-   * 指针移动事件入口。
-   * 拖拽中 → 委托 DragHandler 更新锚点；绘图模式 → 构建预览图元。
+   * 指针移动：拖拽只写会话覆盖；绘图模式只写预览。均不写 kernel。
    * @returns true 表示事件已消费，需要重绘
    */
   onPointerMove(e: PointerEvent, container: HTMLElement): boolean {
-    // 1) 正在拖拽
     if (this.dragHandler.isDragging()) {
       const drawing = this.drawingState.getById(this.dragHandler.getDraggingDrawingId() ?? '')
       if (!drawing) {
+        this.drawingState.clearDragOverride()
         this.dragHandler.endDrag()
         return false
       }
       const updated = this.dragHandler.handleDragMove(drawing, e, container, this.adapter)
       if (!updated) return false
-      this.drawingState.addOrUpdate(updated)
+      this.drawingState.setDragOverride(updated)
       return true
     }
 
-    // 2) 绘图工具预览
     const activeTool = this.getActiveTool()
     if (activeTool !== 'cursor') {
       const anchor = resolveAnchorFromPointer(e, container, this.adapter)
@@ -169,30 +160,25 @@ export class DrawingInteractionController {
   }
 
   /**
-   * 指针按下事件入口。
-   * 光标模式 → 命中检测 + 选中 + 拖拽开始；绘图模式 → 创建或累积锚点。
+   * 指针按下：光标模式命中+选中+开拖；绘图模式创建或累积锚点。
    * @returns true 表示事件已消费
    */
   onPointerDown(e: PointerEvent, container: HTMLElement): boolean {
     const activeTool = this.getActiveTool()
-    // 光标模式：命中检测 → 选中 → 开始拖拽
     if (activeTool === 'cursor') {
       return this.handleCursorDown(e, container)
     }
 
-    // 绘图模式
     const anchor = resolveAnchorFromPointer(e, container, this.adapter)
     if (!anchor) return false
 
     const anchorCount = getAnchorCountForTool(activeTool)
 
-    // 单锚点工具：点击即创建
     if (anchorCount === 1) {
       this.createSingleAnchorDrawing(anchor, activeTool)
       return true
     }
 
-    // 多锚点工具：累积
     if (anchorCount === 2 || anchorCount === 3) {
       const result = this.anchorCollector.addAnchor(anchor, activeTool)
       if (result) {
@@ -205,18 +191,18 @@ export class DrawingInteractionController {
   }
 
   /**
-   * 指针抬起事件入口。结束拖拽。
+   * 指针抬起：拖拽结果一次 commit 到 kernel。
    * @returns true 表示事件已消费
    */
   onPointerUp(_e: PointerEvent, _container: HTMLElement): boolean {
     if (!this.dragHandler.isDragging()) return false
+    this.drawingState.commitDrag()
     this.dragHandler.endDrag()
     return true
   }
 
   // ============ 私有方法 ============
 
-  /** 光标模式下指针按下：命中检测 → 选中 → 开始拖拽 */
   private handleCursorDown(e: PointerEvent, container: HTMLElement): boolean {
     const rect = container.getBoundingClientRect()
     const mouseX = e.clientX - rect.left
@@ -244,13 +230,11 @@ export class DrawingInteractionController {
     return true
   }
 
-  /** 设置选中图元并通知回调 */
   private setSelected(drawing: DrawingObject | null) {
     this.drawingState.setSelected(drawing)
     this.callbacks.onDrawingSelected?.(drawing)
   }
 
-  /** 单锚点工具：点击即创建图元，完成后切回光标模式 */
   private createSingleAnchorDrawing(anchor: DrawingAnchorInput, activeTool: DrawingToolId) {
     this.drawingState.removePreview()
 
@@ -280,7 +264,6 @@ export class DrawingInteractionController {
     this.adapter.setDrawingToolId('cursor')
   }
 
-  /** 多锚点工具（2-3 锚点）：锚点累积满后创建图元，完成后切回光标模式 */
   private createMultiAnchorDrawing(anchors: DrawingAnchorInput[], activeTool: DrawingToolId) {
     this.drawingState.removePreview()
 
@@ -327,3 +310,5 @@ export class DrawingInteractionController {
     this.adapter.setDrawingToolId('cursor')
   }
 }
+
+export { PREVIEW_ID }

--- a/packages/core/src/engine/indicators/chartIndicatorManager.ts
+++ b/packages/core/src/engine/indicators/chartIndicatorManager.ts
@@ -13,7 +13,6 @@ import {
 } from '../../foundation/reactivity/signal'
 import type { MainIndicatorEntry } from '../state/indicatorState'
 import type { SubPaneSpec } from '../state/subPaneState'
-import { createLayerFromPlugin } from '../../rendering/scene/createLayerFromPlugin'
 import type { Layer } from '../../rendering/scene/types'
 import type { KLineData } from '../../foundation/types/price'
 import type { IndicatorInstance, SubPaneInfo, PaneSpec, ChartOptions } from '../chartTypes'
@@ -371,29 +370,21 @@ export class ChartIndicatorManager {
 
     if (!existingLayer) {
       const plugin = definition.rendererFactory({ paneId: 'main', indicatorId })
-      // register with old system for getRenderer compatibility
+      // useRenderer：注册表 + 唯一 Scene Layer
       this.deps.useRenderer(plugin)
-      // disable old rendering to avoid double rendering (scene handles it)
-      this.deps.setRendererEnabled(rendererName, false)
-      // create bridge layer and add to scene
-      const layer = createLayerFromPlugin(plugin, () => this.deps.getRenderContext('main'), 'main')
-      this.deps.addLayer(layer)
     }
 
     this.deps.setLayerVisibility(layerId, true)
 
-    if (!this.deps.getRenderer('mainIndicatorLegend')) {
+    // core 可能已挂 legend Layer 且未进 Manager；两者任一存在都不再注册第二实例
+    if (
+      !this.deps.getLayer('plugin:mainIndicatorLegend') &&
+      !this.deps.getRenderer('mainIndicatorLegend')
+    ) {
       const legend = createMainIndicatorLegendRendererPlugin({
         yPaddingPx: this.deps.getOption().yPaddingPx,
       })
       this.deps.useRenderer(legend)
-      this.deps.setRendererEnabled('mainIndicatorLegend', false)
-      const legendLayer = createLayerFromPlugin(
-        legend,
-        () => this.deps.getRenderContext('main'),
-        'main',
-      )
-      this.deps.addLayer(legendLayer)
     }
   }
 
@@ -402,7 +393,6 @@ export class ChartIndicatorManager {
       this.indicatorScheduler.getIndicatorMetadata(indicatorId)?.mainPane?.rendererName
     if (rendererName) {
       this.deps.setRendererEnabled(rendererName, false)
-      this.deps.setLayerVisibility(`plugin:${rendererName}`, false)
     }
   }
 

--- a/packages/core/src/engine/layout/chartPaneLayout.ts
+++ b/packages/core/src/engine/layout/chartPaneLayout.ts
@@ -1,7 +1,6 @@
 import type { PaneRole } from '../../foundation/plugin/index'
 import type { ChartDom, PaneSpec, Viewport } from '../chartTypes'
 import { PaneRenderer } from '../paneRenderer'
-import type { SharedWebGLSurface } from '../renderers/webgl/sharedWebGLSurface'
 import type { ScaleType } from '../utils/tickPosition'
 
 import { Pane, UpdateLevel } from './pane'
@@ -18,7 +17,6 @@ export interface PaneLayoutDependencies {
     defaultPaneMinHeightPx?: number
   }
   getViewport: () => Viewport | null
-  getSharedWebGLSurface: () => SharedWebGLSurface
   setKnownPaneIds: (ids: string[]) => void
   notifyPaneResize: (paneId: string, pane: Pane) => void
   scheduleDraw: (level?: UpdateLevel) => void
@@ -160,7 +158,6 @@ export class ChartPaneLayout {
           yPaddingPx: this.deps.getOption().yPaddingPx,
           priceLabelWidth: this.deps.getOption().priceLabelWidth,
         },
-        this.deps.getSharedWebGLSurface(),
       )
 
       return renderer
@@ -330,13 +327,6 @@ export class ChartPaneLayout {
       pane.setPadding(opt.yPaddingPx, opt.yPaddingPx)
 
       renderer.resize(vp.plotWidth, h, vp.dpr)
-      renderer.setWebGLRegion({
-        x: 0,
-        y,
-        width: vp.plotWidth,
-        height: h,
-        dpr: vp.dpr,
-      })
       this.deps.notifyPaneResize(pane.id, pane)
       const domEls = renderer.getDom()
       domEls.mainCanvas.style.top = `${y}px`

--- a/packages/core/src/engine/layout/chartPaneLayout.ts
+++ b/packages/core/src/engine/layout/chartPaneLayout.ts
@@ -138,6 +138,7 @@ export class ChartPaneLayout {
       mainCanvas.style.position = 'absolute'
       mainCanvas.style.left = '0'
       mainCanvas.style.top = '0'
+      mainCanvas.style.zIndex = '0'
 
       overlayCanvas.id = `${spec.id}-overlay`
       overlayCanvas.className = 'overlay-canvas'
@@ -146,6 +147,7 @@ export class ChartPaneLayout {
       overlayCanvas.style.top = '0'
       overlayCanvas.style.pointerEvents = 'none'
       overlayCanvas.style.backgroundColor = 'transparent'
+      overlayCanvas.style.zIndex = '2'
 
       const leftYAxisCanvas = this.createAxisCanvas(spec, pane, 'left')
 
@@ -168,7 +170,10 @@ export class ChartPaneLayout {
     const rightAxisLayer = dom.rightAxisLayer
     const leftAxisLayer = dom.leftAxisLayer
     if (canvasLayer) {
-      const existingCanvases = canvasLayer.querySelectorAll('canvas:not(.x-axis-canvas)')
+      // 保留 chart 级 WebGPU scene canvas（M2 hybrid DOM）
+      const existingCanvases = canvasLayer.querySelectorAll(
+        'canvas:not(.x-axis-canvas):not(.gpu-scene-canvas)',
+      )
       existingCanvases.forEach((canvas) => canvas.remove())
     }
     if (rightAxisLayer) {

--- a/packages/core/src/engine/layout/pane.ts
+++ b/packages/core/src/engine/layout/pane.ts
@@ -1,6 +1,5 @@
 import type { PaneCapabilities, PaneRole } from '../../foundation/plugin/index'
 import type { KLineData } from '../../foundation/types/price'
-import type { MarkerManager } from '../marker/registry'
 import type { PriceRange } from '../scale/price'
 import { PriceScale } from '../scale/priceScale'
 import { getVisiblePriceRange } from '../viewport/viewport'
@@ -50,38 +49,6 @@ function defaultCapabilitiesByRole(role: PaneRole): PaneCapabilities {
 }
 
 /**
- * Pane 级渲染器接口：在单个 pane 的坐标系中绘制内容
- */
-export interface PaneRenderer {
-  /**
-   * 在指定 pane 坐标系中绘制内容
-   * @param ctx Canvas 绘图上下文，Chart 已执行 translate(0, pane.top)，y=0 对应 pane 顶部
-   * @param pane 当前 pane 实例
-   * @param data 全量 K 线数据
-   * @param range 当前视口可见的索引范围
-   * @param scrollLeft 滚动偏移量，renderer 内部如需 world 坐标需执行 ctx.translate(-scrollLeft, 0)
-   * @param kWidth K 线宽度
-   * @param kGap K 线间隔
-   * @param dpr 设备像素比
-   * @param paneWidth pane 宽度
-   * @param kLinePositions 可选，K 线起始 x 坐标数组（由 Chart 统一计算）
-   */
-  draw(args: {
-    ctx: CanvasRenderingContext2D
-    pane: Pane
-    data: KLineData[]
-    range: VisibleRange
-    scrollLeft: number
-    kWidth: number
-    kGap: number
-    dpr: number
-    paneWidth: number
-    kLinePositions: number[]
-    markerManager?: MarkerManager
-  }): void
-}
-
-/**
  * Pane：代表一个"窗口区域"（主图 / 副图）
  */
 export class Pane {
@@ -96,9 +63,6 @@ export class Pane {
 
   /** pane 独立 Y 轴 */
   readonly yAxis = new PriceScale()
-
-  /** 该 pane 的渲染器列表 */
-  readonly renderers: PaneRenderer[] = []
 
   /**
    * 创建 pane 实例
@@ -131,14 +95,6 @@ export class Pane {
    */
   setPadding(top: number, bottom: number) {
     this.yAxis.setPadding(top, bottom)
-  }
-
-  /**
-   * 注册一个 pane 级渲染器
-   * @param renderer pane 级渲染器实例
-   */
-  addRenderer(renderer: PaneRenderer) {
-    this.renderers.push(renderer)
   }
 
   /**

--- a/packages/core/src/engine/paneRenderer.ts
+++ b/packages/core/src/engine/paneRenderer.ts
@@ -1,6 +1,4 @@
 import type { PaneRendererDom } from './chartTypes'
-import { CandleWebGLSurface, LineWebGLSurface } from './renderers/webgl/candleSurface'
-import type { SharedWebGLSurface, WebGLRegion } from './renderers/webgl/sharedWebGLSurface'
 
 export type { PaneRendererDom }
 
@@ -18,38 +16,23 @@ export type PaneRendererOptions = {
   priceLabelWidth?: number
 }
 
-export type PaneRendererWebGLHandles = {
-  candleSurface: CandleWebGLSurface | null
-  lineSurface: LineWebGLSurface | null
-}
-
 /* PaneRenderer：负责单个 Pane 的 Canvas 管理与运行时状态持有
    创建并管理 mainCanvas / overlayCanvas / yAxisCanvas
    持有 Pane 实例（布局、Y 轴、价格范围）
    响应 Chart 的 resize / layout 信号
-   渲染逻辑由 RendererPluginManager 统一调度 */
+   GPU 绘制经 ChartRenderer.sceneRenderer（SharedWebGLSurface），本类不再持有 per-pane surface */
 export class PaneRenderer {
   private dom: PaneRendererDom
   private pane: import('./layout/pane').Pane
   private opt: PaneRendererOptions
   private contexts: PaneRendererContexts | null = null
-  private webgl: PaneRendererWebGLHandles
 
-  constructor(
-    dom: PaneRendererDom,
-    pane: import('./layout/pane').Pane,
-    opt: PaneRendererOptions,
-    sharedWebGLSurface: SharedWebGLSurface,
-  ) {
+  constructor(dom: PaneRendererDom, pane: import('./layout/pane').Pane, opt: PaneRendererOptions) {
     this.dom = dom
     this.pane = pane
     this.opt = {
       ...opt,
       priceLabelWidth: opt.priceLabelWidth || 60,
-    }
-    this.webgl = {
-      candleSurface: new CandleWebGLSurface(sharedWebGLSurface),
-      lineSurface: new LineWebGLSurface(sharedWebGLSurface),
     }
   }
 
@@ -97,15 +80,6 @@ export class PaneRenderer {
     }
   }
 
-  getWebGL(): PaneRendererWebGLHandles {
-    return this.webgl
-  }
-
-  setWebGLRegion(region: WebGLRegion): void {
-    this.webgl.candleSurface?.setRegion(region)
-    this.webgl.lineSurface?.setRegion(region)
-  }
-
   /**
    * 调整 Canvas 尺寸
    * @param width pane 宽度（逻辑像素）
@@ -147,15 +121,10 @@ export class PaneRenderer {
         dpr,
       )
     }
-
-    this.webgl.candleSurface?.resize(width, height, dpr)
-    this.webgl.lineSurface?.resize(width, height, dpr)
   }
 
   /** 销毁 PaneRenderer 实例 */
   destroy() {
     this.contexts = null
-    this.webgl.candleSurface?.destroy()
-    this.webgl.lineSurface?.destroy()
   }
 }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -670,6 +670,17 @@ export class ChartRenderer {
       const xH = xCtx.canvas.height
       xCtx.clearRect(0, 0, xW, xH)
     }
+    // M2 hybrid：可见 WebGPU canvas 不经 2D clearRect，需显式 transparent clear
+    const scene = this.deps.getSceneRenderer()
+    if (scene.caps.name === 'webgpu') {
+      scene.surface.clearRegion({
+        x: 0,
+        y: 0,
+        width: vp.plotWidth,
+        height: vp.plotHeight,
+        dpr: vp.dpr,
+      })
+    }
   }
 
   private renderPanes(

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -61,18 +61,27 @@ type ResolvedChartOptions = Omit<ChartOptions, 'kWidth' | 'kGap'> & {
   kGap: number
 }
 
+/** 一帧的绘制数据 */
 type FrameContext = {
+  /** 视口（scrollLeft、plotWidth、dpr 等） */
   vp: Viewport
+  /** 可见 K 线起止索引 */
   range: VisibleRange
+  /** 每根 K 线在大图上的 x 坐标 */
   kLinePositions: KLinePositions
+  /** 每根 K 线中心的 x 坐标（由物理像素回算逻辑值） */
   kLineCenters: number[]
+  /** 每根 K 线实体的 x 和宽度 */
   kBarRects: Array<{ x: number; width: number }>
+  /** K 线柱物理像素宽度 */
   kWidthPx: number
+  /** Overlay 帧复用上一帧的几何缓存 */
   useCachedFrame: boolean
+  /** 原始 K 线数据 */
   data: KLineData[]
-  mainIndicatorRange: { min: number; max: number } | null
-  hasCrosshair: boolean
+  /** 当前缩放级别索引 */
   zoomLevel: number
+  /** 缩放级别总数 */
   zoomLevelCount: number
 }
 
@@ -98,9 +107,12 @@ export interface RendererDependencies {
 }
 
 export class ChartRenderer {
+  /** 依赖注入容器，ChartRenderer 不直接持有状态，从 deps 接口读取，也便于测试 mock */
   private deps: RendererDependencies
 
+  /** requestAnimationFrame id，不为 null 时触发 RAF 节流，取消被分配帧，确保展示最新帧 */
   private raf: number | null = null
+  // 下一帧重绘级别
   private pendingUpdateLevel: UpdateLevel = UpdateLevel.All
 
   readonly markerManager: MarkerManager
@@ -293,13 +305,25 @@ export class ChartRenderer {
     return this.deps.settings$.peek()
   }
 
+  /**
+   * 申请绘制，把绘制元数据配置合并到下一帧 requestAnimationFrame，避免同帧多次重绘。
+   *
+   * 已有 rAF 在等时只更新 pendingUpdateLevel，不重复注册。如果
+   * pending 和 level 分别是 Main 和 Overlay，合并成 All。
+   *
+   * @param level - Main 只画主层，Overlay 只画覆盖层（crosshair 等），All 全画
+   */
   scheduleDraw(level: UpdateLevel = UpdateLevel.All): void {
+    // 已经有下一帧 raf 被申请，只改下一个申请帧的重绘级别
     if (this.raf !== null) {
+      // pending 已是最全，新请求不论什么级别都不影响
       if (this.pendingUpdateLevel === UpdateLevel.All) return
+      // 新请求要全画，升 pending
       if (level === UpdateLevel.All) {
         this.pendingUpdateLevel = UpdateLevel.All
         return
       }
+      // Main 和 Overlay 各来一次后合并成全画
       if (
         (this.pendingUpdateLevel === UpdateLevel.Main && level === UpdateLevel.Overlay) ||
         (this.pendingUpdateLevel === UpdateLevel.Overlay && level === UpdateLevel.Main)
@@ -307,27 +331,38 @@ export class ChartRenderer {
         this.pendingUpdateLevel = UpdateLevel.All
         return
       }
+      // 同级别重复请求，pending 不变
       return
     }
 
     this.pendingUpdateLevel = level
     this.raf = requestAnimationFrame(() => {
+      // 取出本次要画的级别，pending 改回 All 表示「没有挂起的请求了」
       const levelToDraw = this.pendingUpdateLevel
       this.pendingUpdateLevel = UpdateLevel.All
 
+      // 准备帧绘制数据
       const frame = this.prepareFrameData(levelToDraw)
       if (frame) {
+        // 把 K 线位置写入 interaction state，供十字线等模块读取
         this.writeFramePositionsFromFrame(frame)
       }
+      // 清屏、组 context、遍历 pane 调 Scene.paintPane、画时间轴
       this.drawWithFrame(levelToDraw, frame)
 
       this.raf = null
+      // 如果刚才画的过程中又有 scheduleDraw 写过 pending，补一帧
       if (this.pendingUpdateLevel !== UpdateLevel.All) {
         this.scheduleDraw(this.pendingUpdateLevel)
       }
     })
   }
 
+  /**
+   * 同步绘制一帧，不经 rAF 合并。测试与必须立刻出图的路径使用。
+   *
+   * @param level - 同 scheduleDraw
+   */
   draw(level: UpdateLevel = UpdateLevel.All): void {
     this.drawWithFrame(level, this.prepareFrameData(level))
   }
@@ -390,12 +425,28 @@ export class ChartRenderer {
     )
   }
 
+  /**
+   * 把 K 线位置写入 interaction state。
+   * setKLinePositions 会更新多个 signal（位置、区间、宽度、中心点），
+   * batch 确保这组写入完成后才通知订阅者，不会让十字线等读到一半的新数据。
+   */
   private writeFramePositionsFromFrame(frame: FrameContext): void {
     batch(() => {
       this.deps.getInteraction().setKLinePositions(frame.kLinePositions, frame.range, frame.kWidthPx, frame.kLineCenters)
     })
   }
 
+  /**
+   * 准备一帧的绘制数据：viewport、可见区间、K 线位置。
+   *
+   * Overlay 且上次画完没清缓存时，直接复用 cachedDrawFrame，不重复
+   * 算 viewport 和 bar 位置。非缓存路径会刷新 cachedDrawFrame。
+   * range 变了会调用 checkVisibleRangeGapWhenIdle，方便空闲时补数据。
+   * TimeShare 模式按 plotWidth 平分 bar，不走 K 线物理宽度那套。
+   *
+   * @param level - Overlay 可走缓存，Main/All 强制重算
+   * @returns 无 viewport 或无数据时返回 null，调用方自己清屏或跳过
+   */
   private prepareFrameData(level: UpdateLevel): FrameContext | null {
     const useCachedFrame = level === UpdateLevel.Overlay && this.cachedDrawFrame !== null
 
@@ -514,8 +565,6 @@ export class ChartRenderer {
       kWidthPx,
       useCachedFrame,
       data: internalData,
-      mainIndicatorRange: null,
-      hasCrosshair: false,
       zoomLevel: this.deps.getCurrentZoomLevel(),
       zoomLevelCount: this.deps.getZoomLevelCount(),
     }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -594,7 +594,6 @@ export class ChartRenderer {
     for (const renderer of this.deps.getPaneRenderers()) {
       const pane = renderer.getPane()
       const { mainCtx, overlayCtx, yAxisCtx, leftAxisCtx } = renderer.getContexts()
-      const { candleSurface, lineSurface } = renderer.getWebGL()
 
       if (!useCachedFrame) {
         const indicatorRange =
@@ -617,8 +616,6 @@ export class ChartRenderer {
         mainCtx.setTransform(1, 0, 0, 1, 0, 0)
         mainCtx.scale(vp.dpr, vp.dpr)
         mainCtx.clearRect(0, 0, vp.plotWidth + 1, pane.height + 2 / vp.dpr)
-        candleSurface?.clear()
-        lineSurface?.clear()
       }
 
       if (shouldUpdateOverlay && overlayCtx) {
@@ -660,8 +657,6 @@ export class ChartRenderer {
         crosshairIndex: this.deps.getInteraction().getCrosshairIndex(),
         yAxisCtx: yAxisCtx ?? undefined,
         leftAxisCtx: leftAxisCtx ?? undefined,
-        candleWebGLSurface: candleSurface ?? undefined,
-        lineWebGLSurface: lineSurface ?? undefined,
         zoomLevel: this.deps.getCurrentZoomLevel(),
         zoomLevelCount: this.deps.getZoomLevelCount(),
         viewport: {
@@ -704,7 +699,6 @@ export class ChartRenderer {
       const region = { x: 0, y: pane.top, width: vp.plotWidth, height: pane.height, dpr: vp.dpr }
       if (shouldUpdateMain) {
         this.sceneRenderer.beginFrame(region)
-        ;(this.sceneRenderer as any).setFallbackContext(overlayCtx ?? null, vp.dpr)
         this.scene.paintPane({
           renderer: this.sceneRenderer,
           region,
@@ -717,7 +711,6 @@ export class ChartRenderer {
       }
       if (shouldUpdateOverlay && !shouldUpdateMain) {
         this.sceneRenderer.beginFrame(region)
-        ;(this.sceneRenderer as any).setFallbackContext(overlayCtx ?? null, vp.dpr)
         this.scene.paintPane(
           {
             renderer: this.sceneRenderer,

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -207,10 +207,11 @@ export class ChartRenderer {
       render: (snapshot) => {
         // generation 0 占位不绘制
         if (snapshot.generation === 0) return
-        // seal 与 paint 同属本帧；seal 供 interaction hover 读几何，不得在 paint 中途再写
+        // seal 几何 → flush hover（同代）→ paint；禁止 paint 中途再写 kernel 几何
         if (snapshot.frame) {
           this.sealFrameGeometry(snapshot.frame)
         }
+        this.deps.getInteraction().flushPendingHover()
         this.drawWithFrame(snapshot.level, snapshot.frame)
       },
       schedule: (run) => {

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -54,14 +54,18 @@ import { createLastPriceLineLayer } from './layers/lastPriceLineLayer'
 import { createLeftYAxisLayer } from './layers/leftYAxisLayer'
 import { createMainIndicatorLegendLayer } from './layers/mainIndicatorLegendLayer'
 import { createYAxisLayer } from './layers/yAxisLayer'
-import { batch, type ReadonlySignal } from '../../foundation/reactivity/signal'
+import { createFrameTransaction } from '../../foundation/reactivity/frameTransaction'
+import type { ReadonlySignal } from '../../foundation/reactivity/signal'
 
 type ResolvedChartOptions = Omit<ChartOptions, 'kWidth' | 'kGap'> & {
   kWidth: number
   kGap: number
 }
 
-/** 一帧的绘制数据 */
+/**
+ * 一帧绘制几何与数据（prepare 产出，render 只读）。
+ * 大数组字段做结构共享，禁止深拷贝。
+ */
 type FrameContext = {
   /** 视口（scrollLeft、plotWidth、dpr 等） */
   vp: Viewport
@@ -83,6 +87,34 @@ type FrameContext = {
   zoomLevel: number
   /** 缩放级别总数 */
   zoomLevelCount: number
+}
+
+/** 帧事务输入：仅重绘级别；多次 schedule 浅合并后由 mergeUpdateLevel 升格 */
+type FrameDrawInput = {
+  level: UpdateLevel
+}
+
+/**
+ * 帧事务快照：单代际绘制契约。
+ * generation 由 FrameTransaction 写入；frame 为 null 表示无可画数据。
+ */
+type FrameDrawSnapshot = {
+  generation: number
+  level: UpdateLevel
+  frame: FrameContext | null
+}
+
+/** Main 与 Overlay 合并为 All，其余取更全或后者 */
+function mergeUpdateLevel(current: UpdateLevel, next: UpdateLevel): UpdateLevel {
+  if (current === UpdateLevel.All || next === UpdateLevel.All) return UpdateLevel.All
+  if (current === next) return current
+  if (
+    (current === UpdateLevel.Main && next === UpdateLevel.Overlay) ||
+    (current === UpdateLevel.Overlay && next === UpdateLevel.Main)
+  ) {
+    return UpdateLevel.All
+  }
+  return next
 }
 
 export interface RendererDependencies {
@@ -111,10 +143,22 @@ export class ChartRenderer {
   /** 依赖注入容器，ChartRenderer 不直接持有状态，从 deps 接口读取，也便于测试 mock */
   private deps: RendererDependencies
 
-  /** requestAnimationFrame id，不为 null 时触发 RAF 节流，取消被分配帧，确保展示最新帧 */
+  /**
+   * 帧事务：scheduleDraw 只写输入并合并 rAF；flush 内 prepare → seal → paint。
+   * 绘制阶段不再反向写 kernel 几何（seal 在 render 回调最前、与 paint 同代）。
+   */
+  private readonly frameTx: ReturnType<
+    typeof createFrameTransaction<FrameDrawInput, FrameDrawSnapshot>
+  >
+
+  /**
+   * 与 frameTx pending 同步的重绘级别镜像。
+   * FrameTransaction 对 level 是浅覆盖，Main/Overlay 升格在此完成。
+   */
+  private pendingLevel: UpdateLevel = UpdateLevel.All
+
+  /** 已排队的 rAF 句柄；null 表示当前没有挂起的帧调度 */
   private raf: number | null = null
-  // 下一帧重绘级别
-  private pendingUpdateLevel: UpdateLevel = UpdateLevel.All
 
   readonly markerManager: MarkerManager
   readonly drawingStore: DrawingStore
@@ -147,6 +191,40 @@ export class ChartRenderer {
       getOverlay: deps.getOverlay,
     })
     this.scene = createScene()
+    this.frameTx = createFrameTransaction<FrameDrawInput, FrameDrawSnapshot>({
+      initialInput: { level: UpdateLevel.All },
+      derive: (input, generation) => {
+        // generation 0 是 createFrameTransaction 构造占位，禁止 prepare/副作用
+        if (generation === 0) {
+          return { generation: 0, level: input.level, frame: null }
+        }
+        return {
+          generation,
+          level: input.level,
+          frame: this.prepareFrameData(input.level),
+        }
+      },
+      render: (snapshot) => {
+        // generation 0 占位不绘制
+        if (snapshot.generation === 0) return
+        // seal 与 paint 同属本帧；seal 供 interaction hover 读几何，不得在 paint 中途再写
+        if (snapshot.frame) {
+          this.sealFrameGeometry(snapshot.frame)
+        }
+        this.drawWithFrame(snapshot.level, snapshot.frame)
+      },
+      schedule: (run) => {
+        this.raf = requestAnimationFrame(() => {
+          this.raf = null
+          run()
+          // 若 paint 中又 scheduleDraw，已写入新 pendingLevel 且 raf 非 null，不得清掉
+          if (this.raf === null) {
+            this.pendingLevel = UpdateLevel.All
+          }
+        })
+        return this.raf
+      },
+    })
   }
 
   initCoreRenderers(): void {
@@ -308,65 +386,44 @@ export class ChartRenderer {
   }
 
   /**
-   * 申请绘制，把绘制元数据配置合并到下一帧 requestAnimationFrame，避免同帧多次重绘。
+   * 申请绘制：合并重绘级别并写入帧事务，由 rAF 最多 flush 一次。
    *
-   * 已有 rAF 在等时只更新 pendingUpdateLevel，不重复注册。如果
-   * pending 和 level 分别是 Main 和 Overlay，合并成 All。
+   * 已有调度时只更新 pending level（Main+Overlay→All），不重复注册 rAF。
+   * flush 内：prepareFrameData → sealFrameGeometry → drawWithFrame。
    *
    * @param level - Main 只画主层，Overlay 只画覆盖层（crosshair 等），All 全画
    */
   scheduleDraw(level: UpdateLevel = UpdateLevel.All): void {
-    // 已经有下一帧 raf 被申请，只改下一个申请帧的重绘级别
     if (this.raf !== null) {
-      // pending 已是最全，新请求不论什么级别都不影响
-      if (this.pendingUpdateLevel === UpdateLevel.All) return
-      // 新请求要全画，升 pending
-      if (level === UpdateLevel.All) {
-        this.pendingUpdateLevel = UpdateLevel.All
-        return
-      }
-      // Main 和 Overlay 各来一次后合并成全画
-      if (
-        (this.pendingUpdateLevel === UpdateLevel.Main && level === UpdateLevel.Overlay) ||
-        (this.pendingUpdateLevel === UpdateLevel.Overlay && level === UpdateLevel.Main)
-      ) {
-        this.pendingUpdateLevel = UpdateLevel.All
-        return
-      }
-      // 同级别重复请求，pending 不变
+      this.pendingLevel = mergeUpdateLevel(this.pendingLevel, level)
+      this.frameTx.writeInput({ level: this.pendingLevel })
       return
     }
-
-    this.pendingUpdateLevel = level
-    this.raf = requestAnimationFrame(() => {
-      // 取出本次要画的级别，pending 改回 All 表示「没有挂起的请求了」
-      const levelToDraw = this.pendingUpdateLevel
-      this.pendingUpdateLevel = UpdateLevel.All
-
-      // 准备帧绘制数据
-      const frame = this.prepareFrameData(levelToDraw)
-      if (frame) {
-        // 把 K 线位置写入 interaction state，供十字线等模块读取
-        this.writeFramePositionsFromFrame(frame)
-      }
-      // 清屏、组 context、遍历 pane 调 Scene.paintPane、画时间轴
-      this.drawWithFrame(levelToDraw, frame)
-
-      this.raf = null
-      // 如果刚才画的过程中又有 scheduleDraw 写过 pending，补一帧
-      if (this.pendingUpdateLevel !== UpdateLevel.All) {
-        this.scheduleDraw(this.pendingUpdateLevel)
-      }
-    })
+    this.pendingLevel = level
+    this.frameTx.writeInput({ level })
+    this.frameTx.scheduleFlush()
   }
 
   /**
-   * 同步绘制一帧，不经 rAF 合并。测试与必须立刻出图的路径使用。
+   * 同步绘制一帧，走与 rAF 相同的 flush 管线（prepare → seal → paint）。
    *
    * @param level - 同 scheduleDraw
    */
   draw(level: UpdateLevel = UpdateLevel.All): void {
-    this.drawWithFrame(level, this.prepareFrameData(level))
+    this.pendingLevel = level
+    this.frameTx.writeInput({ level })
+    this.frameTx.flush()
+    this.pendingLevel = UpdateLevel.All
+  }
+
+  /**
+   * 将本帧几何封存到 interaction，供 hover 二分与十字线重算读取。
+   * 在 paint 之前调用；引用未变时 interaction 侧应跳过 signal 通知。
+   */
+  private sealFrameGeometry(frame: FrameContext): void {
+    this.deps
+      .getInteraction()
+      .setKLinePositions(frame.kLinePositions, frame.range, frame.kWidthPx, frame.kLineCenters)
   }
 
   private drawWithFrame(level: UpdateLevel, frame: FrameContext | null): void {
@@ -425,17 +482,6 @@ export class ChartRenderer {
       sharedXAxisRanges,
       renderData,
     )
-  }
-
-  /**
-   * 把 K 线位置写入 interaction state。
-   * setKLinePositions 会更新多个 signal（位置、区间、宽度、中心点），
-   * batch 确保这组写入完成后才通知订阅者，不会让十字线等读到一半的新数据。
-   */
-  private writeFramePositionsFromFrame(frame: FrameContext): void {
-    batch(() => {
-      this.deps.getInteraction().setKLinePositions(frame.kLinePositions, frame.range, frame.kWidthPx, frame.kLineCenters)
-    })
   }
 
   /**

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -104,6 +104,7 @@ export interface RendererDependencies {
   customMarkers$: MarkerManagerDeps['customMarkers$']
   drawings$: DrawingStoreDeps['drawings$']
   selectedDrawingId$: DrawingStoreDeps['selectedDrawingId$']
+  getOverlay?: DrawingStoreDeps['getOverlay']
 }
 
 export class ChartRenderer {
@@ -143,6 +144,7 @@ export class ChartRenderer {
     this.drawingStore = new DrawingStore({
       drawings$: deps.drawings$,
       selectedDrawingId$: deps.selectedDrawingId$,
+      getOverlay: deps.getOverlay,
     })
     this.scene = createScene()
   }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -10,7 +10,6 @@ import type {
   YAxisTick,
 } from '../../foundation/plugin/index'
 import { RendererPluginManager, wrapPaneInfo } from '../../foundation/plugin/index'
-import { createWebGLRenderer, createWebGLSurfaceBackend } from '../../rendering/render/index'
 import type { Renderer } from '../../rendering/render/Renderer'
 import { createLayerFromPlugin } from '../../rendering/scene/createLayerFromPlugin'
 import { createScene } from '../../rendering/scene/createScene'
@@ -39,7 +38,6 @@ import {
 import type { ChartModeHandler } from '../modes/types'
 import { PaneRenderer } from '../paneRenderer'
 import { createTimeAxisRendererPlugin } from '../renderers/timeAxis'
-import { SharedWebGLSurface } from '../renderers/webgl/sharedWebGLSurface'
 import { getPhysicalKLineConfig } from '../utils/klineConfig'
 import { calculateTickCount } from '../utils/tickCount'
 import { ChartViewportManager } from '../viewport/chartViewportManager'
@@ -83,7 +81,7 @@ export interface RendererDependencies {
   getOption: () => ResolvedChartOptions
   getPaneRenderers: () => PaneRenderer[]
   getInteraction: () => InteractionController
-  getSharedWebGLSurface: () => SharedWebGLSurface
+  getSceneRenderer: () => Renderer
   getPluginHost: () => PluginHostImpl
   getRendererPluginManager: () => RendererPluginManager
   getTheme: () => 'light' | 'dark'
@@ -123,7 +121,6 @@ export class ChartRenderer {
   private frameCount = 0
   private paneCtxMap = new Map<string, RenderContext>()
   private currentPaneId = 'main'
-  private sceneRenderer: Renderer = {} as Renderer
   private timeAxisCtx: RenderContext | null = null
   private timeAxisLayer: Layer | null = null
   private _prevFrameRange: { visible: VisibleRange; raw: VisibleRange } | null = null
@@ -136,9 +133,6 @@ export class ChartRenderer {
       selectedDrawingId$: deps.selectedDrawingId$,
     })
     this.scene = createScene()
-    const sharedSurface = deps.getSharedWebGLSurface()
-    const surfaceBackend = createWebGLSurfaceBackend(sharedSurface)
-    this.sceneRenderer = createWebGLRenderer(surfaceBackend, sharedSurface)
   }
 
   initCoreRenderers(): void {
@@ -690,23 +684,24 @@ export class ChartRenderer {
       this.currentPaneId = pane.id
 
       const region = { x: 0, y: pane.top, width: vp.plotWidth, height: pane.height, dpr: vp.dpr }
+      const sceneRenderer = this.deps.getSceneRenderer()
       if (shouldUpdateMain) {
-        this.sceneRenderer.beginFrame(region)
+        sceneRenderer.beginFrame(region)
         this.scene.paintPane({
-          renderer: this.sceneRenderer,
+          renderer: sceneRenderer,
           region,
           paneRole: (pane.id === 'main' ? 'main' : 'sub') as PaneRole,
           paneId: pane.id,
           frameNumber: this.frameCount++,
           deltaMs: 0,
         })
-        this.sceneRenderer.endFrame()
+        sceneRenderer.endFrame()
       }
       if (shouldUpdateOverlay && !shouldUpdateMain) {
-        this.sceneRenderer.beginFrame(region)
+        sceneRenderer.beginFrame(region)
         this.scene.paintPane(
           {
-            renderer: this.sceneRenderer,
+            renderer: sceneRenderer,
             region,
             paneRole: (pane.id === 'main' ? 'main' : 'sub') as PaneRole,
             paneId: pane.id,
@@ -715,7 +710,7 @@ export class ChartRenderer {
           },
           ['overlay'],
         )
-        this.sceneRenderer.endFrame()
+        sceneRenderer.endFrame()
       }
     }
 
@@ -796,7 +791,7 @@ export class ChartRenderer {
         dayKeys: dataManager.getDayKeys() ?? undefined,
       }
       const paintCtx: PaintContext = {
-        renderer: this.sceneRenderer,
+        renderer: this.deps.getSceneRenderer(),
         region: { x: 0, y: 0, width: vp.plotWidth, height: opt.bottomAxisHeight, dpr: vp.dpr },
         paneRole: 'global',
         paneId: 'xAxis',
@@ -856,7 +851,6 @@ export class ChartRenderer {
     }
     this.cachedDrawFrame = null
     this.xAxisCtx = null
-    this.sceneRenderer.dispose()
     this.scene.dispose()
     this.paneCtxMap.clear()
   }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -695,7 +695,6 @@ export class ChartRenderer {
           frameNumber: this.frameCount++,
           deltaMs: 0,
         })
-        sceneRenderer.endFrame()
       }
       if (shouldUpdateOverlay && !shouldUpdateMain) {
         sceneRenderer.beginFrame(region)
@@ -710,9 +709,11 @@ export class ChartRenderer {
           },
           ['overlay'],
         )
-        sceneRenderer.endFrame()
       }
     }
+
+    // WebGPU: one submit after all panes recorded draws
+    this.deps.getSceneRenderer().endFrame()
 
     return { sharedXAxisLabels, sharedXAxisRanges }
   }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -260,14 +260,12 @@ export class ChartRenderer {
     {
       const plugin = createDrawingRendererPlugin({ store: this.drawingStore })
       this.deps.getRendererPluginManager().register(plugin)
-      this.deps.getRendererPluginManager().setEnabled(plugin.name, false)
       const layer = createLayerFromPlugin(plugin, getCtxForCurrentPane, 'global')
       this.scene.addLayer(layer)
     }
     {
       const plugin = createDrawingLabelOverlayPlugin({ store: this.drawingStore })
       this.deps.getRendererPluginManager().register(plugin)
-      this.deps.getRendererPluginManager().setEnabled(plugin.name, false)
       const layer = createLayerFromPlugin(plugin, getCtxForCurrentPane, 'global')
       this.scene.addLayer(layer)
     }
@@ -279,6 +277,10 @@ export class ChartRenderer {
 
   getPaneCtxMap(): Map<string, RenderContext> {
     return this.paneCtxMap
+  }
+
+  getCurrentPaneId(): string {
+    return this.currentPaneId
   }
 
   getMarkerManager(): MarkerManager {
@@ -587,8 +589,6 @@ export class ChartRenderer {
     const sharedXAxisRanges: XAxisRange[] = []
 
     const dataManager = this.deps.getDataManager()
-    const rendererPluginManager = this.deps.getRendererPluginManager()
-    const pluginHost = this.deps.getPluginHost()
     const mode = this.deps.getActiveMode()
 
     for (const renderer of this.deps.getPaneRenderers()) {
@@ -700,13 +700,6 @@ export class ChartRenderer {
 
       this.paneCtxMap.set(pane.id, context)
       this.currentPaneId = pane.id
-
-      if (shouldUpdateMain || shouldUpdateOverlay) {
-        const errors = rendererPluginManager.render(pane.id, context, level)
-        if (errors.length > 0) {
-          pluginHost.events.emit('renderer:error', { paneId: pane.id, errors })
-        }
-      }
 
       const region = { x: 0, y: pane.top, width: vp.plotWidth, height: pane.height, dpr: vp.dpr }
       if (shouldUpdateMain) {

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -408,13 +408,30 @@ export class ChartRenderer {
   /**
    * 同步绘制一帧，走与 rAF 相同的 flush 管线（prepare → seal → paint）。
    *
+   * 若已有 rAF 挂起：与 pendingLevel 合并后同步 flush（消费合并后的 level）。
+   * 若正处于帧事务非 idle（render/publish 重入）：只写输入并调度下一帧，禁止嵌套 flush。
+   *
    * @param level - 同 scheduleDraw
    */
   draw(level: UpdateLevel = UpdateLevel.All): void {
-    this.pendingLevel = level
-    this.frameTx.writeInput({ level })
+    if (this.frameTx.phase !== 'idle') {
+      this.pendingLevel = mergeUpdateLevel(this.pendingLevel, level)
+      this.frameTx.writeInput({ level: this.pendingLevel })
+      this.frameTx.scheduleFlush()
+      return
+    }
+
+    if (this.raf !== null) {
+      this.pendingLevel = mergeUpdateLevel(this.pendingLevel, level)
+    } else {
+      this.pendingLevel = level
+    }
+    this.frameTx.writeInput({ level: this.pendingLevel })
     this.frameTx.flush()
-    this.pendingLevel = UpdateLevel.All
+    // 同步 flush 已消费本帧；若 flush 中又 scheduleDraw，raf 非 null，保留 pendingLevel
+    if (this.raf === null) {
+      this.pendingLevel = UpdateLevel.All
+    }
   }
 
   /**

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -396,13 +396,6 @@ export class ChartRenderer {
     )
   }
 
-  /** 在 draw() 之前单独写入帧数据到 interactionState，分离状态变更与渲染 */
-  private writeFramePositions(level: UpdateLevel): void {
-    const frame = this.prepareFrameData(level)
-    if (!frame) return
-    this.writeFramePositionsFromFrame(frame)
-  }
-
   private writeFramePositionsFromFrame(frame: FrameContext): void {
     batch(() => {
       this.deps.getInteraction().setKLinePositions(frame.kLinePositions, frame.range, frame.kWidthPx, frame.kLineCenters)

--- a/packages/core/src/engine/renderers/Indicator/atr.ts
+++ b/packages/core/src/engine/renderers/Indicator/atr.ts
@@ -16,6 +16,7 @@ import { createNonNegativeSparseVisibleStateComposer } from '../../indicators/vi
 
 import { createAtrScaleRendererPlugin } from './scale/atr_scale'
 import { createSingleLineTitleInfo } from './shared/titleInfo'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -98,7 +99,7 @@ function createATRRendererPlugin(options: ATRRendererOptions = {}): RendererPlug
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -159,22 +160,9 @@ function createATRRendererPlugin(options: ATRRendererOptions = {}): RendererPlug
         }
       }
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        if (cachedPoints.length >= 2) {
-          const ok = lineWebGLSurface.drawLineStrips(
-            [{ points: cachedPoints, width: 1, color: atrColor }],
-            scrollLeft,
-          )
-          if (ok) {
-            usedWebGL = true
-            lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-          }
-        }
-      }
-
-      if (!usedWebGL) {
+      if (
+        !tryDrawLinesGpu(context, [{ points: cachedPoints, width: 1, color: atrColor }], scrollLeft)
+      ) {
         drawWithCanvas2D(ctx, scrollLeft, cachedPoints, atrColor)
       }
     },

--- a/packages/core/src/engine/renderers/Indicator/boll.ts
+++ b/packages/core/src/engine/renderers/Indicator/boll.ts
@@ -56,8 +56,6 @@ function drawBOLLWithWebGL(
     context.isAsiaMarket,
     context.colorPresetSettings,
   )
-  if (context.settings?.enableWebGLRendering === false) return false
-
   // band：画完立即 composite（alpha），再画线（MSAA 会 clear FBO，band 已在 2D）
   let bandOk = false
   if (data.showBand && data.bandUpperPoints.length >= 2 && data.bandLowerPoints.length >= 2) {

--- a/packages/core/src/engine/renderers/Indicator/boll.ts
+++ b/packages/core/src/engine/renderers/Indicator/boll.ts
@@ -20,7 +20,8 @@ import type {
 import type { BOLLSchedulerConfig, IndicatorScheduler } from '../../indicators/scheduler'
 import { BOLL_STATE_KEY, type BOLLRenderState } from '../../indicators/state/bollState'
 
-import { getRgbaAlpha, toOpaqueRgba, compositeLineSurface } from './shared/webglBand'
+import { getRgbaAlpha, toOpaqueRgba } from './shared/webglBand'
+import { tryDrawFilledBandGpu, tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -32,6 +33,10 @@ interface PriceData {
   lower: number
 }
 
+/**
+ * BOLL GPU：先 band fill（半透明 composite）再三轨折线。
+ * sceneRenderer → legacy surface；失败返回 false 走 2D。
+ */
 function drawBOLLWithWebGL(
   context: RenderContext,
   data: {
@@ -52,24 +57,19 @@ function drawBOLLWithWebGL(
     context.colorPresetSettings,
   )
   if (context.settings?.enableWebGLRendering === false) return false
-  const surface = context.lineWebGLSurface
-  if (!surface || !surface.isAvailable()) return false
 
-  surface.clear()
-
-  let allOk = true
+  // band：画完立即 composite（alpha），再画线（MSAA 会 clear FBO，band 已在 2D）
+  let bandOk = false
   if (data.showBand && data.bandUpperPoints.length >= 2 && data.bandLowerPoints.length >= 2) {
-    surface.clear()
-    allOk = surface.drawFilledBand(
-      { upperPoints: data.bandUpperPoints, lowerPoints: data.bandLowerPoints },
+    bandOk = tryDrawFilledBandGpu(
+      context,
+      data.bandUpperPoints,
+      data.bandLowerPoints,
       toOpaqueRgba(colors.boll.bandFill),
       context.scrollLeft,
+      getRgbaAlpha(colors.boll.bandFill),
     )
-    if (allOk) {
-      compositeLineSurface(context, surface, getRgbaAlpha(colors.boll.bandFill))
-    }
   }
-  surface.clear()
 
   const lineStrips: Array<{ points: LinePoint[]; width: number; color: string }> = []
   if (data.showUpper && data.upperPoints.length >= 2) {
@@ -86,17 +86,8 @@ function drawBOLLWithWebGL(
     lineStrips.push({ points: data.lowerPoints, width: BOLL_LINE_WIDTH, color: colors.boll.lower })
   }
 
-  if (lineStrips.length > 0) {
-    allOk = surface.drawLineStrips(lineStrips, context.scrollLeft)
-  }
-  if (!allOk) {
-    surface.clear()
-    return false
-  }
-
-  compositeLineSurface(context, surface)
-  surface.clear()
-  return true
+  if (lineStrips.length === 0) return bandOk
+  return tryDrawLinesGpu(context, lineStrips, context.scrollLeft)
 }
 
 function buildPriceCacheKey(

--- a/packages/core/src/engine/renderers/Indicator/boll.ts
+++ b/packages/core/src/engine/renderers/Indicator/boll.ts
@@ -35,7 +35,7 @@ interface PriceData {
 
 /**
  * BOLL GPU：先 band fill（半透明 composite）再三轨折线。
- * sceneRenderer → legacy surface；失败返回 false 走 2D。
+ * 仅 sceneRenderer；失败返回 false 走 2D。
  */
 function drawBOLLWithWebGL(
   context: RenderContext,

--- a/packages/core/src/engine/renderers/Indicator/cci.ts
+++ b/packages/core/src/engine/renderers/Indicator/cci.ts
@@ -15,6 +15,7 @@ import { createCCIVisibleStateComposer } from '../../indicators/visibleStateComp
 
 import { createCciScaleRendererPlugin } from './scale/cci_scale'
 import { createSingleLineTitleInfo } from './shared/titleInfo'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -100,7 +101,7 @@ function createCCIRendererPlugin(options: CCIRendererOptions = {}): RendererPlug
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, dpr, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -185,22 +186,11 @@ function createCCIRendererPlugin(options: CCIRendererOptions = {}): RendererPlug
       }
 
       // 绘制 CCI 线（WebGL 优先，Canvas2D 回退）
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        if (params.showCCI && cachedCCIPoints.length >= 2) {
-          const ok = lineWebGLSurface.drawLineStrips(
-            [{ points: cachedCCIPoints, width: 1, color: colors.cci.cci }],
-            scrollLeft,
-          )
-          if (ok) {
-            usedWebGL = true
-            lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-          }
-        }
-      }
-
-      if (!usedWebGL) {
+      const cciLines =
+        params.showCCI && cachedCCIPoints.length >= 2
+          ? [{ points: cachedCCIPoints, width: 1, color: colors.cci.cci }]
+          : []
+      if (!tryDrawLinesGpu(context, cciLines, scrollLeft)) {
         drawCCILineWithCanvas2D(ctx, scrollLeft, cachedCCIPoints, params, colors)
       }
     },

--- a/packages/core/src/engine/renderers/Indicator/chaikinVol.ts
+++ b/packages/core/src/engine/renderers/Indicator/chaikinVol.ts
@@ -14,6 +14,7 @@ import {
   EMPTY_CHAIKIN_VOL_STATE,
 } from '../../indicators/state/chaikinVolState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -60,7 +61,7 @@ function createChaikinVolRendererPlugin(options: { paneId?: string } = {}): Rend
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<ChaikinVolRenderState>(stateKey)
@@ -101,20 +102,7 @@ function createChaikinVolRendererPlugin(options: { paneId?: string } = {}): Rend
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: CHAIKIN_VOL_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: CHAIKIN_VOL_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/cmf.ts
+++ b/packages/core/src/engine/renderers/Indicator/cmf.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, CMFSchedulerConfig } from '../../indicators/sc
 import type { CMFRenderState } from '../../indicators/state/cmfState'
 import { createCMFStateKey, EMPTY_CMF_STATE } from '../../indicators/state/cmfState'
 import { createFixedRangeSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -54,7 +55,7 @@ function createCMFRendererPlugin(options: { paneId?: string } = {}): RendererPlu
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<CMFRenderState>(stateKey)
@@ -95,20 +96,7 @@ function createCMFRendererPlugin(options: { paneId?: string } = {}): RendererPlu
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: CMF_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: CMF_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/dema.ts
+++ b/packages/core/src/engine/renderers/Indicator/dema.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, DEMASchedulerConfig } from '../../indicators/s
 import type { DEMARenderState } from '../../indicators/state/demaState'
 import { createDEMAStateKey, EMPTY_DEMA_STATE } from '../../indicators/state/demaState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -62,7 +63,7 @@ function createDEMARendererPlugin(options: DEMARendererOptions = {}): RendererPl
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
 
       const stateKey = resolveKey()
       if (!stateKey) return
@@ -84,20 +85,7 @@ function createDEMARendererPlugin(options: DEMARendererOptions = {}): RendererPl
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: DEMA_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: DEMA_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/donchian.ts
+++ b/packages/core/src/engine/renderers/Indicator/donchian.ts
@@ -68,7 +68,7 @@ function createDonchianRendererPlugin(
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<DonchianRenderState>(stateKey)
@@ -102,17 +102,7 @@ function createDonchianRendererPlugin(
       if (lowerPts.length >= 2)
         lines.push({ points: lowerPts, width: 1, color: DONCHIAN_LOWER_COLOR })
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, lines, scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/donchian.ts
+++ b/packages/core/src/engine/renderers/Indicator/donchian.ts
@@ -16,6 +16,7 @@ import type { IndicatorScheduler, DonchianSchedulerConfig } from '../../indicato
 import type { DonchianRenderState } from '../../indicators/state/donchianState'
 import { createDonchianStateKey, EMPTY_DONCHIAN_STATE } from '../../indicators/state/donchianState'
 import { createBandVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 const DONCHIAN_UPPER_COLOR = '#0891b2'
 const DONCHIAN_MIDDLE_COLOR = '#94a3b8'

--- a/packages/core/src/engine/renderers/Indicator/ene.ts
+++ b/packages/core/src/engine/renderers/Indicator/ene.ts
@@ -20,10 +20,14 @@ import type {
 import type { ENESchedulerConfig, IndicatorScheduler } from '../../indicators/scheduler'
 import { ENE_STATE_KEY, type ENERenderState } from '../../indicators/state/eneState'
 
-import { getRgbaAlpha, toOpaqueRgba, compositeLineSurface } from './shared/webglBand'
+import { getRgbaAlpha, toOpaqueRgba } from './shared/webglBand'
+import { tryDrawFilledBandGpu, tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
+/**
+ * ENE GPU：先 band fill 再上/中/下轨。sceneRenderer → legacy → false。
+ */
 function drawENEWithWebGL(
   context: RenderContext,
   data: {
@@ -38,24 +42,19 @@ function drawENEWithWebGL(
     context.colorPresetSettings,
   )
   if (context.settings?.enableWebGLRendering === false) return false
-  const surface = context.lineWebGLSurface
-  if (!surface || !surface.isAvailable()) return false
 
-  surface.clear()
-
-  let allOk = true
+  // band 默认 false：无 surface 时不得假成功跳过 2D
+  let bandOk = false
   if (data.upperPoints.length >= 2 && data.lowerPoints.length >= 2) {
-    surface.clear()
-    allOk = surface.drawFilledBand(
-      { upperPoints: data.upperPoints, lowerPoints: data.lowerPoints },
+    bandOk = tryDrawFilledBandGpu(
+      context,
+      data.upperPoints,
+      data.lowerPoints,
       toOpaqueRgba(colors.ene.bandFill),
       context.scrollLeft,
+      getRgbaAlpha(colors.ene.bandFill),
     )
-    if (allOk) {
-      compositeLineSurface(context, surface, getRgbaAlpha(colors.ene.bandFill))
-    }
   }
-  surface.clear()
 
   const lineStrips: Array<{ points: LinePoint[]; width: number; color: string }> = []
   if (data.upperPoints.length >= 2) {
@@ -67,17 +66,10 @@ function drawENEWithWebGL(
   if (data.lowerPoints.length >= 2) {
     lineStrips.push({ points: data.lowerPoints, width: 1, color: colors.ene.lower })
   }
-  if (lineStrips.length > 0) {
-    allOk = surface.drawLineStrips(lineStrips, context.scrollLeft)
-  }
-  if (!allOk) {
-    surface.clear()
-    return false
-  }
 
-  compositeLineSurface(context, surface)
-  surface.clear()
-  return true
+  if (lineStrips.length === 0) return bandOk
+  // 线失败 → false，整图 2D 重画（含 band）
+  return tryDrawLinesGpu(context, lineStrips, context.scrollLeft)
 }
 
 /** 创建 ENE（轨道线）渲染器插件（无状态版本）

--- a/packages/core/src/engine/renderers/Indicator/ene.ts
+++ b/packages/core/src/engine/renderers/Indicator/ene.ts
@@ -41,8 +41,6 @@ function drawENEWithWebGL(
     context.isAsiaMarket,
     context.colorPresetSettings,
   )
-  if (context.settings?.enableWebGLRendering === false) return false
-
   // band 默认 false：无 surface 时不得假成功跳过 2D
   let bandOk = false
   if (data.upperPoints.length >= 2 && data.lowerPoints.length >= 2) {

--- a/packages/core/src/engine/renderers/Indicator/ene.ts
+++ b/packages/core/src/engine/renderers/Indicator/ene.ts
@@ -26,7 +26,7 @@ import { tryDrawFilledBandGpu, tryDrawLinesGpu } from '../linesViaRenderer'
 type LinePoint = { x: number; y: number }
 
 /**
- * ENE GPU：先 band fill 再上/中/下轨。sceneRenderer → legacy → false。
+ * ENE GPU：先 band fill 再上/中/下轨。仅 sceneRenderer；失败返回 false 走 2D。
  */
 function drawENEWithWebGL(
   context: RenderContext,

--- a/packages/core/src/engine/renderers/Indicator/expma.ts
+++ b/packages/core/src/engine/renderers/Indicator/expma.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../indicators/indicatorMetadata'
 import type { EXPMASchedulerConfig, IndicatorScheduler } from '../../indicators/scheduler'
 import { EXPMA_STATE_KEY, type EXPMARenderState } from '../../indicators/state/expmaState'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -127,7 +128,7 @@ export function createEXPMARendererPlugin(): RendererPluginWithHost {
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, data, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, data, range, scrollLeft, dpr, kLineCenters } = context
       const klineData = data as KLineData[]
       const colors = resolveThemeColors(
         context.theme,
@@ -169,9 +170,7 @@ export function createEXPMARendererPlugin(): RendererPluginWithHost {
         }
       }
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
+      {
         const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
         if (cachedFastPoints.length >= 2) {
           lines.push({ points: cachedFastPoints, width: 1, color: colors.expma.fast })
@@ -179,16 +178,8 @@ export function createEXPMARendererPlugin(): RendererPluginWithHost {
         if (cachedSlowPoints.length >= 2) {
           lines.push({ points: cachedSlowPoints, width: 1, color: colors.expma.slow })
         }
-
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
+        if (tryDrawLinesGpu(context, lines, scrollLeft)) return
       }
-
-      if (usedWebGL) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/fastk.ts
+++ b/packages/core/src/engine/renderers/Indicator/fastk.ts
@@ -16,6 +16,7 @@ import { createFixedRangeSparseVisibleStateComposer } from '../../indicators/vis
 import { createFastkScaleRendererPlugin } from './scale/fastk_scale'
 import { createDashedLineRenderer } from './shared/dashedLines'
 import { createSingleLineTitleInfo } from './shared/titleInfo'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -104,7 +105,7 @@ function createFASTKRendererPlugin(options: FASTKRendererOptions = {}): Renderer
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, dpr, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -161,22 +162,11 @@ function createFASTKRendererPlugin(options: FASTKRendererOptions = {}): Renderer
       }
 
       // 绘制 FASTK 线（WebGL 优先，Canvas2D 回退）
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        if (params.showFASTK && cachedFASTKPoints.length >= 2) {
-          const ok = lineWebGLSurface.drawLineStrips(
-            [{ points: cachedFASTKPoints, width: 1, color: colors.kdj.k }],
-            scrollLeft,
-          )
-          if (ok) {
-            usedWebGL = true
-            lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-          }
-        }
-      }
-
-      if (!usedWebGL) {
+      const fastkLines =
+        params.showFASTK && cachedFASTKPoints.length >= 2
+          ? [{ points: cachedFASTKPoints, width: 1, color: colors.kdj.k }]
+          : []
+      if (!tryDrawLinesGpu(context, fastkLines, scrollLeft)) {
         drawFASTKLineWithCanvas2D(ctx, scrollLeft, cachedFASTKPoints, params, colors)
       }
     },

--- a/packages/core/src/engine/renderers/Indicator/fib.ts
+++ b/packages/core/src/engine/renderers/Indicator/fib.ts
@@ -16,6 +16,7 @@ import type { IndicatorScheduler, FibSchedulerConfig } from '../../indicators/sc
 import type { FibRenderState } from '../../indicators/state/fibState'
 import { createFibStateKey, EMPTY_FIB_STATE } from '../../indicators/state/fibState'
 import { createExactRangePointVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 const FIB_COLORS = {
   high: '#94a3b8',

--- a/packages/core/src/engine/renderers/Indicator/fib.ts
+++ b/packages/core/src/engine/renderers/Indicator/fib.ts
@@ -66,7 +66,7 @@ function createFibRendererPlugin(options: { paneId?: string } = {}): RendererPlu
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<FibRenderState>(stateKey)
@@ -107,17 +107,7 @@ function createFibRendererPlugin(options: { paneId?: string } = {}): RendererPlu
         }
       }
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, lines, scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/hma.ts
+++ b/packages/core/src/engine/renderers/Indicator/hma.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, HMASchedulerConfig } from '../../indicators/sc
 import type { HMARenderState } from '../../indicators/state/hmaState'
 import { createHMAStateKey, EMPTY_HMA_STATE } from '../../indicators/state/hmaState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -62,7 +63,7 @@ function createHMARendererPlugin(options: HMARendererOptions = {}): RendererPlug
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
 
       const stateKey = resolveKey()
       if (!stateKey) return
@@ -84,20 +85,7 @@ function createHMARendererPlugin(options: HMARendererOptions = {}): RendererPlug
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: HMA_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: HMA_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/hv.ts
+++ b/packages/core/src/engine/renderers/Indicator/hv.ts
@@ -13,6 +13,7 @@ import type { HVRenderState } from '../../indicators/state/hvState'
 import { createHVStateKey } from '../../indicators/state/hvState'
 import { EMPTY_HV_STATE } from '../../indicators/state/hvState'
 import { createNonNegativeSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -57,7 +58,7 @@ function createHVRendererPlugin(options: { paneId?: string } = {}): RendererPlug
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<HVRenderState>(stateKey)
@@ -84,20 +85,7 @@ function createHVRendererPlugin(options: { paneId?: string } = {}): RendererPlug
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: HV_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: HV_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/ichimoku.ts
+++ b/packages/core/src/engine/renderers/Indicator/ichimoku.ts
@@ -228,20 +228,27 @@ function fillCloud(
   bearColor: string,
   alpha = 0.15,
 ): void {
+  if (segs.length < 2) return
   ctx.save()
   ctx.globalAlpha = alpha
-  for (let i = 0; i < segs.length - 1; i++) {
-    const a = segs[i]!
-    const b = segs[i + 1]!
-    ctx.fillStyle = a.bull ? bullColor : bearColor
+
+  let start = 0
+  const lastSeg = segs.length - 1
+  while (start < lastSeg) {
+    const isBull = segs[start]!.bull
+    ctx.fillStyle = isBull ? bullColor : bearColor
+    let end = start
+    while (end < lastSeg && segs[end]!.bull === isBull) end++
+    end--
     ctx.beginPath()
-    ctx.moveTo(a.x, a.ya)
-    ctx.lineTo(b.x, b.ya)
-    ctx.lineTo(b.x, b.yb)
-    ctx.lineTo(a.x, a.yb)
+    ctx.moveTo(segs[start]!.x, segs[start]!.ya)
+    for (let k = start + 1; k <= end + 1; k++) ctx.lineTo(segs[k]!.x, segs[k]!.ya)
+    for (let k = end; k >= start; k--) ctx.lineTo(segs[k]!.x, segs[k]!.yb)
     ctx.closePath()
     ctx.fill()
+    start = end + 1
   }
+
   ctx.restore()
 }
 

--- a/packages/core/src/engine/renderers/Indicator/ichimoku.ts
+++ b/packages/core/src/engine/renderers/Indicator/ichimoku.ts
@@ -19,6 +19,7 @@ import type { IchimokuRenderState } from '../../indicators/state/ichimokuState'
 import { createIchimokuStateKey, EMPTY_ICHIMOKU_STATE } from '../../indicators/state/ichimokuState'
 import { createIchimokuVisibleStateComposer } from '../../indicators/visibleStateComposers'
 import { getPhysicalKLineConfig } from '../../utils/klineConfig'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 const TENKAN_COLOR = '#dc2626'
 const KIJUN_COLOR = '#2563eb'
@@ -99,16 +100,14 @@ function renderCloudFill(
 }
 
 function renderIchimokuLines(
-  ctx: CanvasRenderingContext2D,
-  lineWebGLSurface: RenderContext['lineWebGLSurface'],
-  scrollLeft: number,
-  enableWebGL: boolean,
+  context: RenderContext,
   tenkanPts: Point[],
   kijunPts: Point[],
   spanAPts: Point[],
   spanBPts: Point[],
   chikouPts: Point[],
 ): void {
+  const { ctx, scrollLeft } = context
   const lines: Array<{ points: Point[]; width: number; color: string }> = []
   if (tenkanPts.length >= 2) lines.push({ points: tenkanPts, width: 1, color: TENKAN_COLOR })
   if (kijunPts.length >= 2) lines.push({ points: kijunPts, width: 1, color: KIJUN_COLOR })
@@ -116,13 +115,7 @@ function renderIchimokuLines(
   if (spanBPts.length >= 2) lines.push({ points: spanBPts, width: 1, color: SPAN_B_COLOR })
   if (chikouPts.length >= 2) lines.push({ points: chikouPts, width: 1, color: CHIKOU_COLOR })
 
-  if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-    const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-    if (allOk) {
-      lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-      return
-    }
-  }
+  if (tryDrawLinesGpu(context, lines, scrollLeft)) return
 
   ctx.save()
   ctx.translate(-scrollLeft, 0)
@@ -182,7 +175,7 @@ function createIchimokuRendererPlugin(
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -200,10 +193,7 @@ function createIchimokuRendererPlugin(
         renderCloudFill(ctx, points.cloudSegs, colors, scrollLeft)
       }
       renderIchimokuLines(
-        ctx,
-        lineWebGLSurface,
-        scrollLeft,
-        context.settings?.enableWebGLRendering !== false,
+        context,
         points.tenkanPts,
         points.kijunPts,
         points.spanAPts,

--- a/packages/core/src/engine/renderers/Indicator/kama.ts
+++ b/packages/core/src/engine/renderers/Indicator/kama.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, KAMASchedulerConfig } from '../../indicators/s
 import type { KAMARenderState } from '../../indicators/state/kamaState'
 import { createKAMAStateKey, EMPTY_KAMA_STATE } from '../../indicators/state/kamaState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -62,7 +63,7 @@ function createKAMARendererPlugin(options: KAMARendererOptions = {}): RendererPl
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
 
       const stateKey = resolveKey()
       if (!stateKey) return
@@ -84,20 +85,7 @@ function createKAMARendererPlugin(options: KAMARendererOptions = {}): RendererPl
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: KAMA_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: KAMA_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/keltner.ts
+++ b/packages/core/src/engine/renderers/Indicator/keltner.ts
@@ -66,7 +66,7 @@ function createKeltnerRendererPlugin(options: KeltnerRendererOptions = {}): Rend
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<KeltnerRenderState>(stateKey)
@@ -100,17 +100,7 @@ function createKeltnerRendererPlugin(options: KeltnerRendererOptions = {}): Rend
       if (lowerPts.length >= 2)
         lines.push({ points: lowerPts, width: 1, color: KELTNER_LOWER_COLOR })
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, lines, scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/keltner.ts
+++ b/packages/core/src/engine/renderers/Indicator/keltner.ts
@@ -16,6 +16,7 @@ import type { IndicatorScheduler, KeltnerSchedulerConfig } from '../../indicator
 import type { KeltnerRenderState } from '../../indicators/state/keltnerState'
 import { createKeltnerStateKey, EMPTY_KELTNER_STATE } from '../../indicators/state/keltnerState'
 import { createBandVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 const KELTNER_UPPER_COLOR = '#7c3aed'
 const KELTNER_MIDDLE_COLOR = '#f59e0b'

--- a/packages/core/src/engine/renderers/Indicator/kst.ts
+++ b/packages/core/src/engine/renderers/Indicator/kst.ts
@@ -16,6 +16,7 @@ import { EMPTY_KST_STATE } from '../../indicators/state/kstState'
 import { createPaddedPointVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
 import { createKstScaleRendererPlugin } from './scale/kst_scale'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -108,7 +109,7 @@ function createKSTRendererPlugin(options: KSTRendererOptions = {}): RendererPlug
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, dpr, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -189,26 +190,14 @@ function createKSTRendererPlugin(options: KSTRendererOptions = {}): RendererPlug
       }
 
       // 绘制 KST 线（WebGL 优先，Canvas2D 回退）
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
-        if (params.showKST && cachedKSTPoints.length >= 2) {
-          lines.push({ points: cachedKSTPoints, width: 1, color: colors.kst.kst })
-        }
-        if (params.showSignal && cachedSignalPoints.length >= 2) {
-          lines.push({ points: cachedSignalPoints, width: 1, color: colors.kst.signal })
-        }
-
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
+      const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
+      if (params.showKST && cachedKSTPoints.length >= 2) {
+        lines.push({ points: cachedKSTPoints, width: 1, color: colors.kst.kst })
       }
-
-      if (!usedWebGL) {
+      if (params.showSignal && cachedSignalPoints.length >= 2) {
+        lines.push({ points: cachedSignalPoints, width: 1, color: colors.kst.signal })
+      }
+      if (!tryDrawLinesGpu(context, lines, scrollLeft)) {
         drawKSTLinesWithCanvas2D(
           ctx,
           scrollLeft,

--- a/packages/core/src/engine/renderers/Indicator/ma.ts
+++ b/packages/core/src/engine/renderers/Indicator/ma.ts
@@ -293,7 +293,7 @@ export function createMARendererPlugin(): RendererPluginWithHost {
         lines.push({ points, width: 1, color: maColors[period] ?? colors.ma.ma5 })
       }
 
-      // Phase 1.1: sceneRenderer → legacy surface → 2D
+      // sceneRenderer → fail-closed 2D
       if (tryDrawLinesGpu(context, lines, scrollLeft)) return
 
       ctx.save()

--- a/packages/core/src/engine/renderers/Indicator/ma.ts
+++ b/packages/core/src/engine/renderers/Indicator/ma.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../indicators/indicatorMetadata'
 import type { IndicatorScheduler } from '../../indicators/scheduler'
 import { MA_STATE_KEY, type MARenderState } from '../../indicators/state/maState'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 // Re-export MAFlags from calculators for backward compatibility
 export type { MAFlags } from '../../indicators/calculators'
@@ -227,7 +228,7 @@ export function createMARendererPlugin(): RendererPluginWithHost {
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, dpr, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -285,28 +286,15 @@ export function createMARendererPlugin(): RendererPluginWithHost {
         }
       }
 
-      // 检查 WebGL 渲染开关（默认开启）及 GPU 加速是否可用
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        // 组装所有周期的折线数据，批量提交 GPU 一次性渲染，避免逐条 beginPath 的 CPU 开销
-        const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
-        for (const period of state.enabledPeriods) {
-          const points = cachedLines.get(period)
-          if (!points) continue
-          lines.push({ points, width: 1, color: maColors[period] ?? colors.ma.ma5 })
-        }
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-
-        if (allOk) {
-          usedWebGL = true
-          // 将 WebGL 离屏帧缓冲区内容通过 drawImage 合成到主 Canvas2D
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
+      const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
+      for (const period of state.enabledPeriods) {
+        const points = cachedLines.get(period)
+        if (!points) continue
+        lines.push({ points, width: 1, color: maColors[period] ?? colors.ma.ma5 })
       }
 
-      // WebGL 渲染失败或未开启时的 Canvas2D 降级路径
-      if (usedWebGL) return
+      // Phase 1.1: sceneRenderer → legacy surface → 2D
+      if (tryDrawLinesGpu(context, lines, scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/macd.ts
+++ b/packages/core/src/engine/renderers/Indicator/macd.ts
@@ -135,7 +135,7 @@ function createMACDRendererPlugin(options: MACDRendererOptions = {}): RendererPl
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, data, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, data, range, scrollLeft, dpr, kLineCenters } = context
       const klineData = data as KLineData[]
       const colors = resolveThemeColors(
         context.theme,
@@ -313,10 +313,8 @@ function createMACDRendererPlugin(options: MACDRendererOptions = {}): RendererPl
         }
       }
 
-      // 绘制 DIF/DEA 线（WebGL 优先，Canvas2D 回退）
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGLForLines = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
+      // 绘制 DIF/DEA 线（sceneRenderer → legacy → Canvas2D）
+      {
         const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
         if (config.showDIF && cachedDifPoints.length >= 2) {
           lines.push({ points: cachedDifPoints, width: 1, color: colors.macd.dif })
@@ -324,23 +322,19 @@ function createMACDRendererPlugin(options: MACDRendererOptions = {}): RendererPl
         if (config.showDEA && cachedDeaPoints.length >= 2) {
           lines.push({ points: cachedDeaPoints, width: 1, color: colors.macd.dea })
         }
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-        if (allOk) {
-          usedWebGLForLines = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
+        if (
+          !tryDrawLinesGpu(context, lines, scrollLeft)
+        ) {
+          drawMacdLinesWithCanvas2D(
+            ctx,
+            scrollLeft,
+            colors.macd.dif,
+            colors.macd.dea,
+            cachedDifPoints,
+            cachedDeaPoints,
+            config,
+          )
         }
-      }
-
-      if (!usedWebGLForLines) {
-        drawMacdLinesWithCanvas2D(
-          ctx,
-          scrollLeft,
-          colors.macd.dif,
-          colors.macd.dea,
-          cachedDifPoints,
-          cachedDeaPoints,
-          config,
-        )
       }
     },
 

--- a/packages/core/src/engine/renderers/Indicator/macd.ts
+++ b/packages/core/src/engine/renderers/Indicator/macd.ts
@@ -338,10 +338,6 @@ function createMACDRendererPlugin(options: MACDRendererOptions = {}): RendererPl
       }
     },
 
-    onDataUpdate() {
-      clearLineCache()
-    },
-
     getConfig() {
       return { ...config }
     },

--- a/packages/core/src/engine/renderers/Indicator/macd.ts
+++ b/packages/core/src/engine/renderers/Indicator/macd.ts
@@ -16,6 +16,8 @@ import { createMACDStateKey, EMPTY_MACD_STATE } from '../../indicators/state/mac
 import type { MACDRenderState } from '../../indicators/state/macdState'
 import { createMACDVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
+import { tryDrawRectsGpu } from '../rectsViaRenderer'
+
 import { createMacdScaleRendererPlugin } from './scale/macd_scale'
 
 type LinePoint = { x: number; y: number }
@@ -241,18 +243,17 @@ function createMACDRendererPlugin(options: MACDRendererOptions = {}): RendererPl
           }
         }
 
-        const usedWebGL = drawMacdBarsWithWebGL(
+        const usedGpu = tryDrawRectsGpu(
           context,
-          barUpBuf,
-          barUpCount,
-          barUpLightBuf,
-          barUpLightCount,
-          barDownBuf,
-          barDownCount,
-          barDownLightBuf,
-          barDownLightCount,
+          [
+            { buf: barUpBuf, count: barUpCount, color: colors.macd.barUp },
+            { buf: barUpLightBuf, count: barUpLightCount, color: colors.macd.barUpLight },
+            { buf: barDownBuf, count: barDownCount, color: colors.macd.barDown },
+            { buf: barDownLightBuf, count: barDownLightCount, color: colors.macd.barDownLight },
+          ],
+          scrollLeft,
         )
-        if (!usedWebGL) {
+        if (!usedGpu) {
           drawMacdBarsWithCanvas2D(
             ctx,
             scrollLeft,
@@ -269,8 +270,6 @@ function createMACDRendererPlugin(options: MACDRendererOptions = {}): RendererPl
             barDownLightBuf,
             barDownLightCount,
           )
-        } else {
-          compositeMacdWebGL(ctx, context)
         }
       }
 
@@ -371,64 +370,6 @@ function createMACDRendererPlugin(options: MACDRendererOptions = {}): RendererPl
   }
 }
 
-function drawMacdBarsWithWebGL(
-  context: RenderContext,
-  barUpBuf: Float32Array,
-  barUpCount: number,
-  barUpLightBuf: Float32Array,
-  barUpLightCount: number,
-  barDownBuf: Float32Array,
-  barDownCount: number,
-  barDownLightBuf: Float32Array,
-  barDownLightCount: number,
-): boolean {
-  const colors = resolveThemeColors(
-    context.theme,
-    context.isAsiaMarket,
-    context.colorPresetSettings,
-  )
-  if (context.settings?.enableWebGLRendering === false) return false
-  const surface = context.candleWebGLSurface
-  if (!surface || !surface.isAvailable()) return false
-
-  surface.clear()
-
-  const ok1 =
-    barUpCount === 0 ||
-    surface.drawRectBuffer(
-      barUpBuf.subarray(0, barUpCount * 4),
-      barUpCount,
-      colors.macd.barUp,
-      context.scrollLeft,
-    )
-  const ok2 =
-    barUpLightCount === 0 ||
-    surface.drawRectBuffer(
-      barUpLightBuf.subarray(0, barUpLightCount * 4),
-      barUpLightCount,
-      colors.macd.barUpLight,
-      context.scrollLeft,
-    )
-  const ok3 =
-    barDownCount === 0 ||
-    surface.drawRectBuffer(
-      barDownBuf.subarray(0, barDownCount * 4),
-      barDownCount,
-      colors.macd.barDown,
-      context.scrollLeft,
-    )
-  const ok4 =
-    barDownLightCount === 0 ||
-    surface.drawRectBuffer(
-      barDownLightBuf.subarray(0, barDownLightCount * 4),
-      barDownLightCount,
-      colors.macd.barDownLight,
-      context.scrollLeft,
-    )
-
-  return ok1 && ok2 && ok3 && ok4
-}
-
 function drawMacdBarsWithCanvas2D(
   ctx: CanvasRenderingContext2D,
   scrollLeft: number,
@@ -523,13 +464,6 @@ function drawMacdLinesWithCanvas2D(
   }
 
   ctx.restore()
-}
-
-function compositeMacdWebGL(ctx: CanvasRenderingContext2D, context: RenderContext): void {
-  const surface = context.candleWebGLSurface
-  if (!surface) return
-
-  surface.compositeTo(ctx)
 }
 
 /**

--- a/packages/core/src/engine/renderers/Indicator/macd.ts
+++ b/packages/core/src/engine/renderers/Indicator/macd.ts
@@ -16,6 +16,7 @@ import { createMACDStateKey, EMPTY_MACD_STATE } from '../../indicators/state/mac
 import type { MACDRenderState } from '../../indicators/state/macdState'
 import { createMACDVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 import { tryDrawRectsGpu } from '../rectsViaRenderer'
 
 import { createMacdScaleRendererPlugin } from './scale/macd_scale'
@@ -312,7 +313,7 @@ function createMACDRendererPlugin(options: MACDRendererOptions = {}): RendererPl
         }
       }
 
-      // 绘制 DIF/DEA 线（sceneRenderer → legacy → Canvas2D）
+      // 绘制 DIF/DEA 线（sceneRenderer → Canvas2D）
       {
         const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
         if (config.showDIF && cachedDifPoints.length >= 2) {

--- a/packages/core/src/engine/renderers/Indicator/mfi.ts
+++ b/packages/core/src/engine/renderers/Indicator/mfi.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, MFISchedulerConfig } from '../../indicators/sc
 import type { MFIRenderState } from '../../indicators/state/mfiState'
 import { createMFIStateKey, EMPTY_MFI_STATE } from '../../indicators/state/mfiState'
 import { createFixedRangeSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -54,7 +55,7 @@ function createMFIRendererPlugin(options: { paneId?: string } = {}): RendererPlu
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<MFIRenderState>(stateKey)
@@ -100,20 +101,7 @@ function createMFIRendererPlugin(options: { paneId?: string } = {}): RendererPlu
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: MFI_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: MFI_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/mom.ts
+++ b/packages/core/src/engine/renderers/Indicator/mom.ts
@@ -17,6 +17,7 @@ import { createPaddedSparseVisibleStateComposer } from '../../indicators/visible
 
 import { createMomScaleRendererPlugin } from './scale/mom_scale'
 import { createSingleLineTitleInfo } from './shared/titleInfo'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -158,7 +159,7 @@ function createMOMRendererPlugin(options: MOMRendererOptions = {}): RendererPlug
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, dpr, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -236,22 +237,11 @@ function createMOMRendererPlugin(options: MOMRendererOptions = {}): RendererPlug
       }
 
       // 绘制 MOM 线（WebGL 优先，Canvas2D 回退）
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        if (params.showMOM && cachedMOMPoints.length >= 2) {
-          const ok = lineWebGLSurface.drawLineStrips(
-            [{ points: cachedMOMPoints, width: 1, color: colors.mom.mom }],
-            scrollLeft,
-          )
-          if (ok) {
-            usedWebGL = true
-            lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-          }
-        }
-      }
-
-      if (!usedWebGL) {
+      const momLines =
+        params.showMOM && cachedMOMPoints.length >= 2
+          ? [{ points: cachedMOMPoints, width: 1, color: colors.mom.mom }]
+          : []
+      if (!tryDrawLinesGpu(context, momLines, scrollLeft)) {
         drawMOMLineWithCanvas2D(ctx, scrollLeft, cachedMOMPoints, params, colors)
       }
     },

--- a/packages/core/src/engine/renderers/Indicator/obv.ts
+++ b/packages/core/src/engine/renderers/Indicator/obv.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, OBVSchedulerConfig } from '../../indicators/sc
 import type { OBVRenderState } from '../../indicators/state/obvState'
 import { createOBVStateKey, EMPTY_OBV_STATE } from '../../indicators/state/obvState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -54,7 +55,7 @@ function createOBVRendererPlugin(options: { paneId?: string } = {}): RendererPlu
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<OBVRenderState>(stateKey)
@@ -81,20 +82,7 @@ function createOBVRendererPlugin(options: { paneId?: string } = {}): RendererPlu
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: OBV_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: OBV_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/parkinson.ts
+++ b/packages/core/src/engine/renderers/Indicator/parkinson.ts
@@ -13,6 +13,7 @@ import type { ParkinsonRenderState } from '../../indicators/state/parkinsonState
 import { createParkinsonStateKey } from '../../indicators/state/parkinsonState'
 import { EMPTY_PARKINSON_STATE } from '../../indicators/state/parkinsonState'
 import { createNonNegativeSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -57,7 +58,7 @@ function createParkinsonRendererPlugin(options: { paneId?: string } = {}): Rende
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<ParkinsonRenderState>(stateKey)
@@ -84,20 +85,7 @@ function createParkinsonRendererPlugin(options: { paneId?: string } = {}): Rende
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: PARKINSON_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: PARKINSON_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/pvt.ts
+++ b/packages/core/src/engine/renderers/Indicator/pvt.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, PVTSchedulerConfig } from '../../indicators/sc
 import type { PVTRenderState } from '../../indicators/state/pvtState'
 import { createPVTStateKey, EMPTY_PVT_STATE } from '../../indicators/state/pvtState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -54,7 +55,7 @@ function createPVTRendererPlugin(options: { paneId?: string } = {}): RendererPlu
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<PVTRenderState>(stateKey)
@@ -81,20 +82,7 @@ function createPVTRendererPlugin(options: { paneId?: string } = {}): RendererPlu
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: PVT_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: PVT_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/roc.ts
+++ b/packages/core/src/engine/renderers/Indicator/roc.ts
@@ -12,6 +12,7 @@ import type { IndicatorScheduler, ROCSchedulerConfig } from '../../indicators/sc
 import type { ROCRenderState } from '../../indicators/state/rocState'
 import { createROCStateKey, EMPTY_ROC_STATE } from '../../indicators/state/rocState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -62,7 +63,7 @@ function createROCRendererPlugin(options: ROCRendererOptions = {}): RendererPlug
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<ROCRenderState>(stateKey)
@@ -103,20 +104,7 @@ function createROCRendererPlugin(options: ROCRendererOptions = {}): RendererPlug
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: ROC_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: ROC_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/rsi.ts
+++ b/packages/core/src/engine/renderers/Indicator/rsi.ts
@@ -16,6 +16,7 @@ import { createRSIStateKey, EMPTY_RSI_STATE } from '../../indicators/state/rsiSt
 import { createFixedRangeRecordVisibleStateComposer } from '../../indicators/visibleStateComposers'
 
 import { createRsiScaleRendererPlugin } from './scale/rsi_scale'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -188,7 +189,7 @@ function createRSIRendererPlugin(options: RSIRendererOptions = {}): RendererPlug
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, dpr, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -272,29 +273,17 @@ function createRSIRendererPlugin(options: RSIRendererOptions = {}): RendererPlug
       }
 
       // 绘制 RSI 线（WebGL 优先，Canvas2D 回退）
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
-        if (params.showRSI1 && cachedRSI1Points.length >= 2) {
-          lines.push({ points: cachedRSI1Points, width: 1, color: colors.rsi.rsi1 })
-        }
-        if (params.showRSI2 && cachedRSI2Points.length >= 2) {
-          lines.push({ points: cachedRSI2Points, width: 1, color: colors.rsi.rsi2 })
-        }
-        if (params.showRSI3 && cachedRSI3Points.length >= 2) {
-          lines.push({ points: cachedRSI3Points, width: 1, color: colors.rsi.rsi3 })
-        }
-
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
+      const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
+      if (params.showRSI1 && cachedRSI1Points.length >= 2) {
+        lines.push({ points: cachedRSI1Points, width: 1, color: colors.rsi.rsi1 })
       }
-
-      if (!usedWebGL) {
+      if (params.showRSI2 && cachedRSI2Points.length >= 2) {
+        lines.push({ points: cachedRSI2Points, width: 1, color: colors.rsi.rsi2 })
+      }
+      if (params.showRSI3 && cachedRSI3Points.length >= 2) {
+        lines.push({ points: cachedRSI3Points, width: 1, color: colors.rsi.rsi3 })
+      }
+      if (!tryDrawLinesGpu(context, lines, scrollLeft)) {
         drawRSILinesWithCanvas2D(
           ctx,
           scrollLeft,

--- a/packages/core/src/engine/renderers/Indicator/shared/webglBand.ts
+++ b/packages/core/src/engine/renderers/Indicator/shared/webglBand.ts
@@ -1,5 +1,3 @@
-import type { RenderContext } from '../../../../foundation/plugin/index'
-
 export function getRgbaAlpha(color: string): number {
   const match = color.match(/^rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\)$/i)
   if (!match) return 1
@@ -9,15 +7,4 @@ export function getRgbaAlpha(color: string): number {
 
 export function toOpaqueRgba(color: string): string {
   return color.replace(/,\s*[\d.]+\s*\)$/i, ', 1)')
-}
-
-export function compositeLineSurface(
-  context: RenderContext,
-  surface: NonNullable<RenderContext['lineWebGLSurface']>,
-  alpha = 1,
-): void {
-  surface.compositeTo(context.ctx, {
-    alpha,
-    imageSmoothingEnabled: false,
-  })
 }

--- a/packages/core/src/engine/renderers/Indicator/stoch.ts
+++ b/packages/core/src/engine/renderers/Indicator/stoch.ts
@@ -16,6 +16,7 @@ import { createFixedRangePointVisibleStateComposer } from '../../indicators/visi
 
 import { createStochScaleRendererPlugin } from './scale/stoch_scale'
 import { createDashedLineRenderer } from './shared/dashedLines'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -108,7 +109,7 @@ function createSTOCHRendererPlugin(options: STOCHRendererOptions = {}): Renderer
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, dpr, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -181,26 +182,14 @@ function createSTOCHRendererPlugin(options: STOCHRendererOptions = {}): Renderer
       }
 
       // 绘制 STOCH 线（WebGL 优先，Canvas2D 回退）
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
-        if (params.showK && cachedKPoints.length >= 2) {
-          lines.push({ points: cachedKPoints, width: 1, color: colors.kdj.k })
-        }
-        if (params.showD && cachedDPoints.length >= 2) {
-          lines.push({ points: cachedDPoints, width: 1, color: colors.kdj.d })
-        }
-
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
+      const lines: Array<{ points: LinePoint[]; width: number; color: string }> = []
+      if (params.showK && cachedKPoints.length >= 2) {
+        lines.push({ points: cachedKPoints, width: 1, color: colors.kdj.k })
       }
-
-      if (!usedWebGL) {
+      if (params.showD && cachedDPoints.length >= 2) {
+        lines.push({ points: cachedDPoints, width: 1, color: colors.kdj.d })
+      }
+      if (!tryDrawLinesGpu(context, lines, scrollLeft)) {
         drawSTOCHLinesWithCanvas2D(ctx, scrollLeft, cachedKPoints, cachedDPoints, params, colors)
       }
     },

--- a/packages/core/src/engine/renderers/Indicator/tema.ts
+++ b/packages/core/src/engine/renderers/Indicator/tema.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, TEMASchedulerConfig } from '../../indicators/s
 import type { TEMARenderState } from '../../indicators/state/temaState'
 import { createTEMAStateKey, EMPTY_TEMA_STATE } from '../../indicators/state/temaState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -62,7 +63,7 @@ function createTEMARendererPlugin(options: TEMARendererOptions = {}): RendererPl
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
 
       const stateKey = resolveKey()
       if (!stateKey) return
@@ -84,20 +85,7 @@ function createTEMARendererPlugin(options: TEMARendererOptions = {}): RendererPl
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: TEMA_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: TEMA_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/trix.ts
+++ b/packages/core/src/engine/renderers/Indicator/trix.ts
@@ -15,6 +15,7 @@ import type { TRIXRenderState } from '../../indicators/state/trixState'
 import { createTRIXStateKey } from '../../indicators/state/trixState'
 import { EMPTY_TRIX_STATE } from '../../indicators/state/trixState'
 import { createDualSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 const TRIX_COLOR = '#e11d48'
 const SIGNAL_COLOR = '#f59e0b'

--- a/packages/core/src/engine/renderers/Indicator/trix.ts
+++ b/packages/core/src/engine/renderers/Indicator/trix.ts
@@ -64,7 +64,7 @@ function createTRIXRendererPlugin(options: TRIXRendererOptions = {}): RendererPl
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<TRIXRenderState>(stateKey)
@@ -118,17 +118,7 @@ function createTRIXRendererPlugin(options: TRIXRendererOptions = {}): RendererPl
       if (trixPts.length >= 2) lines.push({ points: trixPts, width: 1, color: TRIX_COLOR })
       if (sigPts.length >= 2) lines.push({ points: sigPts, width: 1, color: SIGNAL_COLOR })
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lines.length > 0 && lineWebGLSurface.drawLineStrips(lines, scrollLeft)
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, lines, scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/vma.ts
+++ b/packages/core/src/engine/renderers/Indicator/vma.ts
@@ -12,6 +12,7 @@ import type { VMARenderState } from '../../indicators/state/vmaState'
 import { createVMAStateKey } from '../../indicators/state/vmaState'
 import { EMPTY_VMA_STATE } from '../../indicators/state/vmaState'
 import { createNonNegativeSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -55,7 +56,7 @@ function createVMARendererPlugin(options: { paneId?: string } = {}): RendererPlu
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<VMARenderState>(stateKey)
@@ -83,20 +84,7 @@ function createVMARendererPlugin(options: { paneId?: string } = {}): RendererPlu
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: VMA_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: VMA_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/vwap.ts
+++ b/packages/core/src/engine/renderers/Indicator/vwap.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, VWAPSchedulerConfig } from '../../indicators/s
 import type { VWAPRenderState } from '../../indicators/state/vwapState'
 import { createVWAPStateKey, EMPTY_VWAP_STATE } from '../../indicators/state/vwapState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -54,7 +55,7 @@ function createVWAPRendererPlugin(options: { paneId?: string } = {}): RendererPl
       return key ? [key] : []
     },
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
       const stateKey = resolveKey()
       if (!stateKey) return
       const state = pluginHost?.getSharedState<VWAPRenderState>(stateKey)
@@ -81,20 +82,7 @@ function createVWAPRendererPlugin(options: { paneId?: string } = {}): RendererPl
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: VWAP_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: VWAP_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/wma.ts
+++ b/packages/core/src/engine/renderers/Indicator/wma.ts
@@ -11,6 +11,7 @@ import type { IndicatorScheduler, WMASchedulerConfig } from '../../indicators/sc
 import type { WMARenderState } from '../../indicators/state/wmaState'
 import { createWMAStateKey, EMPTY_WMA_STATE } from '../../indicators/state/wmaState'
 import { createSparseVisibleStateComposer } from '../../indicators/visibleStateComposers'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 import { createSingleLineTitleInfo } from './shared/titleInfo'
 
@@ -62,7 +63,7 @@ function createWMARendererPlugin(options: WMARendererOptions = {}): RendererPlug
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, kLineCenters } = context
 
       const stateKey = resolveKey()
       if (!stateKey) return
@@ -84,20 +85,7 @@ function createWMARendererPlugin(options: WMARendererOptions = {}): RendererPlug
 
       if (points.length < 2) return
 
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        const allOk = lineWebGLSurface.drawLineStrips(
-          [{ points, width: 1, color: WMA_COLOR }],
-          scrollLeft,
-        )
-        if (allOk) {
-          usedWebGL = true
-          lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-        }
-      }
-
-      if (usedWebGL) return
+      if (tryDrawLinesGpu(context, [{ points, width: 1, color: WMA_COLOR }], scrollLeft)) return
 
       ctx.save()
       ctx.translate(-scrollLeft, 0)

--- a/packages/core/src/engine/renderers/Indicator/wmsr.ts
+++ b/packages/core/src/engine/renderers/Indicator/wmsr.ts
@@ -16,6 +16,7 @@ import { createFixedRangeSparseVisibleStateComposer } from '../../indicators/vis
 
 import { createWmsrScaleRendererPlugin } from './scale/wmsr_scale'
 import { createSingleLineTitleInfo } from './shared/titleInfo'
+import { tryDrawLinesGpu } from '../linesViaRenderer'
 
 type LinePoint = { x: number; y: number }
 
@@ -180,7 +181,7 @@ function createWMSRRendererPlugin(options: WMSRRendererOptions = {}): RendererPl
     },
 
     draw(context: RenderContext) {
-      const { ctx, pane, range, scrollLeft, dpr, kLineCenters, lineWebGLSurface } = context
+      const { ctx, pane, range, scrollLeft, dpr, kLineCenters } = context
       const colors = resolveThemeColors(
         context.theme,
         context.isAsiaMarket,
@@ -258,22 +259,11 @@ function createWMSRRendererPlugin(options: WMSRRendererOptions = {}): RendererPl
       }
 
       // 绘制 WMSR 线（WebGL 优先，Canvas2D 回退）
-      const enableWebGL = context.settings?.enableWebGLRendering !== false
-      let usedWebGL = false
-      if (enableWebGL && lineWebGLSurface?.isAvailable()) {
-        if (params.showWMSR && cachedWMSRPoints.length >= 2) {
-          const ok = lineWebGLSurface.drawLineStrips(
-            [{ points: cachedWMSRPoints, width: 1, color: colors.wmsr.wmsr }],
-            scrollLeft,
-          )
-          if (ok) {
-            usedWebGL = true
-            lineWebGLSurface.compositeTo(ctx, { imageSmoothingEnabled: false })
-          }
-        }
-      }
-
-      if (!usedWebGL) {
+      const wmsrLines =
+        params.showWMSR && cachedWMSRPoints.length >= 2
+          ? [{ points: cachedWMSRPoints, width: 1, color: colors.wmsr.wmsr }]
+          : []
+      if (!tryDrawLinesGpu(context, wmsrLines, scrollLeft)) {
         drawWMSRLineWithCanvas2D(ctx, scrollLeft, cachedWMSRPoints, params, colors)
       }
     },

--- a/packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
@@ -94,7 +94,7 @@ describe('candle sceneRenderer path', () => {
       kBarRects: [],
       theme: 'dark' as const,
       viewport: { scrollLeft: 0, plotWidth: 800, plotHeight: 400 },
-      settings: { enableWebGLRendering: true, showVolumePriceMarkers: false },
+      settings: { rendererBackend: 'webgl', showVolumePriceMarkers: false },
       sceneRenderer: r,
       zoomLevel: 1,
     } as unknown as RenderContext
@@ -145,7 +145,7 @@ describe('candle sceneRenderer path', () => {
       kBarRects: [],
       theme: 'dark' as const,
       viewport: { scrollLeft: 0, plotWidth: 800, plotHeight: 400 },
-      settings: { enableWebGLRendering: true, showVolumePriceMarkers: false },
+      settings: { rendererBackend: 'webgl', showVolumePriceMarkers: false },
       sceneRenderer: r,
       zoomLevel: 1,
     } as unknown as RenderContext

--- a/packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
@@ -56,7 +56,7 @@ function makeSceneRenderer() {
 }
 
 describe('candle sceneRenderer path', () => {
-  it('draws via sceneRenderer.drawInstances and composites', () => {
+  it('draws via sceneRenderer.drawInstances and composites on webgl', () => {
     const { r, drawInstances, compositeTo } = makeSceneRenderer()
 
     const data = Array.from({ length: 5 }, (_, i) => ({
@@ -103,6 +103,56 @@ describe('candle sceneRenderer path', () => {
 
     expect(drawInstances).toHaveBeenCalled()
     expect(compositeTo).toHaveBeenCalledOnce()
+  })
+
+  it('skips compositeTo when sceneRenderer is webgpu (hybrid DOM)', () => {
+    const { r, drawInstances, compositeTo } = makeSceneRenderer()
+    r.caps = { ...r.caps, name: 'webgpu' }
+
+    const data = Array.from({ length: 3 }, (_, i) => ({
+      timestamp: i,
+      open: 100,
+      high: 105,
+      low: 95,
+      close: 102,
+      volume: 1000,
+    }))
+
+    const ctx = {
+      ctx: {
+        save: vi.fn(),
+        restore: vi.fn(),
+        translate: vi.fn(),
+        fillRect: vi.fn(),
+        beginPath: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        closePath: vi.fn(),
+        fill: vi.fn(),
+      } as unknown as CanvasRenderingContext2D,
+      pane: makePane(),
+      data,
+      period: 'daily',
+      range: { start: 0, end: 3 },
+      scrollLeft: 0,
+      kWidth: 8,
+      kGap: 2,
+      dpr: 1,
+      paneWidth: 800,
+      kLinePositions: [0, 10, 20],
+      kLineCenters: [4, 14, 24],
+      kBarRects: [],
+      theme: 'dark' as const,
+      viewport: { scrollLeft: 0, plotWidth: 800, plotHeight: 400 },
+      settings: { rendererBackend: 'webgpu', showVolumePriceMarkers: false },
+      sceneRenderer: r,
+      zoomLevel: 1,
+    } as unknown as RenderContext
+
+    createCandleRenderer().draw(ctx)
+
+    expect(drawInstances).toHaveBeenCalled()
+    expect(compositeTo).not.toHaveBeenCalled()
   })
 
   it('falls to Canvas2D when drawInstances returns false (fail-closed)', () => {

--- a/packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import type { RenderContext } from '../../../foundation/plugin/index'
+import type { Renderer } from '../../../rendering/render/Renderer'
+import { createCandleRenderer } from '../candle'
+
+function makePane() {
+  return {
+    id: 'main',
+    top: 0,
+    height: 400,
+    role: 'price' as const,
+    capabilities: {},
+    yAxis: {
+      getDisplayRange: () => ({ maxPrice: 110, minPrice: 90 }),
+      getPaddingTop: () => 10,
+      getPaddingBottom: () => 10,
+      getScaleType: () => 'linear' as const,
+      priceToY: (p: number) => 200 - (p - 100),
+    },
+    priceRange: { min: 90, max: 110 },
+  }
+}
+
+function makeSceneRenderer() {
+  const compositeTo = vi.fn()
+  const drawInstances = vi.fn(() => true)
+  const writeBuffer = vi.fn()
+  const r: Renderer = {
+    surface: {
+      isAvailable: () => true,
+      resize: () => {},
+      bindRegion: () => true,
+      clearRegion: () => {},
+      compositeTo,
+      dispose: () => {},
+    },
+    caps: { compute: false, storageBuffer: false, maxInstances: 1e6, name: 'webgl2' },
+    createBuffer: vi.fn(() => ({}) as never),
+    writeBuffer,
+    destroyBuffer: vi.fn(),
+    createPipeline: vi.fn(() => ({}) as never),
+    destroyPipeline: vi.fn(),
+    createComputePipeline: () => {
+      throw new Error('no')
+    },
+    destroyComputePipeline: () => {},
+    beginFrame: vi.fn(),
+    drawInstances,
+    drawLines: vi.fn(),
+    dispatchCompute: () => {},
+    endFrame: vi.fn(),
+    dispose: vi.fn(),
+  }
+  return { r, drawInstances, writeBuffer, compositeTo }
+}
+
+describe('candle sceneRenderer path', () => {
+  it('prefers sceneRenderer.drawInstances over candleWebGLSurface', () => {
+    const { r, drawInstances, compositeTo } = makeSceneRenderer()
+    const legacyDraw = vi.fn(() => true)
+    const legacySurface = {
+      isAvailable: () => true,
+      clear: vi.fn(),
+      drawRectBuffer: legacyDraw,
+      compositeTo: vi.fn(),
+    }
+
+    const data = Array.from({ length: 5 }, (_, i) => ({
+      timestamp: i,
+      open: 100,
+      high: 105,
+      low: 95,
+      close: 102,
+      volume: 1000,
+    }))
+
+    const ctx = {
+      ctx: {
+        save: vi.fn(),
+        restore: vi.fn(),
+        translate: vi.fn(),
+        fillRect: vi.fn(),
+        beginPath: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        closePath: vi.fn(),
+        fill: vi.fn(),
+      } as unknown as CanvasRenderingContext2D,
+      pane: makePane(),
+      data,
+      period: 'daily',
+      range: { start: 0, end: 5 },
+      scrollLeft: 0,
+      kWidth: 8,
+      kGap: 2,
+      dpr: 1,
+      paneWidth: 800,
+      kLinePositions: [0, 10, 20, 30, 40],
+      kLineCenters: [4, 14, 24, 34, 44],
+      kBarRects: [],
+      theme: 'dark' as const,
+      viewport: { scrollLeft: 0, plotWidth: 800, plotHeight: 400 },
+      settings: { enableWebGLRendering: true, showVolumePriceMarkers: false },
+      sceneRenderer: r,
+      candleWebGLSurface: legacySurface as never,
+      zoomLevel: 1,
+    } as unknown as RenderContext
+
+    createCandleRenderer().draw(ctx)
+
+    expect(drawInstances).toHaveBeenCalled()
+    expect(legacyDraw).not.toHaveBeenCalled()
+    expect(compositeTo).toHaveBeenCalledOnce()
+  })
+
+  it('falls to Canvas2D when drawInstances returns false (fail-closed)', () => {
+    const { r, drawInstances, compositeTo } = makeSceneRenderer()
+    drawInstances.mockReturnValue(false)
+    const legacyDraw = vi.fn(() => false)
+    const fillRect = vi.fn()
+
+    const data = Array.from({ length: 3 }, (_, i) => ({
+      timestamp: i,
+      open: 100,
+      high: 105,
+      low: 95,
+      close: 102,
+      volume: 1000,
+    }))
+
+    const ctx = {
+      ctx: {
+        save: vi.fn(),
+        restore: vi.fn(),
+        translate: vi.fn(),
+        fillRect,
+        beginPath: vi.fn(),
+        moveTo: vi.fn(),
+        lineTo: vi.fn(),
+        closePath: vi.fn(),
+        fill: vi.fn(),
+      } as unknown as CanvasRenderingContext2D,
+      pane: makePane(),
+      data,
+      period: 'daily',
+      range: { start: 0, end: 3 },
+      scrollLeft: 0,
+      kWidth: 8,
+      kGap: 2,
+      dpr: 1,
+      paneWidth: 800,
+      kLinePositions: [0, 10, 20],
+      kLineCenters: [4, 14, 24],
+      kBarRects: [],
+      theme: 'dark' as const,
+      viewport: { scrollLeft: 0, plotWidth: 800, plotHeight: 400 },
+      settings: { enableWebGLRendering: true, showVolumePriceMarkers: false },
+      sceneRenderer: r,
+      candleWebGLSurface: {
+        isAvailable: () => true,
+        clear: vi.fn(),
+        drawRectBuffer: legacyDraw,
+        compositeTo: vi.fn(),
+      } as never,
+      zoomLevel: 1,
+    } as unknown as RenderContext
+
+    createCandleRenderer().draw(ctx)
+
+    expect(compositeTo).not.toHaveBeenCalled()
+    expect(fillRect).toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/candle.sceneRenderer.test.ts
@@ -56,15 +56,8 @@ function makeSceneRenderer() {
 }
 
 describe('candle sceneRenderer path', () => {
-  it('prefers sceneRenderer.drawInstances over candleWebGLSurface', () => {
+  it('draws via sceneRenderer.drawInstances and composites', () => {
     const { r, drawInstances, compositeTo } = makeSceneRenderer()
-    const legacyDraw = vi.fn(() => true)
-    const legacySurface = {
-      isAvailable: () => true,
-      clear: vi.fn(),
-      drawRectBuffer: legacyDraw,
-      compositeTo: vi.fn(),
-    }
 
     const data = Array.from({ length: 5 }, (_, i) => ({
       timestamp: i,
@@ -103,21 +96,18 @@ describe('candle sceneRenderer path', () => {
       viewport: { scrollLeft: 0, plotWidth: 800, plotHeight: 400 },
       settings: { enableWebGLRendering: true, showVolumePriceMarkers: false },
       sceneRenderer: r,
-      candleWebGLSurface: legacySurface as never,
       zoomLevel: 1,
     } as unknown as RenderContext
 
     createCandleRenderer().draw(ctx)
 
     expect(drawInstances).toHaveBeenCalled()
-    expect(legacyDraw).not.toHaveBeenCalled()
     expect(compositeTo).toHaveBeenCalledOnce()
   })
 
   it('falls to Canvas2D when drawInstances returns false (fail-closed)', () => {
     const { r, drawInstances, compositeTo } = makeSceneRenderer()
     drawInstances.mockReturnValue(false)
-    const legacyDraw = vi.fn(() => false)
     const fillRect = vi.fn()
 
     const data = Array.from({ length: 3 }, (_, i) => ({
@@ -157,12 +147,6 @@ describe('candle sceneRenderer path', () => {
       viewport: { scrollLeft: 0, plotWidth: 800, plotHeight: 400 },
       settings: { enableWebGLRendering: true, showVolumePriceMarkers: false },
       sceneRenderer: r,
-      candleWebGLSurface: {
-        isAvailable: () => true,
-        clear: vi.fn(),
-        drawRectBuffer: legacyDraw,
-        compositeTo: vi.fn(),
-      } as never,
       zoomLevel: 1,
     } as unknown as RenderContext
 

--- a/packages/core/src/engine/renderers/__tests__/candleViaRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/candleViaRenderer.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import type { Renderer } from '../../../rendering/render/Renderer'
+import { drawCandlesViaRenderer } from '../candleViaRenderer'
+
+function mockRenderer(): Renderer & {
+  writeBuffer: ReturnType<typeof vi.fn>
+  drawInstances: ReturnType<typeof vi.fn>
+  createBuffer: ReturnType<typeof vi.fn>
+  createPipeline: ReturnType<typeof vi.fn>
+  destroyBuffer: ReturnType<typeof vi.fn>
+  destroyPipeline: ReturnType<typeof vi.fn>
+} {
+  return {
+    surface: {
+      isAvailable: () => true,
+      resize: () => {},
+      bindRegion: () => true,
+      clearRegion: () => {},
+      compositeTo: vi.fn(),
+      dispose: () => {},
+    },
+    caps: { compute: false, storageBuffer: false, maxInstances: 1_000_000, name: 'webgl2' },
+    createBuffer: vi.fn(() => ({}) as never),
+    writeBuffer: vi.fn(),
+    destroyBuffer: vi.fn(),
+    createPipeline: vi.fn(() => ({}) as never),
+    destroyPipeline: vi.fn(),
+    createComputePipeline: () => {
+      throw new Error('no')
+    },
+    destroyComputePipeline: () => {},
+    beginFrame: vi.fn(),
+    drawInstances: vi.fn(),
+    drawLines: vi.fn(),
+    dispatchCompute: () => {},
+    endFrame: vi.fn(),
+    dispose: vi.fn(),
+  } as never
+}
+
+describe('drawCandlesViaRenderer', () => {
+  const nonEmpty = {
+    upBodyCount: 1,
+    downBodyCount: 1,
+    upWickCount: 1,
+    downWickCount: 1,
+    upBodyBuf: new Float32Array([0, 0, 10, 20]),
+    downBodyBuf: new Float32Array([20, 0, 10, 20]),
+    upWickBuf: new Float32Array([5, 0, 1, 30]),
+    downWickBuf: new Float32Array([25, 0, 1, 30]),
+  }
+
+  it('issues 4 drawInstances for non-empty up/down body and wick', () => {
+    const r = mockRenderer()
+    r.drawInstances.mockReturnValue(true)
+    const ok = drawCandlesViaRenderer(r, nonEmpty, '#0f0', '#f00', 0)
+    expect(ok).toBe(true)
+    expect(r.drawInstances).toHaveBeenCalledTimes(4)
+    expect(r.writeBuffer).toHaveBeenCalledTimes(4)
+  })
+
+  it('returns true without draw when all counts are zero', () => {
+    const r = mockRenderer()
+    r.drawInstances.mockReturnValue(true)
+    const prepared = {
+      upBodyCount: 0,
+      downBodyCount: 0,
+      upWickCount: 0,
+      downWickCount: 0,
+      upBodyBuf: new Float32Array(0),
+      downBodyBuf: new Float32Array(0),
+      upWickBuf: new Float32Array(0),
+      downWickBuf: new Float32Array(0),
+    }
+    const ok = drawCandlesViaRenderer(r, prepared, '#0f0', '#f00', 0)
+    expect(ok).toBe(true)
+    expect(r.drawInstances).not.toHaveBeenCalled()
+  })
+
+  it('returns false when surface unavailable', () => {
+    const r = mockRenderer()
+    r.surface.isAvailable = () => false
+    expect(drawCandlesViaRenderer(r, nonEmpty, '#0f0', '#f00', 0)).toBe(false)
+  })
+
+  it('returns false when drawInstances silent-fails (fail-closed)', () => {
+    const r = mockRenderer()
+    r.drawInstances.mockReturnValue(false)
+    expect(drawCandlesViaRenderer(r, nonEmpty, '#0f0', '#f00', 0)).toBe(false)
+  })
+
+  it('returns false if any non-empty batch fails', () => {
+    const r = mockRenderer()
+    r.drawInstances
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+    expect(drawCandlesViaRenderer(r, nonEmpty, '#0f0', '#f00', 0)).toBe(false)
+  })
+})

--- a/packages/core/src/engine/renderers/__tests__/linesViaRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/linesViaRenderer.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 
 import type { Renderer } from '../../../rendering/render/Renderer'
-import { drawFilledBandViaRenderer, drawLinesViaRenderer } from '../linesViaRenderer'
+import {
+  compositeSceneRenderer,
+  drawFilledBandViaRenderer,
+  drawLinesViaRenderer,
+  shouldCompositeSceneRenderer,
+  tryDrawFilledBandGpu,
+} from '../linesViaRenderer'
 
 function mockRenderer(): Renderer & {
   drawLines: ReturnType<typeof vi.fn>
@@ -165,5 +171,93 @@ describe('drawFilledBandViaRenderer', () => {
     expect(r.createPipeline).toHaveBeenCalledTimes(1)
     expect(r.createBuffer).toHaveBeenCalledTimes(1)
     expect(r.destroyBuffer).not.toHaveBeenCalled()
+  })
+})
+
+describe('compositeSceneRenderer hybrid DOM', () => {
+  it('composites on webgl and skips on webgpu', () => {
+    const webgl = mockRenderer()
+    const webgpu = mockRenderer()
+    ;(webgpu.caps as { name: string }).name = 'webgpu'
+    expect(shouldCompositeSceneRenderer(webgl)).toBe(true)
+    expect(shouldCompositeSceneRenderer(webgpu)).toBe(false)
+
+    compositeSceneRenderer({
+      ctx: {} as CanvasRenderingContext2D,
+      pane: { top: 0, height: 100 },
+      paneWidth: 200,
+      dpr: 1,
+      sceneRenderer: webgpu,
+    })
+    expect(webgpu.surface.compositeTo).not.toHaveBeenCalled()
+
+    compositeSceneRenderer({
+      ctx: {} as CanvasRenderingContext2D,
+      pane: { top: 0, height: 100 },
+      paneWidth: 200,
+      dpr: 1,
+      sceneRenderer: webgl,
+    })
+    expect(webgl.surface.compositeTo).toHaveBeenCalledOnce()
+  })
+})
+
+describe('tryDrawFilledBandGpu alpha on hybrid DOM', () => {
+  const upper = [
+    { x: 0, y: 10 },
+    { x: 1, y: 12 },
+  ]
+  const lower = [
+    { x: 0, y: 20 },
+    { x: 1, y: 22 },
+  ]
+
+  it('webgl keeps opaque color and applies alpha via compositeTo', () => {
+    const r = mockRenderer()
+    r.drawLines.mockReturnValue(true)
+    const ok = tryDrawFilledBandGpu(
+      {
+        ctx: {} as CanvasRenderingContext2D,
+        pane: { top: 0, height: 100 },
+        paneWidth: 200,
+        dpr: 1,
+        sceneRenderer: r,
+      } as never,
+      upper,
+      lower,
+      'rgba(0, 128, 255, 1)',
+      0,
+      0.2,
+    )
+    expect(ok).toBe(true)
+    expect(r.drawLines.mock.calls[0]![0].uniforms.color).toBe('rgba(0, 128, 255, 1)')
+    expect(r.surface.compositeTo).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ alpha: 0.2 }),
+    )
+  })
+
+  it('webgpu bakes alpha into fill color and skips compositeTo', () => {
+    const r = mockRenderer()
+    ;(r.caps as { name: string }).name = 'webgpu'
+    r.drawLines.mockReturnValue(true)
+    const ok = tryDrawFilledBandGpu(
+      {
+        ctx: {} as CanvasRenderingContext2D,
+        pane: { top: 0, height: 100 },
+        paneWidth: 200,
+        dpr: 1,
+        sceneRenderer: r,
+      } as never,
+      upper,
+      lower,
+      'rgba(0, 128, 255, 1)',
+      0,
+      0.2,
+    )
+    expect(ok).toBe(true)
+    expect(r.drawLines.mock.calls[0]![0].uniforms.color).toBe('rgba(0, 128, 255, 0.2)')
+    expect(r.surface.compositeTo).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/engine/renderers/__tests__/linesViaRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/linesViaRenderer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 
 import type { Renderer } from '../../../rendering/render/Renderer'
-import { drawLinesViaRenderer } from '../linesViaRenderer'
+import { drawFilledBandViaRenderer, drawLinesViaRenderer } from '../linesViaRenderer'
 
 function mockRenderer(): Renderer & {
   drawLines: ReturnType<typeof vi.fn>
@@ -114,5 +114,38 @@ describe('drawLinesViaRenderer', () => {
         0,
       ),
     ).toBe(false)
+  })
+})
+
+describe('drawFilledBandViaRenderer', () => {
+  it('uses fill pipeline and packs upper/lower points', () => {
+    const r = mockRenderer()
+    r.drawLines.mockReturnValue(true)
+    const ok = drawFilledBandViaRenderer(
+      r,
+      [
+        { x: 0, y: 10 },
+        { x: 1, y: 12 },
+      ],
+      [
+        { x: 0, y: 20 },
+        { x: 1, y: 22 },
+      ],
+      'rgba(0,0,255,0.2)',
+      5,
+    )
+    expect(ok).toBe(true)
+    expect(r.createPipeline).toHaveBeenCalledWith({ type: 'fill' })
+    expect(r.drawLines).toHaveBeenCalledTimes(1)
+    const args = r.drawLines.mock.calls[0]![0]
+    expect(args.vertexCount).toBe(4)
+    expect(args.uniforms.color).toBe('rgba(0,0,255,0.2)')
+    expect(args.uniforms.scrollLeft).toBe(5)
+  })
+
+  it('returns false when fewer than 2 points', () => {
+    const r = mockRenderer()
+    expect(drawFilledBandViaRenderer(r, [{ x: 0, y: 1 }], [{ x: 0, y: 2 }], '#00f', 0)).toBe(false)
+    expect(r.drawLines).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/engine/renderers/__tests__/linesViaRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/linesViaRenderer.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import type { Renderer } from '../../../rendering/render/Renderer'
+import { drawLinesViaRenderer } from '../linesViaRenderer'
+
+function mockRenderer(): Renderer & {
+  drawLines: ReturnType<typeof vi.fn>
+  createPipeline: ReturnType<typeof vi.fn>
+  destroyPipeline: ReturnType<typeof vi.fn>
+} {
+  return {
+    surface: {
+      isAvailable: () => true,
+      resize: () => {},
+      bindRegion: () => true,
+      clearRegion: () => {},
+      compositeTo: vi.fn(),
+      dispose: () => {},
+    },
+    caps: { compute: false, storageBuffer: false, maxInstances: 1e6, name: 'webgl2' },
+    createBuffer: vi.fn(() => ({}) as never),
+    writeBuffer: vi.fn(),
+    destroyBuffer: vi.fn(),
+    createPipeline: vi.fn(() => ({}) as never),
+    destroyPipeline: vi.fn(),
+    createComputePipeline: () => {
+      throw new Error('no')
+    },
+    destroyComputePipeline: () => {},
+    beginFrame: vi.fn(),
+    drawInstances: vi.fn(() => true),
+    drawLines: vi.fn(() => true),
+    dispatchCompute: () => {},
+    endFrame: vi.fn(),
+    dispose: vi.fn(),
+  } as never
+}
+
+describe('drawLinesViaRenderer', () => {
+  it('issues one batched drawLines with all strips (not N calls)', () => {
+    const r = mockRenderer()
+    const ok = drawLinesViaRenderer(
+      r,
+      [
+        {
+          points: [
+            { x: 0, y: 1 },
+            { x: 2, y: 3 },
+          ],
+          color: '#f00',
+          width: 1,
+        },
+        {
+          points: [
+            { x: 0, y: 0 },
+            { x: 1, y: 1 },
+            { x: 2, y: 0 },
+          ],
+          color: '#0f0',
+        },
+      ],
+      10,
+    )
+    expect(ok).toBe(true)
+    expect(r.drawLines).toHaveBeenCalledTimes(1)
+    const args = r.drawLines.mock.calls[0]![0]
+    expect(args.strips).toHaveLength(2)
+    expect(args.strips[0].color).toBe('#f00')
+    expect(args.strips[1].color).toBe('#0f0')
+    expect(args.uniforms.scrollLeft).toBe(10)
+  })
+
+  it('returns true without draw when no drawable strips', () => {
+    const r = mockRenderer()
+    expect(drawLinesViaRenderer(r, [{ points: [{ x: 0, y: 0 }], color: '#f00' }], 0)).toBe(true)
+    expect(r.drawLines).not.toHaveBeenCalled()
+  })
+
+  it('returns false when drawLines silent-fails', () => {
+    const r = mockRenderer()
+    r.drawLines.mockReturnValue(false)
+    expect(
+      drawLinesViaRenderer(
+        r,
+        [
+          {
+            points: [
+              { x: 0, y: 0 },
+              { x: 1, y: 1 },
+            ],
+            color: '#f00',
+          },
+        ],
+        0,
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when surface unavailable', () => {
+    const r = mockRenderer()
+    r.surface.isAvailable = () => false
+    expect(
+      drawLinesViaRenderer(
+        r,
+        [
+          {
+            points: [
+              { x: 0, y: 0 },
+              { x: 1, y: 1 },
+            ],
+            color: '#f00',
+          },
+        ],
+        0,
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/core/src/engine/renderers/__tests__/linesViaRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/linesViaRenderer.test.ts
@@ -148,4 +148,22 @@ describe('drawFilledBandViaRenderer', () => {
     expect(drawFilledBandViaRenderer(r, [{ x: 0, y: 1 }], [{ x: 0, y: 2 }], '#00f', 0)).toBe(false)
     expect(r.drawLines).not.toHaveBeenCalled()
   })
+
+  it('reuses fill pipeline and vertex buffer across frames', () => {
+    const r = mockRenderer()
+    r.drawLines.mockReturnValue(true)
+    const upper = [
+      { x: 0, y: 10 },
+      { x: 1, y: 12 },
+    ]
+    const lower = [
+      { x: 0, y: 20 },
+      { x: 1, y: 22 },
+    ]
+    expect(drawFilledBandViaRenderer(r, upper, lower, '#00f', 0)).toBe(true)
+    expect(drawFilledBandViaRenderer(r, upper, lower, '#00f', 5)).toBe(true)
+    expect(r.createPipeline).toHaveBeenCalledTimes(1)
+    expect(r.createBuffer).toHaveBeenCalledTimes(1)
+    expect(r.destroyBuffer).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core/src/engine/renderers/__tests__/rectsViaRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/rectsViaRenderer.test.ts
@@ -74,13 +74,14 @@ describe('drawRectBatchesViaRenderer', () => {
     expect(r.drawInstances).not.toHaveBeenCalled()
   })
 
-  it('reuses pipeline and instance buffers across frames', () => {
+  it('caches pipeline and unit vertex buffer; creates + destroys instance buffer per batch', () => {
     const r = mockRenderer()
     const batches = [{ buf: new Float32Array([0, 0, 10, 20]), count: 1, color: '#0f0' }]
     expect(drawRectBatchesViaRenderer(r, batches, 0)).toBe(true)
     expect(drawRectBatchesViaRenderer(r, batches, 3)).toBe(true)
     expect(r.createPipeline).toHaveBeenCalledTimes(1)
-    expect(r.createBuffer).toHaveBeenCalledTimes(2) // unit + one instance slot
-    expect(r.destroyBuffer).not.toHaveBeenCalled()
+    // unit buffer created once; each batch creates its own instance buffer
+    expect(r.createBuffer).toHaveBeenCalledTimes(3)
+    expect(r.destroyBuffer).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/core/src/engine/renderers/__tests__/rectsViaRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/rectsViaRenderer.test.ts
@@ -73,4 +73,14 @@ describe('drawRectBatchesViaRenderer', () => {
     ).toBe(true)
     expect(r.drawInstances).not.toHaveBeenCalled()
   })
+
+  it('reuses pipeline and instance buffers across frames', () => {
+    const r = mockRenderer()
+    const batches = [{ buf: new Float32Array([0, 0, 10, 20]), count: 1, color: '#0f0' }]
+    expect(drawRectBatchesViaRenderer(r, batches, 0)).toBe(true)
+    expect(drawRectBatchesViaRenderer(r, batches, 3)).toBe(true)
+    expect(r.createPipeline).toHaveBeenCalledTimes(1)
+    expect(r.createBuffer).toHaveBeenCalledTimes(2) // unit + one instance slot
+    expect(r.destroyBuffer).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core/src/engine/renderers/__tests__/rectsViaRenderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/rectsViaRenderer.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import type { Renderer } from '../../../rendering/render/Renderer'
+import { drawRectBatchesViaRenderer } from '../rectsViaRenderer'
+
+function mockRenderer(): Renderer & {
+  drawInstances: ReturnType<typeof vi.fn>
+  writeBuffer: ReturnType<typeof vi.fn>
+} {
+  return {
+    surface: {
+      isAvailable: () => true,
+      resize: () => {},
+      bindRegion: () => true,
+      clearRegion: () => {},
+      compositeTo: vi.fn(),
+      dispose: () => {},
+    },
+    caps: { compute: false, storageBuffer: false, maxInstances: 1e6, name: 'webgl2' },
+    createBuffer: vi.fn(() => ({}) as never),
+    writeBuffer: vi.fn(),
+    destroyBuffer: vi.fn(),
+    createPipeline: vi.fn(() => ({}) as never),
+    destroyPipeline: vi.fn(),
+    createComputePipeline: () => {
+      throw new Error('no')
+    },
+    destroyComputePipeline: () => {},
+    beginFrame: vi.fn(),
+    drawInstances: vi.fn(() => true),
+    drawLines: vi.fn(() => true),
+    dispatchCompute: () => {},
+    endFrame: vi.fn(),
+    dispose: vi.fn(),
+  } as never
+}
+
+describe('drawRectBatchesViaRenderer', () => {
+  it('draws each non-empty batch via drawInstances', () => {
+    const r = mockRenderer()
+    const ok = drawRectBatchesViaRenderer(
+      r,
+      [
+        { buf: new Float32Array([0, 0, 10, 20]), count: 1, color: '#0f0' },
+        { buf: new Float32Array(0), count: 0, color: '#f00' },
+        { buf: new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]), count: 2, color: '#00f' },
+      ],
+      3,
+    )
+    expect(ok).toBe(true)
+    expect(r.drawInstances).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns false when any batch fails', () => {
+    const r = mockRenderer()
+    r.drawInstances.mockReturnValueOnce(true).mockReturnValueOnce(false)
+    expect(
+      drawRectBatchesViaRenderer(
+        r,
+        [
+          { buf: new Float32Array([0, 0, 1, 1]), count: 1, color: '#0f0' },
+          { buf: new Float32Array([0, 0, 1, 1]), count: 1, color: '#f00' },
+        ],
+        0,
+      ),
+    ).toBe(false)
+  })
+
+  it('returns true when all counts are zero', () => {
+    const r = mockRenderer()
+    expect(
+      drawRectBatchesViaRenderer(r, [{ buf: new Float32Array(0), count: 0, color: '#0f0' }], 0),
+    ).toBe(true)
+    expect(r.drawInstances).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -111,11 +111,9 @@ export function createCandleRenderer(): RendererPlugin {
 
       const upColor = colors.candleUpBody
       const downColor = colors.candleDownBody
-      const webglOn = settings?.enableWebGLRendering !== false
-
       // sceneRenderer → fail-closed 2D
       let usedGpu = false
-      if (webglOn && context.sceneRenderer) {
+      if (context.sceneRenderer) {
         usedGpu = drawCandlesViaRenderer(
           context.sceneRenderer,
           prepared,

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -10,6 +10,7 @@ import {
 } from '../../foundation/utils/volumePrice'
 import type { MarkerManager } from '../marker/registry'
 import { getPhysicalKLineConfig } from '../utils/klineConfig'
+import { drawCandlesViaRenderer } from './candleViaRenderer'
 
 // --- Float32Array buffer pool (reduces per-frame GC pressure) ---
 let poolUpBody: Float32Array | null = null
@@ -108,22 +109,41 @@ export function createCandleRenderer(): RendererPlugin {
         settings,
       })
 
-      const usedWebGL = drawCandlesWithWebGL(
-        context,
-        prepared,
-        colors.candleUpBody,
-        colors.candleDownBody,
-      )
-      if (!usedWebGL) {
-        drawCandlesWithCanvas2D(
-          ctx,
-          scrollLeft,
+      const upColor = colors.candleUpBody
+      const downColor = colors.candleDownBody
+      const webglOn = settings?.enableWebGLRendering !== false
+
+      // Phase 1: 优先统一画笔；失败再 legacy surface；再 2D
+      let usedGpu = false
+      if (webglOn && context.sceneRenderer) {
+        usedGpu = drawCandlesViaRenderer(
+          context.sceneRenderer,
           prepared,
-          colors.candleUpBody,
-          colors.candleDownBody,
+          upColor,
+          downColor,
+          scrollLeft,
         )
-      } else {
-        compositeWebGLToMainCanvas(ctx, context)
+        if (usedGpu) {
+          const region = {
+            x: 0,
+            y: pane.top,
+            width: context.viewport?.plotWidth ?? context.paneWidth,
+            height: pane.height,
+            dpr,
+          }
+          context.sceneRenderer.surface.compositeTo(ctx, region, {
+            imageSmoothingEnabled: false,
+          })
+        }
+      }
+      if (!usedGpu && webglOn) {
+        usedGpu = drawCandlesWithWebGL(context, prepared, upColor, downColor)
+        if (usedGpu) {
+          compositeWebGLToMainCanvas(ctx, context)
+        }
+      }
+      if (!usedGpu) {
+        drawCandlesWithCanvas2D(ctx, scrollLeft, prepared, upColor, downColor)
       }
 
       drawVolumePriceMarkers(context, prepared, markerManager as MarkerManager | undefined)

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -113,7 +113,7 @@ export function createCandleRenderer(): RendererPlugin {
       const downColor = colors.candleDownBody
       const webglOn = settings?.enableWebGLRendering !== false
 
-      // Phase 1: 优先统一画笔；失败再 legacy surface；再 2D
+      // sceneRenderer → fail-closed 2D
       let usedGpu = false
       if (webglOn && context.sceneRenderer) {
         usedGpu = drawCandlesViaRenderer(
@@ -134,12 +134,6 @@ export function createCandleRenderer(): RendererPlugin {
           context.sceneRenderer.surface.compositeTo(ctx, region, {
             imageSmoothingEnabled: false,
           })
-        }
-      }
-      if (!usedGpu && webglOn) {
-        usedGpu = drawCandlesWithWebGL(context, prepared, upColor, downColor)
-        if (usedGpu) {
-          compositeWebGLToMainCanvas(ctx, context)
         }
       }
       if (!usedGpu) {
@@ -387,61 +381,6 @@ function drawCandlesWithCanvas2D(
   }
 
   ctx.restore()
-}
-
-function drawCandlesWithWebGL(
-  context: RenderContext,
-  prepared: PreparedCandles,
-  upColor: string,
-  downColor: string,
-): boolean {
-  if (context.settings?.enableWebGLRendering === false) return false
-  const surface = context.candleWebGLSurface
-  if (!surface || !surface.isAvailable()) return false
-
-  surface.clear()
-
-  const bodyUpOk =
-    prepared.upBodyCount === 0 ||
-    surface.drawRectBuffer(
-      prepared.upBodyBuf.subarray(0, prepared.upBodyCount * 4),
-      prepared.upBodyCount,
-      upColor,
-      context.scrollLeft,
-    )
-  const bodyDownOk =
-    prepared.downBodyCount === 0 ||
-    surface.drawRectBuffer(
-      prepared.downBodyBuf.subarray(0, prepared.downBodyCount * 4),
-      prepared.downBodyCount,
-      downColor,
-      context.scrollLeft,
-    )
-  const wickUpOk =
-    prepared.upWickCount === 0 ||
-    surface.drawRectBuffer(
-      prepared.upWickBuf.subarray(0, prepared.upWickCount * 4),
-      prepared.upWickCount,
-      upColor,
-      context.scrollLeft,
-    )
-  const wickDownOk =
-    prepared.downWickCount === 0 ||
-    surface.drawRectBuffer(
-      prepared.downWickBuf.subarray(0, prepared.downWickCount * 4),
-      prepared.downWickCount,
-      downColor,
-      context.scrollLeft,
-    )
-
-  return bodyUpOk && bodyDownOk && wickUpOk && wickDownOk
-}
-
-function compositeWebGLToMainCanvas(ctx: CanvasRenderingContext2D, context: RenderContext): void {
-  const surface = context.candleWebGLSurface
-  if (!surface) return
-
-  surface.compositeTo(ctx)
 }
 
 function drawVolumePriceMarkers(

--- a/packages/core/src/engine/renderers/candle.ts
+++ b/packages/core/src/engine/renderers/candle.ts
@@ -121,7 +121,7 @@ export function createCandleRenderer(): RendererPlugin {
           downColor,
           scrollLeft,
         )
-        if (usedGpu) {
+        if (usedGpu && context.sceneRenderer.caps.name !== 'webgpu') {
           const region = {
             x: 0,
             y: pane.top,

--- a/packages/core/src/engine/renderers/candleViaRenderer.ts
+++ b/packages/core/src/engine/renderers/candleViaRenderer.ts
@@ -1,4 +1,5 @@
 import type { Renderer } from '../../rendering/render/Renderer'
+import { drawRectBatchesViaRenderer } from './rectsViaRenderer'
 
 /** 与 prepareCandles 输出对齐的矩形 batch（仅 GPU 路径所需字段） */
 export type CandleRectBatch = {
@@ -24,42 +25,14 @@ export function drawCandlesViaRenderer(
   downColor: string,
   scrollLeft: number,
 ): boolean {
-  if (!renderer.surface.isAvailable()) return false
-
-  let pipeline: ReturnType<Renderer['createPipeline']> | null = null
-  let unit: ReturnType<Renderer['createBuffer']> | null = null
-
-  try {
-    pipeline = renderer.createPipeline({ type: 'candle' })
-    unit = renderer.createBuffer('vertex', 64)
-
-    const drawBatch = (buf: Float32Array, count: number, color: string): boolean => {
-      if (count <= 0) return true
-      const instances = renderer.createBuffer('instance', count * 4 * 4)
-      try {
-        renderer.writeBuffer(instances, buf.subarray(0, count * 4))
-        return renderer.drawInstances({
-          pipeline: pipeline!,
-          vertices: unit!,
-          instances,
-          instanceCount: count,
-          vertexCount: 6,
-          uniforms: { color, scrollLeft },
-        })
-      } finally {
-        renderer.destroyBuffer(instances)
-      }
-    }
-
-    if (!drawBatch(prepared.upBodyBuf, prepared.upBodyCount, upColor)) return false
-    if (!drawBatch(prepared.downBodyBuf, prepared.downBodyCount, downColor)) return false
-    if (!drawBatch(prepared.upWickBuf, prepared.upWickCount, upColor)) return false
-    if (!drawBatch(prepared.downWickBuf, prepared.downWickCount, downColor)) return false
-    return true
-  } catch {
-    return false
-  } finally {
-    if (unit) renderer.destroyBuffer(unit)
-    if (pipeline) renderer.destroyPipeline(pipeline)
-  }
+  return drawRectBatchesViaRenderer(
+    renderer,
+    [
+      { buf: prepared.upBodyBuf, count: prepared.upBodyCount, color: upColor },
+      { buf: prepared.downBodyBuf, count: prepared.downBodyCount, color: downColor },
+      { buf: prepared.upWickBuf, count: prepared.upWickCount, color: upColor },
+      { buf: prepared.downWickBuf, count: prepared.downWickCount, color: downColor },
+    ],
+    scrollLeft,
+  )
 }

--- a/packages/core/src/engine/renderers/candleViaRenderer.ts
+++ b/packages/core/src/engine/renderers/candleViaRenderer.ts
@@ -1,0 +1,65 @@
+import type { Renderer } from '../../rendering/render/Renderer'
+
+/** 与 prepareCandles 输出对齐的矩形 batch（仅 GPU 路径所需字段） */
+export type CandleRectBatch = {
+  upBodyCount: number
+  downBodyCount: number
+  upWickCount: number
+  downWickCount: number
+  upBodyBuf: Float32Array
+  downBodyBuf: Float32Array
+  upWickBuf: Float32Array
+  downWickBuf: Float32Array
+}
+
+/**
+ * 经 Renderer.drawInstances 画 body/wick。
+ * 任一非空 batch 绘制失败 → false（调用方应走 2D）。
+ * 不负责 composite。
+ */
+export function drawCandlesViaRenderer(
+  renderer: Renderer,
+  prepared: CandleRectBatch,
+  upColor: string,
+  downColor: string,
+  scrollLeft: number,
+): boolean {
+  if (!renderer.surface.isAvailable()) return false
+
+  let pipeline: ReturnType<Renderer['createPipeline']> | null = null
+  let unit: ReturnType<Renderer['createBuffer']> | null = null
+
+  try {
+    pipeline = renderer.createPipeline({ type: 'candle' })
+    unit = renderer.createBuffer('vertex', 64)
+
+    const drawBatch = (buf: Float32Array, count: number, color: string): boolean => {
+      if (count <= 0) return true
+      const instances = renderer.createBuffer('instance', count * 4 * 4)
+      try {
+        renderer.writeBuffer(instances, buf.subarray(0, count * 4))
+        return renderer.drawInstances({
+          pipeline: pipeline!,
+          vertices: unit!,
+          instances,
+          instanceCount: count,
+          vertexCount: 6,
+          uniforms: { color, scrollLeft },
+        })
+      } finally {
+        renderer.destroyBuffer(instances)
+      }
+    }
+
+    if (!drawBatch(prepared.upBodyBuf, prepared.upBodyCount, upColor)) return false
+    if (!drawBatch(prepared.downBodyBuf, prepared.downBodyCount, downColor)) return false
+    if (!drawBatch(prepared.upWickBuf, prepared.upWickCount, upColor)) return false
+    if (!drawBatch(prepared.downWickBuf, prepared.downWickCount, downColor)) return false
+    return true
+  } catch {
+    return false
+  } finally {
+    if (unit) renderer.destroyBuffer(unit)
+    if (pipeline) renderer.destroyPipeline(pipeline)
+  }
+}

--- a/packages/core/src/engine/renderers/linesViaRenderer.ts
+++ b/packages/core/src/engine/renderers/linesViaRenderer.ts
@@ -71,7 +71,7 @@ export function compositeSceneRenderer(context: {
 }
 
 /**
- * 折线 GPU 阶梯：sceneRenderer → legacy lineWebGLSurface → false（调用方 2D）。
+ * 折线 GPU：仅 sceneRenderer；失败返回 false（调用方 2D）。
  * 指标 draw 内：if (tryDrawLinesGpu(context, lines, scrollLeft)) return
  */
 export function tryDrawLinesGpu(
@@ -84,27 +84,10 @@ export function tryDrawLinesGpu(
   const drawable = lines.filter((l) => l.points.length >= 2)
   if (drawable.length === 0) return false
 
-  if (context.sceneRenderer) {
-    if (drawLinesViaRenderer(context.sceneRenderer, drawable, scrollLeft)) {
-      compositeSceneRenderer(context)
-      return true
-    }
-  }
-
-  const surface = context.lineWebGLSurface
-  if (surface?.isAvailable()) {
-    const ok = surface.drawLineStrips(
-      drawable.map((l) => ({
-        points: l.points,
-        color: l.color,
-        width: l.width ?? 1,
-      })),
-      scrollLeft,
-    )
-    if (ok) {
-      surface.compositeTo(context.ctx, { imageSmoothingEnabled: false })
-      return true
-    }
+  if (!context.sceneRenderer) return false
+  if (drawLinesViaRenderer(context.sceneRenderer, drawable, scrollLeft)) {
+    compositeSceneRenderer(context)
+    return true
   }
   return false
 }
@@ -154,7 +137,7 @@ export function drawFilledBandViaRenderer(
 }
 
 /**
- * 填充带 GPU 阶梯：sceneRenderer fill → legacy drawFilledBand → false。
+ * 填充带 GPU：仅 sceneRenderer fill；失败返回 false。
  * @param alpha composite 时的全局透明度（半透明 bandFill）
  */
 export function tryDrawFilledBandGpu(
@@ -169,46 +152,29 @@ export function tryDrawFilledBandGpu(
   if (!enableWebGL) return false
   if (Math.min(upperPoints.length, lowerPoints.length) < 2) return false
 
-  if (context.sceneRenderer) {
-    if (
-      drawFilledBandViaRenderer(
-        context.sceneRenderer,
-        upperPoints,
-        lowerPoints,
-        color,
-        scrollLeft,
-      )
-    ) {
-      const r = context.sceneRenderer
-      r.surface.compositeTo(
-        context.ctx,
-        {
-          x: 0,
-          y: context.pane.top,
-          width: context.viewport?.plotWidth ?? context.paneWidth,
-          height: context.pane.height,
-          dpr: context.dpr,
-        },
-        { imageSmoothingEnabled: false, alpha },
-      )
-      return true
-    }
-  }
-
-  const surface = context.lineWebGLSurface
-  if (surface?.isAvailable()) {
-    const ok = surface.drawFilledBand(
-      {
-        upperPoints: upperPoints.map((p) => ({ x: p.x, y: p.y })),
-        lowerPoints: lowerPoints.map((p) => ({ x: p.x, y: p.y })),
-      },
+  if (!context.sceneRenderer) return false
+  if (
+    drawFilledBandViaRenderer(
+      context.sceneRenderer,
+      upperPoints,
+      lowerPoints,
       color,
       scrollLeft,
     )
-    if (ok) {
-      surface.compositeTo(context.ctx, { imageSmoothingEnabled: false, alpha })
-      return true
-    }
+  ) {
+    const r = context.sceneRenderer
+    r.surface.compositeTo(
+      context.ctx,
+      {
+        x: 0,
+        y: context.pane.top,
+        width: context.viewport?.plotWidth ?? context.paneWidth,
+        height: context.pane.height,
+        dpr: context.dpr,
+      },
+      { imageSmoothingEnabled: false, alpha },
+    )
+    return true
   }
   return false
 }

--- a/packages/core/src/engine/renderers/linesViaRenderer.ts
+++ b/packages/core/src/engine/renderers/linesViaRenderer.ts
@@ -54,10 +54,15 @@ export function drawLinesViaRenderer(
   }
 }
 
+/** WebGPU 走可见 DOM canvas，禁止 drawImage 回 2D（M2 hybrid） */
+export function shouldCompositeSceneRenderer(renderer: Renderer): boolean {
+  return renderer.caps.name !== 'webgpu'
+}
+
 /**
  * 将 sceneRenderer 输出合成到主 canvas。
- * 注意：candle 与 line 共用 SharedWebGLSurface；MSAA resolve 会覆盖 shared 上前序 GPU 内容，
- * 因此各业务在本层 GPU 画完后应立即 composite 到 2D（先 candle 后 line），不能只 end-of-pane 合成一次。
+ * WebGL：即时 composite（MSAA resolve 会盖掉 shared 上前序内容，须按层立即合成）。
+ * WebGPU：no-op，由 plot 区可见 GPU canvas 直接显示。
  */
 export function compositeSceneRenderer(context: {
   ctx: CanvasRenderingContext2D
@@ -68,7 +73,7 @@ export function compositeSceneRenderer(context: {
   sceneRenderer?: Renderer
 }): void {
   const r = context.sceneRenderer
-  if (!r) return
+  if (!r || !shouldCompositeSceneRenderer(r)) return
   r.surface.compositeTo(
     context.ctx,
     {
@@ -167,9 +172,26 @@ export function drawFilledBandViaRenderer(
   }
 }
 
+/** 将全局 alpha 烘焙进 rgba 颜色串（WebGPU 无 compositeTo 时用） */
+function bakeAlphaIntoColor(color: string, alpha: number): string {
+  if (!(alpha < 1)) return color
+  const a = Math.max(0, Math.min(1, alpha))
+  const rgba = color.match(/^rgba?\(([^)]+)\)$/i)
+  if (rgba) {
+    const parts = rgba[1]!.split(',').map((p) => p.trim())
+    if (parts.length >= 3) {
+      const baseA = parts.length >= 4 ? Number(parts[3]) : 1
+      const nextA = (Number.isFinite(baseA) ? baseA : 1) * a
+      return `rgba(${parts[0]}, ${parts[1]}, ${parts[2]}, ${nextA})`
+    }
+  }
+  return color
+}
+
 /**
  * 填充带 GPU：仅 sceneRenderer fill；失败返回 false。
  * @param alpha composite 时的全局透明度（半透明 bandFill）
+ * @remarks WebGL 走 compositeTo(alpha)；WebGPU hybrid 把 alpha 烘焙进 fill color
  */
 export function tryDrawFilledBandGpu(
   context: RenderContext,
@@ -182,27 +204,22 @@ export function tryDrawFilledBandGpu(
   if (Math.min(upperPoints.length, lowerPoints.length) < 2) return false
 
   if (!context.sceneRenderer) return false
-  if (
-    drawFilledBandViaRenderer(
-      context.sceneRenderer,
-      upperPoints,
-      lowerPoints,
-      color,
-      scrollLeft,
-    )
-  ) {
-    const r = context.sceneRenderer
-    r.surface.compositeTo(
-      context.ctx,
-      {
-        x: 0,
-        y: context.pane.top,
-        width: context.viewport?.plotWidth ?? context.paneWidth,
-        height: context.pane.height,
-        dpr: context.dpr,
-      },
-      { imageSmoothingEnabled: false, alpha },
-    )
+  const r = context.sceneRenderer
+  const fillColor = shouldCompositeSceneRenderer(r) ? color : bakeAlphaIntoColor(color, alpha)
+  if (drawFilledBandViaRenderer(r, upperPoints, lowerPoints, fillColor, scrollLeft)) {
+    if (shouldCompositeSceneRenderer(r)) {
+      r.surface.compositeTo(
+        context.ctx,
+        {
+          x: 0,
+          y: context.pane.top,
+          width: context.viewport?.plotWidth ?? context.paneWidth,
+          height: context.pane.height,
+          dpr: context.dpr,
+        },
+        { imageSmoothingEnabled: false, alpha },
+      )
+    }
     return true
   }
   return false

--- a/packages/core/src/engine/renderers/linesViaRenderer.ts
+++ b/packages/core/src/engine/renderers/linesViaRenderer.ts
@@ -79,8 +79,6 @@ export function tryDrawLinesGpu(
   lines: ReadonlyArray<ColoredLineStrip>,
   scrollLeft: number,
 ): boolean {
-  const enableWebGL = context.settings?.enableWebGLRendering !== false
-  if (!enableWebGL) return false
   const drawable = lines.filter((l) => l.points.length >= 2)
   if (drawable.length === 0) return false
 
@@ -148,8 +146,6 @@ export function tryDrawFilledBandGpu(
   scrollLeft: number,
   alpha = 1,
 ): boolean {
-  const enableWebGL = context.settings?.enableWebGLRendering !== false
-  if (!enableWebGL) return false
   if (Math.min(upperPoints.length, lowerPoints.length) < 2) return false
 
   if (!context.sceneRenderer) return false

--- a/packages/core/src/engine/renderers/linesViaRenderer.ts
+++ b/packages/core/src/engine/renderers/linesViaRenderer.ts
@@ -108,3 +108,107 @@ export function tryDrawLinesGpu(
   }
   return false
 }
+
+/**
+ * 经 Renderer fill pipeline 画上下轨填充带（BOLL/ENE）。
+ * 顶点布局与 createWebGLRenderer fill 一致：每点 upper.x,y + lower.x,y。
+ */
+export function drawFilledBandViaRenderer(
+  renderer: Renderer,
+  upperPoints: ReadonlyArray<LinePoint>,
+  lowerPoints: ReadonlyArray<LinePoint>,
+  color: string,
+  scrollLeft: number,
+): boolean {
+  if (!renderer.surface.isAvailable()) return false
+  const n = Math.min(upperPoints.length, lowerPoints.length)
+  if (n < 2) return false
+
+  let pipeline: ReturnType<Renderer['createPipeline']> | null = null
+  let vertices: ReturnType<Renderer['createBuffer']> | null = null
+  try {
+    pipeline = renderer.createPipeline({ type: 'fill' })
+    // vertexCount = n*2（上轨 n + 下轨 n 交错为 n 组 4 floats）
+    const floats = new Float32Array(n * 4)
+    for (let i = 0; i < n; i++) {
+      const o = i * 4
+      floats[o] = upperPoints[i]!.x
+      floats[o + 1] = upperPoints[i]!.y
+      floats[o + 2] = lowerPoints[i]!.x
+      floats[o + 3] = lowerPoints[i]!.y
+    }
+    vertices = renderer.createBuffer('vertex', floats.byteLength)
+    renderer.writeBuffer(vertices, floats)
+    return renderer.drawLines({
+      pipeline,
+      vertices,
+      vertexCount: n * 2,
+      uniforms: { color, scrollLeft },
+    })
+  } catch {
+    return false
+  } finally {
+    if (vertices) renderer.destroyBuffer(vertices)
+    if (pipeline) renderer.destroyPipeline(pipeline)
+  }
+}
+
+/**
+ * 填充带 GPU 阶梯：sceneRenderer fill → legacy drawFilledBand → false。
+ * @param alpha composite 时的全局透明度（半透明 bandFill）
+ */
+export function tryDrawFilledBandGpu(
+  context: RenderContext,
+  upperPoints: ReadonlyArray<LinePoint>,
+  lowerPoints: ReadonlyArray<LinePoint>,
+  color: string,
+  scrollLeft: number,
+  alpha = 1,
+): boolean {
+  const enableWebGL = context.settings?.enableWebGLRendering !== false
+  if (!enableWebGL) return false
+  if (Math.min(upperPoints.length, lowerPoints.length) < 2) return false
+
+  if (context.sceneRenderer) {
+    if (
+      drawFilledBandViaRenderer(
+        context.sceneRenderer,
+        upperPoints,
+        lowerPoints,
+        color,
+        scrollLeft,
+      )
+    ) {
+      const r = context.sceneRenderer
+      r.surface.compositeTo(
+        context.ctx,
+        {
+          x: 0,
+          y: context.pane.top,
+          width: context.viewport?.plotWidth ?? context.paneWidth,
+          height: context.pane.height,
+          dpr: context.dpr,
+        },
+        { imageSmoothingEnabled: false, alpha },
+      )
+      return true
+    }
+  }
+
+  const surface = context.lineWebGLSurface
+  if (surface?.isAvailable()) {
+    const ok = surface.drawFilledBand(
+      {
+        upperPoints: upperPoints.map((p) => ({ x: p.x, y: p.y })),
+        lowerPoints: lowerPoints.map((p) => ({ x: p.x, y: p.y })),
+      },
+      color,
+      scrollLeft,
+    )
+    if (ok) {
+      surface.compositeTo(context.ctx, { imageSmoothingEnabled: false, alpha })
+      return true
+    }
+  }
+  return false
+}

--- a/packages/core/src/engine/renderers/linesViaRenderer.ts
+++ b/packages/core/src/engine/renderers/linesViaRenderer.ts
@@ -9,10 +9,25 @@ export type ColoredLineStrip = {
   width?: number
 }
 
+type LineGpuCache = {
+  pipeline: ReturnType<Renderer['createPipeline']>
+}
+
+const lineCacheByRenderer = new WeakMap<Renderer, LineGpuCache>()
+
+function ensureLineCache(renderer: Renderer): LineGpuCache {
+  let cache = lineCacheByRenderer.get(renderer)
+  if (!cache) {
+    cache = { pipeline: renderer.createPipeline({ type: 'line' }) }
+    lineCacheByRenderer.set(renderer, cache)
+  }
+  return cache
+}
+
 /**
  * 经 Renderer.drawLines 一次提交多条折线（strips 批量）。
  * 禁止 per-strip 循环 drawLines：LineWebGLSurface MSAA 每次 clear 会盖掉前一条。
- * 不负责 composite。
+ * 不负责 composite。pipeline 按 renderer 缓存。
  */
 export function drawLinesViaRenderer(
   renderer: Renderer,
@@ -23,11 +38,10 @@ export function drawLinesViaRenderer(
   const drawable = lines.filter((l) => l.points.length >= 2)
   if (drawable.length === 0) return true
 
-  let pipeline: ReturnType<Renderer['createPipeline']> | null = null
   try {
-    pipeline = renderer.createPipeline({ type: 'line' })
+    const cache = ensureLineCache(renderer)
     return renderer.drawLines({
-      pipeline,
+      pipeline: cache.pipeline,
       strips: drawable.map((l) => ({
         points: l.points,
         color: l.color,
@@ -37,8 +51,6 @@ export function drawLinesViaRenderer(
     })
   } catch {
     return false
-  } finally {
-    if (pipeline) renderer.destroyPipeline(pipeline)
   }
 }
 
@@ -90,9 +102,31 @@ export function tryDrawLinesGpu(
   return false
 }
 
+type FillGpuCache = {
+  pipeline: ReturnType<Renderer['createPipeline']>
+  vertices: ReturnType<Renderer['createBuffer']> | null
+  capacity: number
+}
+
+const fillCacheByRenderer = new WeakMap<Renderer, FillGpuCache>()
+
+function ensureFillCache(renderer: Renderer): FillGpuCache {
+  let cache = fillCacheByRenderer.get(renderer)
+  if (!cache) {
+    cache = {
+      pipeline: renderer.createPipeline({ type: 'fill' }),
+      vertices: null,
+      capacity: 0,
+    }
+    fillCacheByRenderer.set(renderer, cache)
+  }
+  return cache
+}
+
 /**
  * 经 Renderer fill pipeline 画上下轨填充带（BOLL/ENE）。
  * 顶点布局与 createWebGLRenderer fill 一致：每点 upper.x,y + lower.x,y。
+ * vertex buffer 按 renderer 缓存扩容，不每帧 destroy。
  */
 export function drawFilledBandViaRenderer(
   renderer: Renderer,
@@ -105,10 +139,8 @@ export function drawFilledBandViaRenderer(
   const n = Math.min(upperPoints.length, lowerPoints.length)
   if (n < 2) return false
 
-  let pipeline: ReturnType<Renderer['createPipeline']> | null = null
-  let vertices: ReturnType<Renderer['createBuffer']> | null = null
   try {
-    pipeline = renderer.createPipeline({ type: 'fill' })
+    const cache = ensureFillCache(renderer)
     // vertexCount = n*2（上轨 n + 下轨 n 交错为 n 组 4 floats）
     const floats = new Float32Array(n * 4)
     for (let i = 0; i < n; i++) {
@@ -118,19 +150,20 @@ export function drawFilledBandViaRenderer(
       floats[o + 2] = lowerPoints[i]!.x
       floats[o + 3] = lowerPoints[i]!.y
     }
-    vertices = renderer.createBuffer('vertex', floats.byteLength)
-    renderer.writeBuffer(vertices, floats)
+    if (!cache.vertices || cache.capacity < floats.byteLength) {
+      if (cache.vertices) renderer.destroyBuffer(cache.vertices)
+      cache.vertices = renderer.createBuffer('vertex', floats.byteLength)
+      cache.capacity = floats.byteLength
+    }
+    renderer.writeBuffer(cache.vertices, floats)
     return renderer.drawLines({
-      pipeline,
-      vertices,
+      pipeline: cache.pipeline,
+      vertices: cache.vertices,
       vertexCount: n * 2,
       uniforms: { color, scrollLeft },
     })
   } catch {
     return false
-  } finally {
-    if (vertices) renderer.destroyBuffer(vertices)
-    if (pipeline) renderer.destroyPipeline(pipeline)
   }
 }
 

--- a/packages/core/src/engine/renderers/linesViaRenderer.ts
+++ b/packages/core/src/engine/renderers/linesViaRenderer.ts
@@ -1,0 +1,110 @@
+import type { RenderContext } from '../../foundation/plugin/index'
+import type { Renderer } from '../../rendering/render/Renderer'
+
+export type LinePoint = { x: number; y: number }
+
+export type ColoredLineStrip = {
+  points: LinePoint[]
+  color: string
+  width?: number
+}
+
+/**
+ * 经 Renderer.drawLines 一次提交多条折线（strips 批量）。
+ * 禁止 per-strip 循环 drawLines：LineWebGLSurface MSAA 每次 clear 会盖掉前一条。
+ * 不负责 composite。
+ */
+export function drawLinesViaRenderer(
+  renderer: Renderer,
+  lines: ReadonlyArray<ColoredLineStrip>,
+  scrollLeft: number,
+): boolean {
+  if (!renderer.surface.isAvailable()) return false
+  const drawable = lines.filter((l) => l.points.length >= 2)
+  if (drawable.length === 0) return true
+
+  let pipeline: ReturnType<Renderer['createPipeline']> | null = null
+  try {
+    pipeline = renderer.createPipeline({ type: 'line' })
+    return renderer.drawLines({
+      pipeline,
+      strips: drawable.map((l) => ({
+        points: l.points,
+        color: l.color,
+        width: l.width ?? 1,
+      })),
+      uniforms: { scrollLeft },
+    })
+  } catch {
+    return false
+  } finally {
+    if (pipeline) renderer.destroyPipeline(pipeline)
+  }
+}
+
+/**
+ * 将 sceneRenderer 输出合成到主 canvas。
+ * 注意：candle 与 line 共用 SharedWebGLSurface；MSAA resolve 会覆盖 shared 上前序 GPU 内容，
+ * 因此各业务在本层 GPU 画完后应立即 composite 到 2D（先 candle 后 line），不能只 end-of-pane 合成一次。
+ */
+export function compositeSceneRenderer(context: {
+  ctx: CanvasRenderingContext2D
+  pane: { top: number; height: number }
+  viewport?: { plotWidth: number }
+  paneWidth: number
+  dpr: number
+  sceneRenderer?: Renderer
+}): void {
+  const r = context.sceneRenderer
+  if (!r) return
+  r.surface.compositeTo(
+    context.ctx,
+    {
+      x: 0,
+      y: context.pane.top,
+      width: context.viewport?.plotWidth ?? context.paneWidth,
+      height: context.pane.height,
+      dpr: context.dpr,
+    },
+    { imageSmoothingEnabled: false },
+  )
+}
+
+/**
+ * 折线 GPU 阶梯：sceneRenderer → legacy lineWebGLSurface → false（调用方 2D）。
+ * 指标 draw 内：if (tryDrawLinesGpu(context, lines, scrollLeft)) return
+ */
+export function tryDrawLinesGpu(
+  context: RenderContext,
+  lines: ReadonlyArray<ColoredLineStrip>,
+  scrollLeft: number,
+): boolean {
+  const enableWebGL = context.settings?.enableWebGLRendering !== false
+  if (!enableWebGL) return false
+  const drawable = lines.filter((l) => l.points.length >= 2)
+  if (drawable.length === 0) return false
+
+  if (context.sceneRenderer) {
+    if (drawLinesViaRenderer(context.sceneRenderer, drawable, scrollLeft)) {
+      compositeSceneRenderer(context)
+      return true
+    }
+  }
+
+  const surface = context.lineWebGLSurface
+  if (surface?.isAvailable()) {
+    const ok = surface.drawLineStrips(
+      drawable.map((l) => ({
+        points: l.points,
+        color: l.color,
+        width: l.width ?? 1,
+      })),
+      scrollLeft,
+    )
+    if (ok) {
+      surface.compositeTo(context.ctx, { imageSmoothingEnabled: false })
+      return true
+    }
+  }
+  return false
+}

--- a/packages/core/src/engine/renderers/rectsViaRenderer.ts
+++ b/packages/core/src/engine/renderers/rectsViaRenderer.ts
@@ -1,0 +1,95 @@
+import type { RenderContext } from '../../foundation/plugin/index'
+import type { Renderer } from '../../rendering/render/Renderer'
+import { compositeSceneRenderer } from './linesViaRenderer'
+
+export type RectBatch = {
+  buf: Float32Array
+  count: number
+  color: string
+}
+
+/**
+ * 经 Renderer.drawInstances 画多组矩形（volume / MACD bar / candle 共用）。
+ * 任一非空 batch 失败 → false。不负责 composite。
+ */
+export function drawRectBatchesViaRenderer(
+  renderer: Renderer,
+  batches: ReadonlyArray<RectBatch>,
+  scrollLeft: number,
+): boolean {
+  if (!renderer.surface.isAvailable()) return false
+
+  let pipeline: ReturnType<Renderer['createPipeline']> | null = null
+  let unit: ReturnType<Renderer['createBuffer']> | null = null
+
+  try {
+    pipeline = renderer.createPipeline({ type: 'candle' })
+    unit = renderer.createBuffer('vertex', 64)
+
+    for (const batch of batches) {
+      if (batch.count <= 0) continue
+      const instances = renderer.createBuffer('instance', batch.count * 4 * 4)
+      try {
+        renderer.writeBuffer(instances, batch.buf.subarray(0, batch.count * 4))
+        const ok = renderer.drawInstances({
+          pipeline,
+          vertices: unit,
+          instances,
+          instanceCount: batch.count,
+          vertexCount: 6,
+          uniforms: { color: batch.color, scrollLeft },
+        })
+        if (!ok) return false
+      } finally {
+        renderer.destroyBuffer(instances)
+      }
+    }
+    return true
+  } catch {
+    return false
+  } finally {
+    if (unit) renderer.destroyBuffer(unit)
+    if (pipeline) renderer.destroyPipeline(pipeline)
+  }
+}
+
+/**
+ * 矩形 GPU 阶梯：sceneRenderer → legacy candleWebGLSurface → false。
+ */
+export function tryDrawRectsGpu(
+  context: RenderContext,
+  batches: ReadonlyArray<RectBatch>,
+  scrollLeft: number,
+): boolean {
+  const enableWebGL = context.settings?.enableWebGLRendering !== false
+  if (!enableWebGL) return false
+  const active = batches.filter((b) => b.count > 0)
+  if (active.length === 0) return true
+
+  if (context.sceneRenderer) {
+    if (drawRectBatchesViaRenderer(context.sceneRenderer, active, scrollLeft)) {
+      compositeSceneRenderer(context)
+      return true
+    }
+  }
+
+  const surface = context.candleWebGLSurface
+  if (surface?.isAvailable()) {
+    surface.clear()
+    for (const batch of active) {
+      const ok = surface.drawRectBuffer(
+        batch.buf.subarray(0, batch.count * 4),
+        batch.count,
+        batch.color,
+        scrollLeft,
+      )
+      if (!ok) {
+        surface.clear()
+        return false
+      }
+    }
+    surface.compositeTo(context.ctx)
+    return true
+  }
+  return false
+}

--- a/packages/core/src/engine/renderers/rectsViaRenderer.ts
+++ b/packages/core/src/engine/renderers/rectsViaRenderer.ts
@@ -61,8 +61,6 @@ export function tryDrawRectsGpu(
   batches: ReadonlyArray<RectBatch>,
   scrollLeft: number,
 ): boolean {
-  const enableWebGL = context.settings?.enableWebGLRendering !== false
-  if (!enableWebGL) return false
   const active = batches.filter((b) => b.count > 0)
   if (active.length === 0) return true
 

--- a/packages/core/src/engine/renderers/rectsViaRenderer.ts
+++ b/packages/core/src/engine/renderers/rectsViaRenderer.ts
@@ -11,8 +11,6 @@ export type RectBatch = {
 type RectGpuCache = {
   pipeline: PipelineHandle
   unit: BufferHandle
-  instances: BufferHandle[]
-  instanceCapacities: number[]
 }
 
 const rectCacheByRenderer = new WeakMap<Renderer, RectGpuCache>()
@@ -23,34 +21,16 @@ function ensureRectCache(renderer: Renderer): RectGpuCache {
     cache = {
       pipeline: renderer.createPipeline({ type: 'candle' }),
       unit: renderer.createBuffer('vertex', 64),
-      instances: [],
-      instanceCapacities: [],
     }
     rectCacheByRenderer.set(renderer, cache)
   }
   return cache
 }
 
-function ensureInstanceBuffer(
-  renderer: Renderer,
-  cache: RectGpuCache,
-  slot: number,
-  byteLength: number,
-): BufferHandle {
-  const existing = cache.instances[slot]
-  const capacity = cache.instanceCapacities[slot] ?? 0
-  if (existing && capacity >= byteLength) return existing
-  if (existing) renderer.destroyBuffer(existing)
-  const handle = renderer.createBuffer('instance', byteLength)
-  cache.instances[slot] = handle
-  cache.instanceCapacities[slot] = byteLength
-  return handle
-}
-
 /**
  * 经 Renderer.drawInstances 画多组矩形（volume / MACD bar / candle 共用）。
  * 任一非空 batch 失败 → false。不负责 composite。
- * instance buffer 按 renderer 缓存，跨帧复用。
+ * instance buffer 每 batch 独立创建，避免同 frame 内不同绘制目标互相覆盖。
  */
 export function drawRectBatchesViaRenderer(
   renderer: Renderer,
@@ -61,12 +41,10 @@ export function drawRectBatchesViaRenderer(
 
   try {
     const cache = ensureRectCache(renderer)
-    let slot = 0
     for (const batch of batches) {
       if (batch.count <= 0) continue
       const byteLength = batch.count * 4 * 4
-      const instances = ensureInstanceBuffer(renderer, cache, slot, byteLength)
-      slot += 1
+      const instances = renderer.createBuffer('instance', byteLength)
       renderer.writeBuffer(instances, batch.buf.subarray(0, batch.count * 4))
       const ok = renderer.drawInstances({
         pipeline: cache.pipeline,
@@ -76,6 +54,7 @@ export function drawRectBatchesViaRenderer(
         vertexCount: 6,
         uniforms: { color: batch.color, scrollLeft },
       })
+      renderer.destroyBuffer(instances)
       if (!ok) return false
     }
     return true

--- a/packages/core/src/engine/renderers/rectsViaRenderer.ts
+++ b/packages/core/src/engine/renderers/rectsViaRenderer.ts
@@ -1,5 +1,5 @@
 import type { RenderContext } from '../../foundation/plugin/index'
-import type { Renderer } from '../../rendering/render/Renderer'
+import type { BufferHandle, PipelineHandle, Renderer } from '../../rendering/render/Renderer'
 import { compositeSceneRenderer } from './linesViaRenderer'
 
 export type RectBatch = {
@@ -8,9 +8,49 @@ export type RectBatch = {
   color: string
 }
 
+type RectGpuCache = {
+  pipeline: PipelineHandle
+  unit: BufferHandle
+  instances: BufferHandle[]
+  instanceCapacities: number[]
+}
+
+const rectCacheByRenderer = new WeakMap<Renderer, RectGpuCache>()
+
+function ensureRectCache(renderer: Renderer): RectGpuCache {
+  let cache = rectCacheByRenderer.get(renderer)
+  if (!cache) {
+    cache = {
+      pipeline: renderer.createPipeline({ type: 'candle' }),
+      unit: renderer.createBuffer('vertex', 64),
+      instances: [],
+      instanceCapacities: [],
+    }
+    rectCacheByRenderer.set(renderer, cache)
+  }
+  return cache
+}
+
+function ensureInstanceBuffer(
+  renderer: Renderer,
+  cache: RectGpuCache,
+  slot: number,
+  byteLength: number,
+): BufferHandle {
+  const existing = cache.instances[slot]
+  const capacity = cache.instanceCapacities[slot] ?? 0
+  if (existing && capacity >= byteLength) return existing
+  if (existing) renderer.destroyBuffer(existing)
+  const handle = renderer.createBuffer('instance', byteLength)
+  cache.instances[slot] = handle
+  cache.instanceCapacities[slot] = byteLength
+  return handle
+}
+
 /**
  * 经 Renderer.drawInstances 画多组矩形（volume / MACD bar / candle 共用）。
  * 任一非空 batch 失败 → false。不负责 composite。
+ * instance buffer 按 renderer 缓存，跨帧复用。
  */
 export function drawRectBatchesViaRenderer(
   renderer: Renderer,
@@ -19,37 +59,28 @@ export function drawRectBatchesViaRenderer(
 ): boolean {
   if (!renderer.surface.isAvailable()) return false
 
-  let pipeline: ReturnType<Renderer['createPipeline']> | null = null
-  let unit: ReturnType<Renderer['createBuffer']> | null = null
-
   try {
-    pipeline = renderer.createPipeline({ type: 'candle' })
-    unit = renderer.createBuffer('vertex', 64)
-
+    const cache = ensureRectCache(renderer)
+    let slot = 0
     for (const batch of batches) {
       if (batch.count <= 0) continue
-      const instances = renderer.createBuffer('instance', batch.count * 4 * 4)
-      try {
-        renderer.writeBuffer(instances, batch.buf.subarray(0, batch.count * 4))
-        const ok = renderer.drawInstances({
-          pipeline,
-          vertices: unit,
-          instances,
-          instanceCount: batch.count,
-          vertexCount: 6,
-          uniforms: { color: batch.color, scrollLeft },
-        })
-        if (!ok) return false
-      } finally {
-        renderer.destroyBuffer(instances)
-      }
+      const byteLength = batch.count * 4 * 4
+      const instances = ensureInstanceBuffer(renderer, cache, slot, byteLength)
+      slot += 1
+      renderer.writeBuffer(instances, batch.buf.subarray(0, batch.count * 4))
+      const ok = renderer.drawInstances({
+        pipeline: cache.pipeline,
+        vertices: cache.unit,
+        instances,
+        instanceCount: batch.count,
+        vertexCount: 6,
+        uniforms: { color: batch.color, scrollLeft },
+      })
+      if (!ok) return false
     }
     return true
   } catch {
     return false
-  } finally {
-    if (unit) renderer.destroyBuffer(unit)
-    if (pipeline) renderer.destroyPipeline(pipeline)
   }
 }
 

--- a/packages/core/src/engine/renderers/rectsViaRenderer.ts
+++ b/packages/core/src/engine/renderers/rectsViaRenderer.ts
@@ -54,7 +54,7 @@ export function drawRectBatchesViaRenderer(
 }
 
 /**
- * 矩形 GPU 阶梯：sceneRenderer → legacy candleWebGLSurface → false。
+ * 矩形 GPU：仅 sceneRenderer；失败返回 false。
  */
 export function tryDrawRectsGpu(
   context: RenderContext,
@@ -66,29 +66,9 @@ export function tryDrawRectsGpu(
   const active = batches.filter((b) => b.count > 0)
   if (active.length === 0) return true
 
-  if (context.sceneRenderer) {
-    if (drawRectBatchesViaRenderer(context.sceneRenderer, active, scrollLeft)) {
-      compositeSceneRenderer(context)
-      return true
-    }
-  }
-
-  const surface = context.candleWebGLSurface
-  if (surface?.isAvailable()) {
-    surface.clear()
-    for (const batch of active) {
-      const ok = surface.drawRectBuffer(
-        batch.buf.subarray(0, batch.count * 4),
-        batch.count,
-        batch.color,
-        scrollLeft,
-      )
-      if (!ok) {
-        surface.clear()
-        return false
-      }
-    }
-    surface.compositeTo(context.ctx)
+  if (!context.sceneRenderer) return false
+  if (drawRectBatchesViaRenderer(context.sceneRenderer, active, scrollLeft)) {
+    compositeSceneRenderer(context)
     return true
   }
   return false

--- a/packages/core/src/engine/renderers/subVolume.ts
+++ b/packages/core/src/engine/renderers/subVolume.ts
@@ -13,6 +13,7 @@ import { resolveStateKey } from '../indicators/indicatorMetadata'
 import type { IndicatorScheduler } from '../indicators/scheduler'
 
 import { createVolumeScaleRendererPlugin } from './Indicator/scale/volume_scale'
+import { tryDrawRectsGpu } from './rectsViaRenderer'
 
 interface VolumeRendererOptions {
   /** 目标 pane ID（默认 'sub'） */
@@ -164,19 +165,16 @@ function createVolumeRendererPlugin(options: VolumeRendererOptions = {}): Render
         buf[off + 3] = finalH
       }
 
-      const usedWebGL = drawVolumeWithWebGL(
+      const usedGpu = tryDrawRectsGpu(
         context,
-        upBuf,
-        upCount,
-        downBuf,
-        downCount,
-        neutralBuf,
-        neutralCount,
-        upVolume,
-        downVolume,
-        neutralVolume,
+        [
+          { buf: upBuf, count: upCount, color: upVolume },
+          { buf: downBuf, count: downCount, color: downVolume },
+          { buf: neutralBuf, count: neutralCount, color: neutralVolume },
+        ],
+        context.scrollLeft,
       )
-      if (!usedWebGL) {
+      if (!usedGpu) {
         drawVolumeWithCanvas2D(
           ctx,
           context.scrollLeft,
@@ -190,52 +188,9 @@ function createVolumeRendererPlugin(options: VolumeRendererOptions = {}): Render
           downVolume,
           neutralVolume,
         )
-      } else {
-        compositeVolumeWebGL(ctx, context)
       }
     },
   }
-}
-
-function drawVolumeWithWebGL(
-  context: RenderContext,
-  upBuf: Float32Array,
-  upCount: number,
-  downBuf: Float32Array,
-  downCount: number,
-  neutralBuf: Float32Array,
-  neutralCount: number,
-  upColor: string,
-  downColor: string,
-  neutralColor: string,
-): boolean {
-  if (context.settings?.enableWebGLRendering === false) return false
-  const surface = context.candleWebGLSurface
-  if (!surface || !surface.isAvailable()) return false
-
-  surface.clear()
-
-  const ok1 =
-    upCount === 0 ||
-    surface.drawRectBuffer(upBuf.subarray(0, upCount * 4), upCount, upColor, context.scrollLeft)
-  const ok2 =
-    downCount === 0 ||
-    surface.drawRectBuffer(
-      downBuf.subarray(0, downCount * 4),
-      downCount,
-      downColor,
-      context.scrollLeft,
-    )
-  const ok3 =
-    neutralCount === 0 ||
-    surface.drawRectBuffer(
-      neutralBuf.subarray(0, neutralCount * 4),
-      neutralCount,
-      neutralColor,
-      context.scrollLeft,
-    )
-
-  return ok1 && ok2 && ok3
 }
 
 function drawVolumeWithCanvas2D(
@@ -273,13 +228,6 @@ function drawVolumeWithCanvas2D(
   }
 
   ctx.restore()
-}
-
-function compositeVolumeWebGL(ctx: CanvasRenderingContext2D, context: RenderContext): void {
-  const surface = context.candleWebGLSurface
-  if (!surface) return
-
-  surface.compositeTo(ctx)
 }
 
 /**

--- a/packages/core/src/engine/renderers/timeAxis.ts
+++ b/packages/core/src/engine/renderers/timeAxis.ts
@@ -26,7 +26,7 @@ export function createTimeAxisRendererPlugin(options: {
     debugName: '时间轴',
     paneId: TIME_AXIS_PANE_ID,
     priority: RENDERER_PRIORITY.SYSTEM_XAXIS,
-    isSystem: true, // 系统渲染器，只能通过 renderPlugin 单独渲染
+    isSystem: true, // 系统渲染器：由 Scene Layer 调度
 
     draw(context: RenderContext) {
       const { ctx, data, range, scrollLeft, kWidth, kGap, dpr, paneWidth } = context

--- a/packages/core/src/engine/state/__tests__/rendererState.test.ts
+++ b/packages/core/src/engine/state/__tests__/rendererState.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createRendererState } from '../rendererState'
+
+describe('rendererState', () => {
+  it('publishes immutable backend runtime snapshots through an Action', () => {
+    const state = createRendererState({ effective: 'webgl', status: 'ready', error: null })
+    const listener = vi.fn()
+    state.readonly.runtime.subscribe(listener)
+
+    state.actions.setRuntime({
+      effective: 'canvas',
+      status: 'degraded',
+      error: 'WebGPU adapter unavailable',
+    })
+
+    expect(state.readonly.runtime.peek()).toEqual({
+      effective: 'canvas',
+      status: 'degraded',
+      error: 'WebGPU adapter unavailable',
+    })
+    expect(Object.isFrozen(state.readonly.runtime.peek())).toBe(true)
+    expect(listener).toHaveBeenCalledOnce()
+  })
+
+  it('does not notify for an identical runtime', () => {
+    const runtime = { effective: 'webgpu', status: 'ready', error: null } as const
+    const state = createRendererState(runtime)
+    const listener = vi.fn()
+    state.readonly.runtime.subscribe(listener)
+
+    state.actions.setRuntime({ ...runtime })
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/engine/state/__tests__/settingsState.test.ts
+++ b/packages/core/src/engine/state/__tests__/settingsState.test.ts
@@ -15,7 +15,7 @@ describe('settingsState', () => {
     const s = createSettingsState()
     s.actions.replace({ showGridLines: false })
     expect(s.readonly.settings.peek().showGridLines).toBe(false)
-    expect(s.readonly.settings.peek().enableWebGLRendering).toBeDefined()
+    expect(s.readonly.settings.peek().rendererBackend).toBe('webgl')
   })
 
   it('patch merges onto current then re-resolves', () => {

--- a/packages/core/src/engine/state/chartStateKernel.ts
+++ b/packages/core/src/engine/state/chartStateKernel.ts
@@ -254,17 +254,16 @@ export class ChartStateKernel extends StateKernel {
       setDrawings: (drawings: ReadonlyArray<DrawingObject>) =>
         this.drawing.actions.setDrawings(drawings),
       clearDrawings: () => this.drawing.actions.clearDrawings(),
-      updateCrosshair: (pos: { x: number; y: number } | null, price: number | null) =>
-        this.interaction.actions.updateCrosshair(pos, price),
+      updateCrosshair: (
+        pos: { x: number; y: number } | null,
+        price: number | null,
+        index?: number | null,
+      ) => this.interaction.actions.updateCrosshair(pos, price, index),
+      setCrosshairIndex: (index: number | null) => this.interaction.actions.setCrosshairIndex(index),
       updateHover: (index: number | null, paneId: string | null) =>
         this.interaction.actions.updateHover(index, paneId),
       setHoveredIndex: (index: number | null) => this.interaction.actions.setHoveredIndex(index),
       setActivePaneId: (paneId: string | null) => this.interaction.actions.setActivePaneId(paneId),
-      updateFramePositions: (
-        positions: number[] | null,
-        centers: number[] | null,
-        kWidthPx: number | null,
-      ) => this.interaction.actions.updateFramePositions(positions, centers, kWidthPx),
       startDrag: (mode: DragMode) => this.interaction.actions.startDrag(mode),
       endDrag: () => this.interaction.actions.endDrag(),
       setDragMode: (mode: DragMode) => this.interaction.actions.setDragMode(mode),

--- a/packages/core/src/engine/state/chartStateKernel.ts
+++ b/packages/core/src/engine/state/chartStateKernel.ts
@@ -22,6 +22,7 @@ import { createComparisonState, type ComparisonStateModule } from './comparisonS
 import { createIndicatorState, type IndicatorStateModule } from './indicatorState'
 import { createSubPaneState, type SubPaneStateModule } from './subPaneState'
 import { createMarkerState, type MarkerStateModule } from './markerState'
+import { createRendererState, type RendererStateModule } from './rendererState'
 import { batch, computed, type ReadonlySignal } from '../../foundation/reactivity/signal'
 import type { DrawingObject } from '../../foundation/plugin/index'
 import type { PaneSpec } from '../chartTypes'
@@ -29,6 +30,8 @@ import type { DrawingToolId } from '../drawing/toolConfig'
 import type { SymbolSpec, SymbolInfo } from '../../controllers/types'
 import type { MarkerEntity, CustomMarkerEntity } from '../marker/registry'
 import type { DragMode } from './interactionState'
+import type { ChartSettings } from '../../foundation/config/chartSettings'
+import type { RendererBackendRuntime } from '../../rendering/render/rendererHost'
 
 export interface ChartStateKernelDeps {
   initialOptions: {
@@ -48,6 +51,8 @@ export interface ChartStateKernelDeps {
     [key: string]: unknown
   }
   initialZoomLevel: number
+  initialSettings?: Partial<ChartSettings>
+  initialRendererRuntime?: RendererBackendRuntime
   scheduleDraw: (level?: unknown) => void
 }
 
@@ -68,6 +73,7 @@ export class ChartStateKernel extends StateKernel {
   readonly indicator: IndicatorStateModule
   readonly subPane: SubPaneStateModule
   readonly marker: MarkerStateModule
+  readonly renderer: RendererStateModule
 
   readonly zoomLevel$: ReadonlySignal<number>
   readonly dataLength$: ReadonlySignal<number>
@@ -140,7 +146,10 @@ export class ChartStateKernel extends StateKernel {
     }
 
     // ── Settings state（用户偏好 SSOT，含 theme light|dark|auto）──
-    this.settings = createSettingsState()
+    this.settings = createSettingsState(deps.initialSettings)
+    this.renderer = createRendererState(
+      deps.initialRendererRuntime ?? { effective: 'webgl', status: 'ready', error: null },
+    )
 
     // ── 系统主题（auto 时参与 effectiveTheme 推导）──
     this.systemTheme = createSystemThemeState()
@@ -193,6 +202,7 @@ export class ChartStateKernel extends StateKernel {
       theme: this.effectiveTheme$,
       // Settings
       settings: this.settings.readonly.settings,
+      rendererRuntime: this.renderer.readonly.runtime,
       // Mode
       chartMode: this.mode.readonly.chartMode,
       // Pane scale types
@@ -238,6 +248,8 @@ export class ChartStateKernel extends StateKernel {
         this.pane.actions.commitLayout(ratios, specs),
       setTheme: (theme: 'light' | 'dark') => this.settings.actions.patch({ theme }),
       setSystemTheme: (theme: 'light' | 'dark') => this.systemTheme.actions.setSystemTheme(theme),
+      setRendererRuntime: (runtime: RendererBackendRuntime) =>
+        this.renderer.actions.setRuntime(runtime),
       setDrawingTool: (tool: DrawingToolId) => this.drawing.actions.setDrawingTool(tool),
       setDrawings: (drawings: ReadonlyArray<DrawingObject>) =>
         this.drawing.actions.setDrawings(drawings),
@@ -396,6 +408,7 @@ export class ChartStateKernel extends StateKernel {
     this.indicator.dispose()
     this.subPane.dispose()
     this.marker.dispose()
+    this.renderer.dispose()
   }
 }
 

--- a/packages/core/src/engine/state/interactionState.ts
+++ b/packages/core/src/engine/state/interactionState.ts
@@ -27,77 +27,30 @@ export interface InteractionDeps {
   scheduleDraw: (level?: unknown) => void
 }
 
-function computeCrosshairIndex(
-  crosshairPos: { x: number; y: number } | null,
-  kLinePositions: number[] | null,
-  kWidthPx: number | null,
-  visibleRange: { start: number; end: number } | null,
-  scrollLeftLogical: number,
-  dpr: number,
-): number | null {
-  if (!crosshairPos || !kLinePositions || !kWidthPx || !visibleRange) return null
-  const kWidthLogical = kWidthPx / dpr
-  const worldX = scrollLeftLogical + crosshairPos.x
-  const positions = kLinePositions
+/**
+ * 交互业务态（kernel）。
+ * 帧几何 kLinePositions/centers/kWidth 不在此模块，由 InteractionController 私有持有。
+ */
+export function createInteractionState(_deps: InteractionDeps) {
+  const { signals, readonly } = createSubState({
+    crosshairPos: null as { x: number; y: number } | null,
+    crosshairPrice: null as number | null,
+    /** 由 controller 在 flush hover 时写入，不再从几何 signal 推导 */
+    crosshairIndex: null as number | null,
+    hoveredIndex: null as number | null,
+    activePaneId: null as string | null,
+    isDragging: false,
+    dragMode: 'none' as DragMode,
+    hoveredSeparatorUpperPaneId: null as string | null,
+    hoveredRightAxisPaneId: null as string | null,
+    tooltipPos: { x: 0, y: 0 },
+    tooltipAnchorPlacement: 'right-bottom' as 'right-bottom' | 'left-bottom',
+    hoveredMarkerData: null as MarkerEntity | null,
+    hoveredCustomMarker: null as CustomMarkerEntity | null,
+    hoveredMarkerId: null as string | null,
+  })
 
-  let lo = 0
-  let hi = positions.length
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1
-    if (positions[mid]! < worldX) lo = mid + 1
-    else hi = mid
-  }
-  let localIdx = lo
-  if (lo > 0 && lo < positions.length) {
-    const prevCenter = positions[lo - 1]! + kWidthLogical / 2
-    const currCenter = positions[lo]! + kWidthLogical / 2
-    if (Math.abs(worldX - prevCenter) < Math.abs(worldX - currCenter)) {
-      localIdx = lo - 1
-    }
-  } else if (lo === positions.length && positions.length > 0) {
-    localIdx = positions.length - 1
-  }
-  return localIdx + visibleRange.start
-}
-
-export function createInteractionState(deps: InteractionDeps) {
-  const { signals, readonly } = createSubState(
-    {
-      crosshairPos: null as { x: number; y: number } | null,
-      crosshairPrice: null as number | null,
-      hoveredIndex: null as number | null,
-      activePaneId: null as string | null,
-      isDragging: false,
-      dragMode: 'none' as DragMode,
-      hoveredSeparatorUpperPaneId: null as string | null,
-      hoveredRightAxisPaneId: null as string | null,
-      tooltipPos: { x: 0, y: 0 },
-      tooltipAnchorPlacement: 'right-bottom' as 'right-bottom' | 'left-bottom',
-      hoveredMarkerData: null as MarkerEntity | null,
-      hoveredCustomMarker: null as CustomMarkerEntity | null,
-      hoveredMarkerId: null as string | null,
-      kLinePositions: null as number[] | null,
-      kLineCenters: null as number[] | null,
-      kWidthPx: null as number | null,
-    },
-    {
-      crosshairIndex: (s) => {
-        if (!s.crosshairPos()) return null
-        return computeCrosshairIndex(
-          s.crosshairPos(),
-          s.kLinePositions(),
-          s.kWidthPx(),
-          deps.visibleRange$(),
-          deps.scrollLeftLogical$(),
-          deps.dpr$(),
-        )
-      },
-    },
-  )
-
-  // ── 带引用缓存 + deps 收紧的 interactionSnapshot ──
-  // crosshairPos 为 null 时跳过 visibleRange$/scrollLeftLogical$ 读取，
-  // 避免滚动事件触发无十字线状态下的虚假重算
+  // ── 带引用缓存的 interactionSnapshot ──
   let _cachedSnapshot: InteractionSnapshot | null = null
   const cachedInteractionSnapshot = computed<InteractionSnapshot>(() => {
     const crosshairPos = readonly.crosshairPos()
@@ -106,20 +59,9 @@ export function createInteractionState(deps: InteractionDeps) {
     const hoveredSep = readonly.hoveredSeparatorUpperPaneId()
     const hoveredRight = readonly.hoveredRightAxisPaneId()
 
-    const crosshairIndex = crosshairPos
-      ? computeCrosshairIndex(
-          crosshairPos,
-          readonly.kLinePositions(),
-          readonly.kWidthPx(),
-          deps.visibleRange$(),
-          deps.scrollLeftLogical$(),
-          deps.dpr$(),
-        )
-      : null
-
     const next: InteractionSnapshot = {
       crosshairPos,
-      crosshairIndex,
+      crosshairIndex: readonly.crosshairIndex(),
       crosshairPrice: readonly.crosshairPrice(),
       hoveredIndex,
       activePaneId: readonly.activePaneId(),
@@ -169,11 +111,18 @@ export function createInteractionState(deps: InteractionDeps) {
 
     actions: {
       /**
-       * 更新十字线。坐标结构相等时保留旧对象引用，避免无意义 notify。
+       * 更新十字线位置与价格。坐标结构相等时保留旧对象引用。
+       * @param index 可选；传入时同步写入 crosshairIndex（与几何同帧）
        */
-      updateCrosshair(pos: { x: number; y: number } | null, price: number | null) {
+      updateCrosshair(
+        pos: { x: number; y: number } | null,
+        price: number | null,
+        index?: number | null,
+      ) {
         const prevPos = signals.crosshairPos.peek()
         const prevPrice = signals.crosshairPrice.peek()
+        const prevIndex = signals.crosshairIndex.peek()
+        const nextIndex = index === undefined ? prevIndex : index
         const posUnchanged =
           prevPos === pos ||
           (prevPos === null && pos === null) ||
@@ -181,11 +130,17 @@ export function createInteractionState(deps: InteractionDeps) {
             pos !== null &&
             prevPos.x === pos.x &&
             prevPos.y === pos.y)
-        if (posUnchanged && prevPrice === price) return
+        if (posUnchanged && prevPrice === price && prevIndex === nextIndex) return
         batch(() => {
           if (!posUnchanged) signals.crosshairPos.set(pos)
           if (prevPrice !== price) signals.crosshairPrice.set(price)
+          if (prevIndex !== nextIndex) signals.crosshairIndex.set(nextIndex)
         })
+      },
+
+      setCrosshairIndex(index: number | null) {
+        if (signals.crosshairIndex.peek() === index) return
+        signals.crosshairIndex.set(index)
       },
 
       updateHover(index: number | null, paneId: string | null) {
@@ -201,29 +156,6 @@ export function createInteractionState(deps: InteractionDeps) {
 
       setActivePaneId(paneId: string | null) {
         signals.activePaneId.set(paneId)
-      },
-
-      /**
-       * 封存本帧几何。同一引用且 kWidth 未变时跳过 set，避免每帧无意义广播。
-       * 数组所有权在 ChartRenderer 帧缓存；此处不拷贝。
-       */
-      updateFramePositions(
-        positions: number[] | null,
-        centers: number[] | null,
-        kWidthPx: number | null,
-      ) {
-        if (
-          signals.kLinePositions.peek() === positions &&
-          signals.kLineCenters.peek() === centers &&
-          signals.kWidthPx.peek() === kWidthPx
-        ) {
-          return
-        }
-        batch(() => {
-          signals.kLinePositions.set(positions)
-          signals.kLineCenters.set(centers)
-          signals.kWidthPx.set(kWidthPx)
-        })
       },
 
       startDrag(mode: DragMode) {
@@ -294,6 +226,7 @@ export function createInteractionState(deps: InteractionDeps) {
         batch(() => {
           signals.crosshairPos.set(null)
           signals.crosshairPrice.set(null)
+          signals.crosshairIndex.set(null)
           signals.hoveredIndex.set(null)
           signals.activePaneId.set(null)
           signals.isDragging.set(false)
@@ -313,6 +246,7 @@ export function createInteractionState(deps: InteractionDeps) {
       batch(() => {
         signals.crosshairPos.set(null)
         signals.crosshairPrice.set(null)
+        signals.crosshairIndex.set(null)
         signals.hoveredIndex.set(null)
         signals.activePaneId.set(null)
         signals.isDragging.set(false)
@@ -324,9 +258,6 @@ export function createInteractionState(deps: InteractionDeps) {
         signals.hoveredMarkerData.set(null)
         signals.hoveredCustomMarker.set(null)
         signals.hoveredMarkerId.set(null)
-        signals.kLinePositions.set(null)
-        signals.kLineCenters.set(null)
-        signals.kWidthPx.set(null)
       })
     },
   }

--- a/packages/core/src/engine/state/interactionState.ts
+++ b/packages/core/src/engine/state/interactionState.ts
@@ -168,10 +168,23 @@ export function createInteractionState(deps: InteractionDeps) {
     readonly: mergedReadonly,
 
     actions: {
+      /**
+       * 更新十字线。坐标结构相等时保留旧对象引用，避免无意义 notify。
+       */
       updateCrosshair(pos: { x: number; y: number } | null, price: number | null) {
+        const prevPos = signals.crosshairPos.peek()
+        const prevPrice = signals.crosshairPrice.peek()
+        const posUnchanged =
+          prevPos === pos ||
+          (prevPos === null && pos === null) ||
+          (prevPos !== null &&
+            pos !== null &&
+            prevPos.x === pos.x &&
+            prevPos.y === pos.y)
+        if (posUnchanged && prevPrice === price) return
         batch(() => {
-          signals.crosshairPos.set(pos)
-          signals.crosshairPrice.set(price)
+          if (!posUnchanged) signals.crosshairPos.set(pos)
+          if (prevPrice !== price) signals.crosshairPrice.set(price)
         })
       },
 
@@ -239,13 +252,29 @@ export function createInteractionState(deps: InteractionDeps) {
         signals.hoveredRightAxisPaneId.set(paneId)
       },
 
+      /**
+       * 更新 tooltip。位置与锚点均未变时跳过写入。
+       */
       updateTooltip(
         pos: { x: number; y: number },
         placement: 'right-bottom' | 'left-bottom',
       ) {
+        const prevPos = signals.tooltipPos.peek()
+        const prevPlacement = signals.tooltipAnchorPlacement.peek()
+        if (
+          prevPos.x === pos.x &&
+          prevPos.y === pos.y &&
+          prevPlacement === placement
+        ) {
+          return
+        }
         batch(() => {
-          signals.tooltipPos.set(pos)
-          signals.tooltipAnchorPlacement.set(placement)
+          if (prevPos.x !== pos.x || prevPos.y !== pos.y) {
+            signals.tooltipPos.set(pos)
+          }
+          if (prevPlacement !== placement) {
+            signals.tooltipAnchorPlacement.set(placement)
+          }
         })
       },
 

--- a/packages/core/src/engine/state/interactionState.ts
+++ b/packages/core/src/engine/state/interactionState.ts
@@ -190,11 +190,22 @@ export function createInteractionState(deps: InteractionDeps) {
         signals.activePaneId.set(paneId)
       },
 
+      /**
+       * 封存本帧几何。同一引用且 kWidth 未变时跳过 set，避免每帧无意义广播。
+       * 数组所有权在 ChartRenderer 帧缓存；此处不拷贝。
+       */
       updateFramePositions(
         positions: number[] | null,
         centers: number[] | null,
         kWidthPx: number | null,
       ) {
+        if (
+          signals.kLinePositions.peek() === positions &&
+          signals.kLineCenters.peek() === centers &&
+          signals.kWidthPx.peek() === kWidthPx
+        ) {
+          return
+        }
         batch(() => {
           signals.kLinePositions.set(positions)
           signals.kLineCenters.set(centers)

--- a/packages/core/src/engine/state/rendererState.ts
+++ b/packages/core/src/engine/state/rendererState.ts
@@ -1,0 +1,32 @@
+import type { RendererBackendRuntime } from '../../rendering/render/rendererHost'
+import { createSubState } from '../../foundation/reactivity/signal'
+
+function snapshot(runtime: RendererBackendRuntime): Readonly<RendererBackendRuntime> {
+  return Object.freeze({ ...runtime })
+}
+
+function equal(left: RendererBackendRuntime, right: RendererBackendRuntime): boolean {
+  return (
+    left.effective === right.effective && left.status === right.status && left.error === right.error
+  )
+}
+
+export function createRendererState(initial: RendererBackendRuntime) {
+  const initialSnapshot = snapshot(initial)
+  const { signals, readonly } = createSubState({ runtime: initialSnapshot })
+
+  return {
+    readonly,
+    actions: {
+      setRuntime(runtime: RendererBackendRuntime): void {
+        if (equal(signals.runtime.peek(), runtime)) return
+        signals.runtime.set(snapshot(runtime))
+      },
+    },
+    dispose(): void {
+      signals.runtime.set(initialSnapshot)
+    },
+  }
+}
+
+export type RendererStateModule = ReturnType<typeof createRendererState>

--- a/packages/core/src/engine/state/viewportState.ts
+++ b/packages/core/src/engine/state/viewportState.ts
@@ -256,11 +256,14 @@ export function createViewportState(signalDeps: ViewportSignalDeps) {
   let webglEffect: (() => void) | null = null
   let scrollDomEffect: (() => void) | null = null
 
+  /**
+   * 写入请求 scrollLeft；与当前值相等时跳过，避免 pan 重复事件空通知。
+   */
   const setRequestedScrollLeft = (value: number): void => {
     const normalized = Number.isFinite(value) ? value : 0
-    batch(() => {
-      signals.requestedScrollLeft.set(Math.max(0, Math.min(normalized, maxScrollLeft.peek())))
-    })
+    const clamped = Math.max(0, Math.min(normalized, maxScrollLeft.peek()))
+    if (signals.requestedScrollLeft.peek() === clamped) return
+    signals.requestedScrollLeft.set(clamped)
   }
 
   const syncFromDomScroll = () => {

--- a/packages/core/src/engine/subPaneManager.ts
+++ b/packages/core/src/engine/subPaneManager.ts
@@ -4,7 +4,6 @@ import type {
   RendererPluginWithHost,
   RenderContext,
 } from '../foundation/plugin/index'
-import { createLayerFromPlugin } from '../rendering/scene/createLayerFromPlugin'
 import type { Layer } from '../rendering/scene/types'
 import type { IndicatorScheduler } from './indicators/scheduler'
 import { findIndicator } from './renderers/Indicator/indicatorCatalog'
@@ -192,11 +191,8 @@ export class SubPaneManager {
         definition,
         params: { ...entry.params },
       })
+      // useRenderer：注册表 + 唯一 Scene Layer
       ctx.useRenderer(renderer, { ...entry.params })
-      ctx.setRendererEnabled(entry.rendererName, false)
-      ctx.addLayer(
-        createLayerFromPlugin(renderer, () => ctx.getRenderContext(entry.paneId), entry.paneId),
-      )
     }
     this.mountScaleRenderer(ctx, entry)
   }
@@ -232,10 +228,6 @@ export class SubPaneManager {
         : null
     if (!plugin) return
     ctx.useRenderer(plugin)
-    ctx.setRendererEnabled(entry.scaleRendererName, false)
-    ctx.addLayer(
-      createLayerFromPlugin(plugin, () => ctx.getRenderContext(entry.paneId), entry.paneId),
-    )
   }
 
   private mountPaneTitleRenderer(ctx: SubPaneContext, entry: ProjectedSubPaneEntry): void {
@@ -254,10 +246,6 @@ export class SubPaneManager {
       params: { ...entry.params },
     })
     ctx.useRenderer(renderer)
-    ctx.setRendererEnabled(entry.paneTitleRendererName, false)
-    ctx.addLayer(
-      createLayerFromPlugin(renderer, () => ctx.getRenderContext(entry.paneId), entry.paneId),
-    )
   }
 
   private updateParams(ctx: SubPaneContext, resources: SubPaneResources, spec: SubPaneSpec): void {
@@ -271,13 +259,11 @@ export class SubPaneManager {
   }
 
   private unmount(ctx: SubPaneContext, entry: SubPaneResources, preserveTitle = false): void {
+    // removeRenderer 已同步卸 Scene Layer + Manager onUninstall，勿再 removeLayer
     ctx.removeRenderer(entry.rendererName)
     ctx.removeRenderer(entry.scaleRendererName)
-    ctx.removeLayer(entry.layerId)
-    ctx.removeLayer(entry.scaleLayerId)
     if (!preserveTitle) {
       ctx.removeRenderer(entry.paneTitleRendererName)
-      ctx.removeLayer(entry.paneTitleLayerId)
     }
   }
 

--- a/packages/core/src/foundation/config/__tests__/chartSettings.test.ts
+++ b/packages/core/src/foundation/config/__tests__/chartSettings.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { migrateStoredSettings, resolveSettings } from '../chartSettings'
+
+describe('chart renderer settings', () => {
+  it('defaults to WebGL', () => {
+    expect(resolveSettings().rendererBackend).toBe('webgl')
+  })
+
+  it('migrates the old WebGL toggle without retaining it', () => {
+    expect(migrateStoredSettings({ enableWebGLRendering: true, showGridLines: false })).toEqual({
+      rendererBackend: 'webgl',
+      showGridLines: false,
+    })
+    expect(migrateStoredSettings({ enableWebGLRendering: false })).toEqual({
+      rendererBackend: 'canvas',
+    })
+  })
+
+  it('prefers an existing rendererBackend during migration', () => {
+    expect(
+      migrateStoredSettings({ rendererBackend: 'webgpu', enableWebGLRendering: false }),
+    ).toEqual({ rendererBackend: 'webgpu' })
+  })
+})

--- a/packages/core/src/foundation/config/chartSettings.ts
+++ b/packages/core/src/foundation/config/chartSettings.ts
@@ -44,9 +44,6 @@ export function getDeviceType(): 'mobile' | 'tablet' | 'desktop' {
   return 'desktop'
 }
 
-/** 移动端（含平板）默认不开启 WebGL */
-const ENABLE_WEBGL_DEFAULT = getDeviceType() === 'desktop'
-
 /** 默认设置配置 */
 export const DEFAULT_SETTINGS = [
   { key: 'showGridLines', label: '显示网格', type: 'boolean', default: true, group: 'main' },
@@ -96,11 +93,16 @@ export const DEFAULT_SETTINGS = [
     group: 'style',
   },
   {
-    key: 'enableWebGLRendering',
-    label: '启用 WebGL 硬件加速渲染',
-    type: 'boolean',
-    default: ENABLE_WEBGL_DEFAULT,
+    key: 'rendererBackend',
+    label: '渲染后端',
+    type: 'select',
+    default: 'webgl',
     group: 'main',
+    options: [
+      { value: 'webgl', label: 'WebGL' },
+      { value: 'webgpu', label: 'WebGPU' },
+      { value: 'canvas', label: 'Canvas' },
+    ],
   },
   {
     key: 'theme',
@@ -169,6 +171,21 @@ export function resolveSettings(partial?: Partial<ChartSettings>): ChartSettings
     partial?.colorPresetSettings,
   )
   return result as ChartSettings
+}
+
+/** 将旧版持久设置迁移为 rendererBackend，返回结果不保留旧字段。 */
+export function migrateStoredSettings(stored: Record<string, unknown>): Partial<ChartSettings> {
+  const { enableWebGLRendering, rendererBackend, ...rest } = stored
+  const validBackend =
+    rendererBackend === 'webgpu' || rendererBackend === 'webgl' || rendererBackend === 'canvas'
+      ? rendererBackend
+      : typeof enableWebGLRendering === 'boolean'
+        ? enableWebGLRendering
+          ? 'webgl'
+          : 'canvas'
+        : undefined
+
+  return validBackend ? { ...rest, rendererBackend: validBackend } : rest
 }
 
 /** localStorage 存储键名 */

--- a/packages/core/src/foundation/plugin/index.ts
+++ b/packages/core/src/foundation/plugin/index.ts
@@ -16,4 +16,3 @@ export { ConfigManager } from './ConfigManager'
 
 // 渲染器插件
 export { RendererPluginManager } from './rendererPluginManager'
-export type { RendererErrorEvent } from './rendererPluginManager'

--- a/packages/core/src/foundation/plugin/rendererPluginManager.ts
+++ b/packages/core/src/foundation/plugin/rendererPluginManager.ts
@@ -245,16 +245,6 @@ export class RendererPluginManager {
     return cached
   }
 
-  /** 获取指定 pane 的渲染器元数据（已缓存；不含系统渲染器） */
-  getRenderers(paneId: string): RendererPlugin[] {
-    const cached = this.getMergedRenderers(paneId)
-
-    return cached.filter((p) => {
-      if (p.isSystem) return false
-      return this.isRendererEnabled(p)
-    })
-  }
-
   /** 启用/禁用渲染器（修改独立状态，不影响原始插件对象） */
   setEnabled(name: string, enabled: boolean): void {
     if (!this.plugins.has(name)) return
@@ -280,22 +270,6 @@ export class RendererPluginManager {
   /** 获取指定渲染器 */
   getPlugin<T extends RendererPlugin = RendererPlugin>(name: string): T | undefined {
     return this.plugins.get(name) as T | undefined
-  }
-
-  /* 调用 onDataUpdate 钩子通知数据更新 */
-  notifyDataUpdate(data: unknown[], range: { start: number; end: number }): void {
-    for (const plugin of this.plugins.values()) {
-      if (!plugin.onDataUpdate) continue
-
-      // 检查启用状态，跳过禁用的插件
-      if (!this.isRendererEnabled(plugin)) continue
-
-      try {
-        plugin.onDataUpdate(data, range)
-      } catch (e) {
-        console.error(`[RendererPlugin] ${plugin.name} onDataUpdate error:`, e)
-      }
-    }
   }
 
   /** 通知尺寸变化 */

--- a/packages/core/src/foundation/plugin/rendererPluginManager.ts
+++ b/packages/core/src/foundation/plugin/rendererPluginManager.ts
@@ -2,23 +2,12 @@
  * 渲染器插件管理器
  */
 
-import { UpdateLevel } from '../../engine/layout/pane'
-
 import type {
   RendererPlugin,
-  RenderContext,
   PaneInfo,
   RendererPluginWithHost,
   PluginHost,
 } from './types'
-
-/** 渲染器错误事件（裁剪后，不含大数据） */
-export interface RendererErrorEvent {
-  name: string
-  error: { message: string; stack?: string }
-  paneId: string
-  timestamp: number
-}
 
 /** 内部缓存 key（模块私有，避免与外部 paneId 冲突） */
 const GLOBAL_CACHE_KEY = Symbol('renderer:global-cache')
@@ -256,76 +245,14 @@ export class RendererPluginManager {
     return cached
   }
 
-  /** 获取指定 pane 的渲染器（已缓存，无穿透） */
+  /** 获取指定 pane 的渲染器元数据（已缓存；不含系统渲染器） */
   getRenderers(paneId: string): RendererPlugin[] {
     const cached = this.getMergedRenderers(paneId)
 
-    // 根据启用状态过滤，同时排除系统渲染器
     return cached.filter((p) => {
-      // 系统渲染器不通过 getRenderers 返回，只能通过 renderPlugin 单独渲染
       if (p.isSystem) return false
       return this.isRendererEnabled(p)
     })
-  }
-
-  /** 渲染指定 pane（带错误隔离，支持按 UpdateLevel 过滤） */
-  render(paneId: string, context: RenderContext, level?: UpdateLevel): RendererErrorEvent[] {
-    const renderers = this.getRenderers(paneId)
-    const errors: RendererErrorEvent[] = []
-
-    for (const renderer of renderers) {
-      // UpdateLevel 过滤：未传 level 或为 All 时不过滤
-      if (level) {
-        const rendererLayer = renderer.layer ?? 'main'
-        if (level === UpdateLevel.Overlay && rendererLayer !== 'overlay') {
-          continue // Overlay 更新时跳过非 overlay 渲染器
-        }
-        if (level === UpdateLevel.Main && rendererLayer === 'overlay') {
-          continue // Main 更新时跳过 overlay 渲染器
-        }
-      }
-
-      try {
-        renderer.draw(context)
-      } catch (e) {
-        const error = e instanceof Error ? e : new Error(String(e))
-        console.error(`[RendererPlugin] ${renderer.name} draw error:`, error)
-        // 裁剪错误事件，不含大数据
-        errors.push({
-          name: renderer.name,
-          error: { message: error.message, stack: error.stack },
-          paneId: context.pane.id,
-          timestamp: Date.now(),
-        })
-      }
-    }
-
-    return errors
-  }
-
-  /** 渲染指定名称的插件（带错误隔离，用于系统渲染器） */
-  renderPlugin(name: string, context: RenderContext): RendererErrorEvent[] {
-    const plugin = this.plugins.get(name)
-    if (!plugin) return []
-
-    // 检查启用状态
-    if (!this.isRendererEnabled(plugin)) return []
-
-    const errors: RendererErrorEvent[] = []
-    try {
-      plugin.draw(context)
-    } catch (e) {
-      const error = e instanceof Error ? e : new Error(String(e))
-      console.error(`[RendererPlugin] ${name} draw error:`, error)
-      errors.push({
-        name,
-        error: { message: error.message, stack: error.stack },
-        paneId: context.pane.id,
-        timestamp: Date.now(),
-      })
-    }
-
-    return errors
   }
 
   /** 启用/禁用渲染器（修改独立状态，不影响原始插件对象） */

--- a/packages/core/src/foundation/plugin/types.ts
+++ b/packages/core/src/foundation/plugin/types.ts
@@ -2,10 +2,6 @@
  * 插件系统核心类型定义
  */
 
-import type {
-  CandleWebGLSurface,
-  LineWebGLSurface,
-} from '../../engine/renderers/webgl/candleSurface'
 import type { KLineData } from '../types/price'
 
 /** 插件生命周期状态 */
@@ -314,18 +310,8 @@ export interface RenderContext {
   /** 覆盖层 Canvas 上下文（用于十字线、Tooltip 等动态内容） */
   overlayCtx?: CanvasRenderingContext2D
   /**
-   * price pane 可选的 WebGL candle surface
-   * @deprecated Phase 1+: prefer sceneRenderer for rect draws; remove after all rect drawers migrate
-   */
-  candleWebGLSurface?: CandleWebGLSurface
-  /**
-   * line indicator 可选的 WebGL line surface
-   * @deprecated Phase 1+: prefer sceneRenderer for line draws; remove after line drawers migrate
-   */
-  lineWebGLSurface?: LineWebGLSurface
-  /**
    * Scene 本帧 Renderer（createLayerFromPlugin 注入）。
-   * candle 等迁出 surface 旁路时经 drawInstances / drawLines 出画。
+   * 业务绘制经 drawInstances / drawLines；失败 fail-closed 走 2D。
    */
   sceneRenderer?: import('../../rendering/render/Renderer').Renderer
   /** 当前缩放级别（1 ~ zoomLevels） */
@@ -527,17 +513,16 @@ export interface RendererPlugin {
   enabled?: boolean
 
   /**
-   * 是否为系统渲染器
-   * 系统渲染器不会通过 getRenderers() 返回，只能通过 renderPlugin() 单独渲染
-   * 用于时间轴、全局边框等需要单独控制渲染时机的场景
+   * 是否为系统渲染器（时间轴等）。
+   * 调度由 Scene Layer 负责；Manager 仅作注册表。
    */
   isSystem?: boolean
 
   /**
-   * 渲染器所属层，决定 UpdateLevel 过滤行为
-   * - 'main': 低频/静态内容，随主画布一起渲染
-   * - 'overlay': 高频/动态内容，可在 overlay-only 更新时独立重绘
-   * 未指定时默认为 'main'（向后兼容）
+   * 渲染器所属层，供 Scene role 过滤
+   * - 'main': 低频/静态内容
+   * - 'overlay': 高频/动态内容
+   * 未指定时默认为 'main'
    */
   layer?: 'main' | 'overlay'
 

--- a/packages/core/src/foundation/plugin/types.ts
+++ b/packages/core/src/foundation/plugin/types.ts
@@ -529,9 +529,6 @@ export interface RendererPlugin {
   /** 渲染方法 */
   draw(context: RenderContext): void
 
-  /** 数据更新时回调 */
-  onDataUpdate?(data: unknown[], range: { start: number; end: number }): void
-
   /** 容器尺寸变化时回调 */
   onResize?(pane: PaneInfo): void
 

--- a/packages/core/src/foundation/plugin/types.ts
+++ b/packages/core/src/foundation/plugin/types.ts
@@ -313,10 +313,21 @@ export interface RenderContext {
   borderCtx?: CanvasRenderingContext2D
   /** 覆盖层 Canvas 上下文（用于十字线、Tooltip 等动态内容） */
   overlayCtx?: CanvasRenderingContext2D
-  /** price pane 可选的 WebGL candle surface */
+  /**
+   * price pane 可选的 WebGL candle surface
+   * @deprecated Phase 1+: prefer sceneRenderer for rect draws; remove after all rect drawers migrate
+   */
   candleWebGLSurface?: CandleWebGLSurface
-  /** line indicator 可选的 WebGL line surface */
+  /**
+   * line indicator 可选的 WebGL line surface
+   * @deprecated Phase 1+: prefer sceneRenderer for line draws; remove after line drawers migrate
+   */
   lineWebGLSurface?: LineWebGLSurface
+  /**
+   * Scene 本帧 Renderer（createLayerFromPlugin 注入）。
+   * candle 等迁出 surface 旁路时经 drawInstances / drawLines 出画。
+   */
+  sceneRenderer?: import('../../rendering/render/Renderer').Renderer
   /** 当前缩放级别（1 ~ zoomLevels） */
   zoomLevel?: number
   /** 总缩放级别数 */

--- a/packages/core/src/foundation/reactivity/__tests__/frameTransaction.test.ts
+++ b/packages/core/src/foundation/reactivity/__tests__/frameTransaction.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { createFrameTransaction } from '../frameTransaction'
+
+type Input = { x: number; y: number }
+type Snapshot = { generation: number; x: number; y: number; sum: number }
+
+describe('createFrameTransaction', () => {
+  it('coalesces many writeInput into one published snapshot on flush', () => {
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+    })
+    const listener = vi.fn()
+    ft.published$.subscribe(listener)
+
+    ft.writeInput({ x: 1 })
+    ft.writeInput({ x: 2, y: 3 })
+    ft.writeInput({ x: 10 })
+    expect(listener).not.toHaveBeenCalled()
+
+    const snap = ft.flush()
+    expect(snap).toEqual({ generation: 1, x: 10, y: 3, sum: 13 })
+    expect(ft.published$.peek()).toEqual(snap)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('bumps generation only on successful flush', () => {
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+    })
+    expect(ft.generation).toBe(0)
+    ft.writeInput({ x: 1 })
+    ft.flush()
+    expect(ft.generation).toBe(1)
+    ft.writeInput({ y: 2 })
+    ft.flush()
+    expect(ft.generation).toBe(2)
+  })
+
+  it('does not publish when derive throws; generation stays', () => {
+    let fail = false
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => {
+        if (fail) throw new Error('derive-fail')
+        return { generation, x: input.x, y: input.y, sum: input.x + input.y }
+      },
+    })
+    fail = true
+    ft.writeInput({ x: 5 })
+    expect(() => ft.flush()).toThrow('derive-fail')
+    expect(ft.generation).toBe(0)
+    expect(ft.published$.peek().generation).toBe(0)
+
+    fail = false
+    // 失败帧应保留 pending，无需再次 write 也能重试
+    const snap = ft.flush()
+    expect(snap.generation).toBe(1)
+    expect(snap.x).toBe(5)
+  })
+
+  it('routes writeInput during render into next generation only', () => {
+    const seen: number[] = []
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+      render: (snapshot) => {
+        seen.push(snapshot.x)
+        // re-entrant high-frequency write during paint
+        ft.writeInput({ x: 99 })
+      },
+    })
+    ft.writeInput({ x: 1 })
+    const first = ft.flush()
+    expect(first.x).toBe(1)
+    expect(seen).toEqual([1])
+    // re-entrant write not published yet
+    expect(ft.published$.peek().x).toBe(1)
+    const second = ft.flush()
+    expect(second.x).toBe(99)
+    expect(second.generation).toBe(2)
+  })
+
+  it('flush with no pending input returns published snapshot without notify', () => {
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 1, y: 2 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+    })
+    // seed first publish
+    ft.writeInput({ x: 1, y: 2 })
+    ft.flush()
+    const listener = vi.fn()
+    ft.published$.subscribe(listener)
+    const again = ft.flush()
+    expect(again.generation).toBe(1)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('select publishes only when selected value changes by equality', () => {
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+    })
+    const selected = ft.select((s) => s.x)
+    const listener = vi.fn()
+    selected.subscribe(listener)
+
+    ft.writeInput({ x: 1, y: 0 })
+    ft.flush()
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(selected.peek()).toBe(1)
+
+    ft.writeInput({ x: 1, y: 9 })
+    ft.flush()
+    // x unchanged
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    ft.writeInput({ x: 2 })
+    ft.flush()
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(selected.peek()).toBe(2)
+  })
+
+  it('scheduleFlush coalesces to one raf-style runner', () => {
+    const runners: Array<() => void> = []
+    const schedule = (run: () => void) => {
+      runners.push(run)
+      return 1
+    }
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+      schedule,
+    })
+    ft.writeInput({ x: 1 })
+    ft.scheduleFlush()
+    ft.writeInput({ x: 2 })
+    ft.scheduleFlush()
+    expect(runners).toHaveLength(1)
+    runners[0]!()
+    expect(ft.published$.peek().x).toBe(2)
+    expect(ft.generation).toBe(1)
+  })
+})

--- a/packages/core/src/foundation/reactivity/__tests__/frameTransaction.test.ts
+++ b/packages/core/src/foundation/reactivity/__tests__/frameTransaction.test.ts
@@ -173,4 +173,134 @@ describe('createFrameTransaction', () => {
     expect(ft.published$.peek().x).toBe(2)
     expect(ft.generation).toBe(1)
   })
+
+  it('advances generation before notifying published subscribers', () => {
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+    })
+    let seenGeneration = -1
+    ft.published$.subscribe(() => {
+      seenGeneration = ft.generation
+    })
+    ft.writeInput({ x: 1 })
+    ft.flush()
+    expect(seenGeneration).toBe(1)
+    expect(ft.published$.peek().generation).toBe(1)
+  })
+
+  it('defers re-entrant flush during publish to next generation only', () => {
+    const order: number[] = []
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+    })
+    ft.published$.subscribe(() => {
+      const snap = ft.published$.peek()
+      order.push(snap.x)
+      if (snap.x === 1) {
+        ft.writeInput({ x: 2 })
+        // re-entrant flush must not publish x=2 before remaining listeners of gen1
+        ft.flush()
+      }
+    })
+    const late = vi.fn()
+    ft.published$.subscribe(late)
+
+    ft.writeInput({ x: 1 })
+    ft.flush()
+    expect(order).toEqual([1])
+    expect(late).toHaveBeenCalledTimes(1)
+    expect(ft.published$.peek().x).toBe(1)
+    expect(ft.generation).toBe(1)
+
+    // deferred work runs on next idle flush
+    const second = ft.flush()
+    expect(second.x).toBe(2)
+    expect(second.generation).toBe(2)
+  })
+
+  it('freezes generation-0 published snapshot root', () => {
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+    })
+    const snap = ft.published$.peek() as Snapshot & { x: number }
+    expect(Object.isFrozen(snap)).toBe(true)
+    expect(() => {
+      ;(snap as { x: number }).x = 99
+    }).toThrow()
+  })
+
+  it('reschedules after scheduled flush throws', () => {
+    const runners: Array<() => void> = []
+    let failNextRealFrame = false
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => {
+        // generation 0 是构造占位，不可失败
+        if (generation > 0 && failNextRealFrame) {
+          failNextRealFrame = false
+          throw new Error('boom')
+        }
+        return {
+          generation,
+          x: input.x,
+          y: input.y,
+          sum: input.x + input.y,
+        }
+      },
+      schedule: (run) => {
+        runners.push(run)
+        return 1
+      },
+    })
+    failNextRealFrame = true
+    ft.writeInput({ x: 3 })
+    ft.scheduleFlush()
+    expect(runners).toHaveLength(1)
+    expect(() => runners[0]!()).toThrow('boom')
+    // dirty retained → another schedule registered
+    expect(runners.length).toBeGreaterThanOrEqual(2)
+    runners[runners.length - 1]!()
+    expect(ft.published$.peek().x).toBe(3)
+    expect(ft.generation).toBe(1)
+  })
+
+  it('resets scheduleQueued when schedule() throws', () => {
+    let shouldThrow = true
+    const ft = createFrameTransaction<Input, Snapshot>({
+      initialInput: { x: 0, y: 0 },
+      derive: (input, generation) => ({
+        generation,
+        x: input.x,
+        y: input.y,
+        sum: input.x + input.y,
+      }),
+      schedule: () => {
+        if (shouldThrow) throw new Error('no-raf')
+        return 1
+      },
+    })
+    ft.writeInput({ x: 1 })
+    expect(() => ft.scheduleFlush()).toThrow('no-raf')
+    shouldThrow = false
+    // must not be permanently stuck
+    expect(() => ft.scheduleFlush()).not.toThrow()
+  })
 })

--- a/packages/core/src/foundation/reactivity/frameTransaction.ts
+++ b/packages/core/src/foundation/reactivity/frameTransaction.ts
@@ -9,6 +9,7 @@
  * 本原语只暴露 pending 写入与 published 快照，不暴露公开 latest。
  * 一帧固定走 capture → derive → seal → render → publish → complete。
  * render 或 publish 期间的 writeInput 一律进入下一代 pending。
+ * 非 idle 时调用 flush 不会嵌套发布，仅保留 dirty 供外层完成后调度。
  */
 
 import { createSignal, type ReadonlySignal } from './signal'
@@ -24,6 +25,14 @@ function mergeInput<T extends Record<string, unknown>>(base: T, patch: Partial<T
   return { ...base, ...patch }
 }
 
+/** 浅冻结快照根对象；大数组字段由 derive 侧结构共享，禁止深拷贝 */
+function sealSnapshotRoot<T>(snapshot: T): T {
+  if (typeof snapshot === 'object' && snapshot !== null) {
+    Object.freeze(snapshot)
+  }
+  return snapshot
+}
+
 export interface FrameTransactionOptions<TInput extends Record<string, unknown>, TSnapshot> {
   /** 初始 pending 输入；也会用于生成 generation 0 的占位 published */
   initialInput: TInput
@@ -36,7 +45,7 @@ export interface FrameTransactionOptions<TInput extends Record<string, unknown>,
    * 可选：使用本帧快照绘制或执行副作用。
    * 此阶段 writeInput 进入下一代，不得假定能改当前快照。
    */
-  render?: (snapshot: TSnapshot) => void
+  render?: (snapshot: Readonly<TSnapshot>) => void
   /**
    * 调度 flush 的宿主。默认 requestAnimationFrame；测试可注入同步队列。
    * 返回值可忽略（兼容 rAF handle）。
@@ -46,7 +55,7 @@ export interface FrameTransactionOptions<TInput extends Record<string, unknown>,
 
 export interface FrameTransaction<TInput extends Record<string, unknown>, TSnapshot> {
   /** 最近一次成功发布的快照（只读 Signal） */
-  readonly published$: ReadonlySignal<TSnapshot>
+  readonly published$: ReadonlySignal<Readonly<TSnapshot>>
   /** 已成功发布的帧代际；失败 flush 不增加 */
   readonly generation: number
   /** 当前阶段，调试与不变量检查用 */
@@ -58,9 +67,10 @@ export interface FrameTransaction<TInput extends Record<string, unknown>, TSnaps
   writeInput(patch: Partial<TInput>): void
   /**
    * 同步执行一帧事务。无 pending 时返回当前 published，且不通知。
+   * 非 idle 调用不会嵌套发布，返回当前 published。
    * @returns 本帧使用的快照（成功时等于 published$.peek()）
    */
-  flush(): TSnapshot
+  flush(): Readonly<TSnapshot>
   /**
    * 请求在宿主调度器上合并 flush；多次调用在同一 pending 调度内只注册一次。
    */
@@ -69,7 +79,7 @@ export interface FrameTransaction<TInput extends Record<string, unknown>, TSnaps
    * 从 published 投影只读 Signal。
    * 仅当 select 结果相对上一值 Object.is 不等时通知。
    */
-  select<T>(selector: (snapshot: TSnapshot) => T): ReadonlySignal<T>
+  select<T>(selector: (snapshot: Readonly<TSnapshot>) => T): ReadonlySignal<T>
 }
 
 /**
@@ -103,7 +113,7 @@ export function createFrameTransaction<
   let scheduleQueued = false
 
   // generation 0：用初始输入 derive 一次，作为 published 占位，避免订阅者读到 undefined
-  const initialSnapshot = derive({ ...pending }, 0)
+  const initialSnapshot = sealSnapshotRoot(derive({ ...pending }, 0))
   const published = createSignal<TSnapshot>(initialSnapshot)
 
   function writeInput(patch: Partial<TInput>): void {
@@ -117,7 +127,12 @@ export function createFrameTransaction<
     nextPending = mergeInput(base, patch)
   }
 
-  function flush(): TSnapshot {
+  function flush(): Readonly<TSnapshot> {
+    // 禁止嵌套发布：订阅者 / render 中 flush 只保留 dirty，由外层 complete 后再调度
+    if (phase !== 'idle') {
+      return published.peek()
+    }
+
     if (!dirty && nextPending === null) {
       return published.peek()
     }
@@ -142,21 +157,19 @@ export function createFrameTransaction<
       const snapshot = derive(sealedInput, nextGeneration)
 
       phase = 'sealing'
-      // 浅层冻结快照根对象；大数组字段由 derive 侧做结构共享，禁止在此深拷贝
-      if (typeof snapshot === 'object' && snapshot !== null) {
-        Object.freeze(snapshot)
-      }
+      sealSnapshotRoot(snapshot)
 
       phase = 'rendering'
       render?.(snapshot)
 
+      // 先推进代际再发布，保证订阅者读 generation 与 snapshot.generation 一致
       phase = 'publishing'
-      published.set(snapshot)
       generation = nextGeneration
+      published.set(snapshot)
 
       return snapshot
     } catch (err) {
-      // derive/render 失败：不推进 generation，保留 sealed 输入供重试
+      // derive/render 失败：不推进 generation（若已推进则回滚），保留 sealed 输入供重试
       if (sealedInput !== undefined) {
         pending = sealedInput
         dirty = true
@@ -170,6 +183,10 @@ export function createFrameTransaction<
         nextPending = null
         dirty = true
       }
+      // 有残留 dirty 时挂下一代调度（含 re-entrant write / 失败重试）
+      if (dirty) {
+        scheduleFlush()
+      }
     }
   }
 
@@ -177,17 +194,20 @@ export function createFrameTransaction<
     if (scheduleQueued) return
     if (!dirty && nextPending === null) return
     scheduleQueued = true
-    schedule(() => {
+    try {
+      schedule(() => {
+        scheduleQueued = false
+        // flush 的 finally 已在失败时保留 dirty 并 scheduleFlush；此处继续抛出供测试/诊断
+        flush()
+      })
+    } catch (err) {
+      // schedule 本身失败：复位标志，允许后续 scheduleFlush 重试
       scheduleQueued = false
-      flush()
-      // flush 内 render 可能再次 dirty；再挂一轮
-      if (dirty || nextPending !== null) {
-        scheduleFlush()
-      }
-    })
+      throw err
+    }
   }
 
-  function select<T>(selector: (snapshot: TSnapshot) => T): ReadonlySignal<T> {
+  function select<T>(selector: (snapshot: Readonly<TSnapshot>) => T): ReadonlySignal<T> {
     const selected = createSignal(selector(published.peek()))
     published.subscribe(() => {
       const next = selector(published.peek())
@@ -201,7 +221,7 @@ export function createFrameTransaction<
   }
 
   return {
-    published$: Object.assign((() => published()) as ReadonlySignal<TSnapshot>, {
+    published$: Object.assign((() => published()) as ReadonlySignal<Readonly<TSnapshot>>, {
       peek: published.peek,
       subscribe: published.subscribe,
     }),

--- a/packages/core/src/foundation/reactivity/frameTransaction.ts
+++ b/packages/core/src/foundation/reactivity/frameTransaction.ts
@@ -1,0 +1,219 @@
+/**
+ * 帧事务：高频输入集中写入，每帧最多发布一次不可变快照。
+ *
+ * @remarks
+ * 解决两类问题：
+ * 1. pointermove 等事件若直接写普通 Signal，会按事件频率广播订阅者。
+ * 2. latest 与 published 双视图会让不同模块读到不同代际状态。
+ *
+ * 本原语只暴露 pending 写入与 published 快照，不暴露公开 latest。
+ * 一帧固定走 capture → derive → seal → render → publish → complete。
+ * render 或 publish 期间的 writeInput 一律进入下一代 pending。
+ */
+
+import { createSignal, type ReadonlySignal } from './signal'
+
+/** 帧事务所处阶段；用于隔离重入写入 */
+export type FramePhase = 'idle' | 'capturing' | 'deriving' | 'sealing' | 'rendering' | 'publishing'
+
+/**
+ * 浅合并输入补丁。
+ * 仅顶层键覆盖，不递归合并嵌套对象。
+ */
+function mergeInput<T extends Record<string, unknown>>(base: T, patch: Partial<T>): T {
+  return { ...base, ...patch }
+}
+
+export interface FrameTransactionOptions<TInput extends Record<string, unknown>, TSnapshot> {
+  /** 初始 pending 输入；也会用于生成 generation 0 的占位 published */
+  initialInput: TInput
+  /**
+   * 由封存输入纯推导快照。
+   * 不得写外部 kernel / DOM；失败则本帧不发布。
+   */
+  derive: (input: Readonly<TInput>, generation: number) => TSnapshot
+  /**
+   * 可选：使用本帧快照绘制或执行副作用。
+   * 此阶段 writeInput 进入下一代，不得假定能改当前快照。
+   */
+  render?: (snapshot: TSnapshot) => void
+  /**
+   * 调度 flush 的宿主。默认 requestAnimationFrame；测试可注入同步队列。
+   * 返回值可忽略（兼容 rAF handle）。
+   */
+  schedule?: (run: () => void) => unknown
+}
+
+export interface FrameTransaction<TInput extends Record<string, unknown>, TSnapshot> {
+  /** 最近一次成功发布的快照（只读 Signal） */
+  readonly published$: ReadonlySignal<TSnapshot>
+  /** 已成功发布的帧代际；失败 flush 不增加 */
+  readonly generation: number
+  /** 当前阶段，调试与不变量检查用 */
+  readonly phase: FramePhase
+  /**
+   * 合并高频输入。idle 写入当前 pending；非 idle 写入 nextPending。
+   * 不触发订阅通知。
+   */
+  writeInput(patch: Partial<TInput>): void
+  /**
+   * 同步执行一帧事务。无 pending 时返回当前 published，且不通知。
+   * @returns 本帧使用的快照（成功时等于 published$.peek()）
+   */
+  flush(): TSnapshot
+  /**
+   * 请求在宿主调度器上合并 flush；多次调用在同一 pending 调度内只注册一次。
+   */
+  scheduleFlush(): void
+  /**
+   * 从 published 投影只读 Signal。
+   * 仅当 select 结果相对上一值 Object.is 不等时通知。
+   */
+  select<T>(selector: (snapshot: TSnapshot) => T): ReadonlySignal<T>
+}
+
+/**
+ * 创建帧事务控制器。
+ *
+ * @typeParam TInput - 可合并的输入形状（浅层 Partial 合并）
+ * @typeParam TSnapshot - derive 产出的不可变快照类型
+ */
+export function createFrameTransaction<
+  TInput extends Record<string, unknown>,
+  TSnapshot,
+>(options: FrameTransactionOptions<TInput, TSnapshot>): FrameTransaction<TInput, TSnapshot> {
+  const { derive, render } = options
+  const schedule =
+    options.schedule ??
+    ((run: () => void) => {
+      if (typeof requestAnimationFrame === 'function') {
+        return requestAnimationFrame(run)
+      }
+      return setTimeout(run, 0)
+    })
+
+  /** 当前代可写入的输入（仅 idle 时接收 writeInput） */
+  let pending: TInput = { ...options.initialInput }
+  /** 事务进行中产生的输入，complete 后并入下一代 */
+  let nextPending: TInput | null = null
+  /** 是否存在尚未 flush 的 pending 变更 */
+  let dirty = false
+  let generation = 0
+  let phase: FramePhase = 'idle'
+  let scheduleQueued = false
+
+  // generation 0：用初始输入 derive 一次，作为 published 占位，避免订阅者读到 undefined
+  const initialSnapshot = derive({ ...pending }, 0)
+  const published = createSignal<TSnapshot>(initialSnapshot)
+
+  function writeInput(patch: Partial<TInput>): void {
+    if (phase === 'idle') {
+      pending = mergeInput(pending, patch)
+      dirty = true
+      return
+    }
+    // capturing 之后当前输入已封存；重入写入只能进下一代
+    const base = nextPending ?? pending
+    nextPending = mergeInput(base, patch)
+  }
+
+  function flush(): TSnapshot {
+    if (!dirty && nextPending === null) {
+      return published.peek()
+    }
+
+    // 若仅有 nextPending（例如上一帧 render 中写入），提升为当前 pending
+    if (!dirty && nextPending !== null) {
+      pending = nextPending
+      nextPending = null
+      dirty = true
+    }
+
+    let sealedInput: TInput | undefined
+    phase = 'capturing'
+    try {
+      sealedInput = pending
+      dirty = false
+      // 本帧 capture 之后的新写入进入 nextPending，不得污染 sealedInput
+      pending = { ...sealedInput }
+
+      phase = 'deriving'
+      const nextGeneration = generation + 1
+      const snapshot = derive(sealedInput, nextGeneration)
+
+      phase = 'sealing'
+      // 浅层冻结快照根对象；大数组字段由 derive 侧做结构共享，禁止在此深拷贝
+      if (typeof snapshot === 'object' && snapshot !== null) {
+        Object.freeze(snapshot)
+      }
+
+      phase = 'rendering'
+      render?.(snapshot)
+
+      phase = 'publishing'
+      published.set(snapshot)
+      generation = nextGeneration
+
+      return snapshot
+    } catch (err) {
+      // derive/render 失败：不推进 generation，保留 sealed 输入供重试
+      if (sealedInput !== undefined) {
+        pending = sealedInput
+        dirty = true
+      }
+      throw err
+    } finally {
+      phase = 'idle'
+      // 事务中累积的 nextPending 与重试 pending 合并
+      if (nextPending !== null) {
+        pending = mergeInput(pending, nextPending)
+        nextPending = null
+        dirty = true
+      }
+    }
+  }
+
+  function scheduleFlush(): void {
+    if (scheduleQueued) return
+    if (!dirty && nextPending === null) return
+    scheduleQueued = true
+    schedule(() => {
+      scheduleQueued = false
+      flush()
+      // flush 内 render 可能再次 dirty；再挂一轮
+      if (dirty || nextPending !== null) {
+        scheduleFlush()
+      }
+    })
+  }
+
+  function select<T>(selector: (snapshot: TSnapshot) => T): ReadonlySignal<T> {
+    const selected = createSignal(selector(published.peek()))
+    published.subscribe(() => {
+      const next = selector(published.peek())
+      selected.set(next)
+    })
+    const read = (): T => selected()
+    return Object.assign(read, {
+      peek: selected.peek,
+      subscribe: selected.subscribe,
+    }) as ReadonlySignal<T>
+  }
+
+  return {
+    published$: Object.assign((() => published()) as ReadonlySignal<TSnapshot>, {
+      peek: published.peek,
+      subscribe: published.subscribe,
+    }),
+    get generation() {
+      return generation
+    },
+    get phase() {
+      return phase
+    },
+    writeInput,
+    flush,
+    scheduleFlush,
+    select,
+  }
+}

--- a/packages/core/src/foundation/reactivity/index.ts
+++ b/packages/core/src/foundation/reactivity/index.ts
@@ -15,6 +15,7 @@ export type {
   WritableRef,
   ReadonlyRef,
   Computed,
+  SelectedSignal,
 } from './signal'
 export { createFrameTransaction } from './frameTransaction'
 export type {

--- a/packages/core/src/foundation/reactivity/index.ts
+++ b/packages/core/src/foundation/reactivity/index.ts
@@ -15,3 +15,9 @@ export type {
   ReadonlyRef,
   Computed,
 } from './signal'
+export { createFrameTransaction } from './frameTransaction'
+export type {
+  FramePhase,
+  FrameTransaction,
+  FrameTransactionOptions,
+} from './frameTransaction'

--- a/packages/core/src/foundation/reactivity/index.ts
+++ b/packages/core/src/foundation/reactivity/index.ts
@@ -4,6 +4,7 @@ export {
   computed,
   effect,
   batch,
+  selectSignal,
   createStateStore,
   createSubState,
 } from './signal'

--- a/packages/core/src/foundation/reactivity/signal.ts
+++ b/packages/core/src/foundation/reactivity/signal.ts
@@ -234,6 +234,35 @@ export function batch<T>(fn: () => T): T {
 }
 
 /**
+ * 从源 Signal 投影只读 Signal。
+ * 仅当 selector 结果相对上一值 equal 判定为不等时通知。
+ *
+ * @remarks
+ * 用于框架桥接：避免整包 snapshot 变化时无关字段也触发 UI 更新。
+ * 默认 equal 为 Object.is；对 {x,y} 等可传入结构相等函数。
+ *
+ * @typeParam T - 源快照类型
+ * @typeParam U - 投影结果类型
+ */
+export function selectSignal<T, U>(
+  source: ReadonlySignal<T>,
+  selector: (value: T) => U,
+  equal: (a: U, b: U) => boolean = Object.is,
+): ReadonlySignal<U> {
+  const selected = createSignal(selector(source.peek()))
+  source.subscribe(() => {
+    const next = selector(source.peek())
+    if (equal(selected.peek(), next)) return
+    selected.set(next)
+  })
+  const read = (): U => selected()
+  return Object.assign(read, {
+    peek: selected.peek,
+    subscribe: selected.subscribe,
+  }) as ReadonlySignal<U>
+}
+
+/**
  * 从初始状态对象创建一组相关 signal。
  *
  * @typeParam T - 状态对象的形状

--- a/packages/core/src/foundation/reactivity/signal.ts
+++ b/packages/core/src/foundation/reactivity/signal.ts
@@ -234,12 +234,21 @@ export function batch<T>(fn: () => T): T {
 }
 
 /**
+ * selectSignal 返回值：只读投影 + 解除对 source 的订阅。
+ */
+export type SelectedSignal<U> = ReadonlySignal<U> & {
+  /** 取消对 source 的订阅；之后不再随 source 更新 */
+  dispose: () => void
+}
+
+/**
  * 从源 Signal 投影只读 Signal。
  * 仅当 selector 结果相对上一值 equal 判定为不等时通知。
  *
  * @remarks
  * 用于框架桥接：避免整包 snapshot 变化时无关字段也触发 UI 更新。
  * 默认 equal 为 Object.is；对 {x,y} 等可传入结构相等函数。
+ * 短生命周期投影必须调用 dispose，否则会永久订阅 source。
  *
  * @typeParam T - 源快照类型
  * @typeParam U - 投影结果类型
@@ -248,9 +257,9 @@ export function selectSignal<T, U>(
   source: ReadonlySignal<T>,
   selector: (value: T) => U,
   equal: (a: U, b: U) => boolean = Object.is,
-): ReadonlySignal<U> {
+): SelectedSignal<U> {
   const selected = createSignal(selector(source.peek()))
-  source.subscribe(() => {
+  const unsubSource = source.subscribe(() => {
     const next = selector(source.peek())
     if (equal(selected.peek(), next)) return
     selected.set(next)
@@ -259,7 +268,8 @@ export function selectSignal<T, U>(
   return Object.assign(read, {
     peek: selected.peek,
     subscribe: selected.subscribe,
-  }) as ReadonlySignal<U>
+    dispose: unsubSource,
+  }) as SelectedSignal<U>
 }
 
 /**

--- a/packages/core/src/foundation/tokens/__tests__/__snapshots__/baseline.test.ts.snap
+++ b/packages/core/src/foundation/tokens/__tests__/__snapshots__/baseline.test.ts.snap
@@ -71,7 +71,7 @@ exports[`theme baseline — dark > CSS declaration block (snapshot) 1`] = `
   --klc-color-tag-bg-transparent: transparent;
   --klc-color-tag-bg-active: #1890ff;
   --klc-color-tag-bg-active-hover: #40a9ff;
-  --klc-color-tag-bg-hover: #262C36;
+  --klc-color-tag-bg-hover: #2D3544;
   --klc-color-border-dark: rgba(255, 255, 255, 0.15);
   --klc-color-border-medium: rgba(255, 255, 255, 0.12);
   --klc-color-border-light: rgba(255, 255, 255, 0.08);
@@ -271,7 +271,7 @@ exports[`theme baseline — light > CSS declaration block (snapshot) 1`] = `
   --klc-color-tag-bg-transparent: transparent;
   --klc-color-tag-bg-active: #1890ff;
   --klc-color-tag-bg-active-hover: #40a9ff;
-  --klc-color-tag-bg-hover: #f0f0f0;
+  --klc-color-tag-bg-hover: #E5E7EB;
   --klc-color-border-dark: rgba(0, 0, 0, 0.12);
   --klc-color-border-medium: rgba(0, 0, 0, 0.10);
   --klc-color-border-light: rgba(0, 0, 0, 0.08);

--- a/packages/core/src/rendering/render/Renderer.ts
+++ b/packages/core/src/rendering/render/Renderer.ts
@@ -65,12 +65,24 @@ export type DrawInstancesParams = {
   uniforms?: Record<string, unknown>
 }
 
+export type DrawLineStrip = {
+  points: ReadonlyArray<{ x: number; y: number }>
+  color: string
+  width?: number
+}
+
 export type DrawLinesParams = {
   pipeline: PipelineHandle
-  vertices: BufferHandle
-  vertexCount: number
+  /**
+   * 单 strip 路径：vertices 为交错 x,y Float32。
+   * 若提供 strips，则忽略 vertices/vertexCount，一次 GPU 提交多条（避免 MSAA 逐条 clear）。
+   */
+  vertices?: BufferHandle
+  vertexCount?: number
   /** Line strip vs disconnected segments. */
   topology?: 'strip' | 'list'
+  /** 多色折线批量（推荐 MA 等多周期） */
+  strips?: ReadonlyArray<DrawLineStrip>
   uniforms?: Record<string, unknown>
 }
 
@@ -117,8 +129,16 @@ export interface Renderer {
   // --- frame ---
 
   beginFrame(region: SurfaceRegion): void
-  drawInstances(params: DrawInstancesParams): void
-  drawLines(params: DrawLinesParams): void
+  /**
+   * 返回 true 表示本批已成功提交 GPU（或 instanceCount<=0 无需绘制）。
+   * 返回 false 表示未画上（无 surface / pipeline 不匹配 / 资源缺失）——调用方应 fail-closed 走 2D。
+   */
+  drawInstances(params: DrawInstancesParams): boolean
+  /**
+   * 返回 true 表示本批折线/填充已成功提交 GPU。
+   * 返回 false 表示未画上——调用方应 fail-closed 走 2D。
+   */
+  drawLines(params: DrawLinesParams): boolean
   /** WebGPU only — WebGL implementations MUST throw. Caller checks caps first. */
   dispatchCompute(params: DispatchComputeParams): void
   endFrame(): void

--- a/packages/core/src/rendering/render/Renderer.ts
+++ b/packages/core/src/rendering/render/Renderer.ts
@@ -2,12 +2,9 @@
  * High-level renderer interface — the drawing primitives the chart's
  * scene layers (candles, volume, indicators, drawings) call into.
  *
- * Both the existing WebGL renderer (currently spread across
- * `src/core/renderers/{candle,subVolume,crosshair,...}.ts`) and the
- * P1 WebGPU renderer implement this contract. v0's WebGL path will
- * be refactored to fit behind it in a follow-up PR (this file ships
- * the contract first; the legacy code is unchanged until the next
- * step is approved).
+ * WebGL (`createWebGLRenderer`) implements this contract today; P1 WebGPU
+ * will implement the same surface. Call sites only use sceneRenderer
+ * (fail-closed boolean → Canvas2D), never dual-path surfaces.
  *
  * Design notes:
  * - `drawInstances` is the workhorse: render N copies of a unit geometry
@@ -22,10 +19,6 @@
  * - `setUniforms` is intentionally schemaless on the interface — the
  *   uniform layout is owned by each shader/program. Callers pass a
  *   structured object that the backend translates into uniform writes.
- *
- * This file is **pure interface** in this PR; behaviour comes in the
- * next two PRs (Scale interfaces, then a Renderer impl that wraps
- * the existing WebGL primitives).
  */
 
 import type { SurfaceBackend, SurfaceRegion } from './SurfaceBackend'

--- a/packages/core/src/rendering/render/SurfaceBackend.ts
+++ b/packages/core/src/rendering/render/SurfaceBackend.ts
@@ -2,22 +2,20 @@
  * Low-level GPU surface backend.
  *
  * Abstracts canvas + context lifecycle, viewport / scissor regions, clear,
- * compositing into a 2D canvas overlay, and teardown. Both the existing
- * WebGL surface (`src/core/renderers/webgl/sharedWebGLSurface.ts`) and the
- * P1 WebGPU surface implement this contract.
+ * compositing into a 2D canvas overlay, and teardown. WebGL
+ * (`createWebGLSurfaceBackend` over SharedWebGLSurface) implements this today;
+ * P1 WebGPU will implement the same contract.
  *
  * This file is **pure interface** — no implementation. It exists so that:
  *
- * 1. Existing WebGL code can declare conformance via a one-line adapter
- *    (see `createLegacyWebGLBackend` below) without changing any behaviour.
+ * 1. WebGL can adapt SharedWebGLSurface behind a stable contract.
  * 2. P1's WebGPU implementation has a fixed target to write against.
  * 3. The higher-level `Renderer` (`./Renderer.ts`) can compose a backend
  *    without knowing which GPU API it sits on.
  *
  * Design notes:
  * - All region coordinates are in **logical pixels** with the surface
- *   responsible for DPR scaling internally. This matches the existing
- *   `WebGLRegion` semantics so the legacy adapter is a transparent pass-through.
+ *   responsible for DPR scaling internally (same semantics as WebGLRegion).
  * - `compositeTo` takes a 2D `CanvasRenderingContext2D` because the chart's
  *   final composition target is a 2D overlay canvas — WebGL/WebGPU pixels
  *   are drawn into the overlay via `drawImage`. Future paths that bypass

--- a/packages/core/src/rendering/render/__tests__/canvas2DRenderer.test.ts
+++ b/packages/core/src/rendering/render/__tests__/canvas2DRenderer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCanvas2DRenderer } from '../createCanvas2DRenderer'
+
+describe('createCanvas2DRenderer', () => {
+  it('fails closed so business renderers use Canvas2D', () => {
+    const renderer = createCanvas2DRenderer()
+    const buffer = renderer.createBuffer('instance', 16)
+    const pipeline = renderer.createPipeline({ type: 'candle' })
+
+    expect(renderer.caps.name).toBe('canvas2d')
+    expect(renderer.surface.isAvailable()).toBe(false)
+    expect(
+      renderer.drawInstances({
+        pipeline,
+        vertices: buffer,
+        instances: buffer,
+        instanceCount: 1,
+        vertexCount: 6,
+      }),
+    ).toBe(false)
+    expect(renderer.drawLines({ pipeline, strips: [] })).toBe(false)
+  })
+
+  it('has an idempotent disposed lifecycle', () => {
+    const renderer = createCanvas2DRenderer()
+
+    renderer.dispose()
+    renderer.dispose()
+
+    expect(() => renderer.createBuffer('vertex', 8)).toThrow('Renderer is disposed')
+    expect(() => renderer.createComputePipeline({})).toThrow('compute not supported')
+  })
+})

--- a/packages/core/src/rendering/render/__tests__/contract.test.ts
+++ b/packages/core/src/rendering/render/__tests__/contract.test.ts
@@ -109,8 +109,8 @@ function makeMockRenderer(surface: SurfaceBackend, computeSupported: boolean): R
     },
     destroyComputePipeline: () => {},
     beginFrame: () => {},
-    drawInstances: () => {},
-    drawLines: () => {},
+    drawInstances: () => true,
+    drawLines: () => true,
     dispatchCompute: () => {
       if (!computeSupported) {
         throw new Error('dispatchCompute requires a backend with caps.compute === true')

--- a/packages/core/src/rendering/render/__tests__/frameMetrics.test.ts
+++ b/packages/core/src/rendering/render/__tests__/frameMetrics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { createFrameMetrics, getFrameMetrics, resetFrameMetrics } from '../frameMetrics'
+
+describe('frameMetrics', () => {
+  it('counts submits uploads and buffer creates per frame', () => {
+    resetFrameMetrics()
+    const m = createFrameMetrics()
+    m.beginFrame()
+    m.recordBufferCreate()
+    m.recordUpload(64)
+    m.recordDraw()
+    m.recordSubmit()
+    m.recordComposite()
+    m.endFrame()
+    expect(getFrameMetrics()).toMatchObject({
+      bufferCreateCount: 1,
+      bufferUploadBytes: 64,
+      drawCallCount: 1,
+      queueSubmitCount: 1,
+      compositeCount: 1,
+    })
+  })
+})

--- a/packages/core/src/rendering/render/__tests__/rendererHost.test.ts
+++ b/packages/core/src/rendering/render/__tests__/rendererHost.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Renderer } from '../Renderer'
+import { createCanvas2DRenderer } from '../createCanvas2DRenderer'
+import { createRendererHost, type RendererBackend } from '../rendererHost'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function makeRenderer(backend: RendererBackend): Renderer {
+  const renderer = createCanvas2DRenderer()
+  return {
+    ...renderer,
+    caps: { ...renderer.caps, name: backend === 'webgl' ? 'webgl2' : backend },
+  }
+}
+
+describe('RendererHost', () => {
+  it('degrades WebGPU to WebGL without changing the requested preference', async () => {
+    const webgl = makeRenderer('webgl')
+    const onRuntimeChange = vi.fn()
+    const host = await createRendererHost('webgpu', {
+      createWebGPU: async () => {
+        throw new Error('adapter unavailable')
+      },
+      createWebGL: () => webgl,
+      createCanvas: createCanvas2DRenderer,
+      onRuntimeChange,
+    })
+
+    expect(host.renderer).toBe(webgl)
+    expect(host.runtime).toEqual({
+      effective: 'webgl',
+      status: 'degraded',
+      error: 'adapter unavailable',
+    })
+    expect(onRuntimeChange).toHaveBeenLastCalledWith(host.runtime)
+  })
+
+  it('degrades WebGL to Canvas when WebGL is unavailable', async () => {
+    const host = await createRendererHost('webgl', {
+      createWebGPU: () => makeRenderer('webgpu'),
+      createWebGL: () => {
+        throw new Error('WebGL2 unavailable')
+      },
+      createCanvas: createCanvas2DRenderer,
+    })
+
+    expect(host.renderer.caps.name).toBe('canvas2d')
+    expect(host.runtime).toEqual({
+      effective: 'canvas',
+      status: 'degraded',
+      error: 'WebGL2 unavailable',
+    })
+  })
+
+  it('keeps the active renderer while a replacement is prepared', async () => {
+    const pending = deferred<Renderer>()
+    const webgl = makeRenderer('webgl')
+    const webgpu = makeRenderer('webgpu')
+    const host = await createRendererHost('webgl', {
+      createWebGPU: () => pending.promise,
+      createWebGL: () => webgl,
+      createCanvas: createCanvas2DRenderer,
+    })
+
+    const switching = host.switchTo('webgpu')
+
+    expect(host.renderer).toBe(webgl)
+    expect(host.runtime.status).toBe('switching')
+
+    pending.resolve(webgpu)
+    await switching
+
+    expect(host.renderer).toBe(webgpu)
+    expect(host.runtime).toEqual({ effective: 'webgpu', status: 'ready', error: null })
+  })
+
+  it('preserves the surface size when switching renderers', async () => {
+    const webgl = makeRenderer('webgl')
+    const webgpu = makeRenderer('webgpu')
+    const resizeWebGL = vi.spyOn(webgl.surface, 'resize')
+    const resizeWebGPU = vi.spyOn(webgpu.surface, 'resize')
+    const host = await createRendererHost('webgl', {
+      createWebGPU: () => webgpu,
+      createWebGL: () => webgl,
+      createCanvas: createCanvas2DRenderer,
+    })
+
+    host.resize(960, 540, 1.5)
+    await host.switchTo('webgpu')
+
+    expect(resizeWebGL).toHaveBeenCalledWith(960, 540, 1.5)
+    expect(resizeWebGPU).toHaveBeenCalledWith(960, 540, 1.5)
+  })
+
+  it('disposes a stale renderer created by an older switch', async () => {
+    const pending = deferred<Renderer>()
+    const stale = makeRenderer('webgpu')
+    const staleDispose = vi.spyOn(stale, 'dispose')
+    const host = await createRendererHost('canvas', {
+      createWebGPU: () => pending.promise,
+      createWebGL: () => makeRenderer('webgl'),
+      createCanvas: createCanvas2DRenderer,
+    })
+
+    const oldSwitch = host.switchTo('webgpu')
+    await host.switchTo('canvas')
+    pending.resolve(stale)
+    await oldSwitch
+
+    expect(staleDispose).toHaveBeenCalledOnce()
+    expect(host.runtime.effective).toBe('canvas')
+  })
+
+  it('disposes a renderer that arrives after the host is disposed', async () => {
+    const pending = deferred<Renderer>()
+    const late = makeRenderer('webgpu')
+    const lateDispose = vi.spyOn(late, 'dispose')
+    const host = await createRendererHost('canvas', {
+      createWebGPU: () => pending.promise,
+      createWebGL: () => makeRenderer('webgl'),
+      createCanvas: createCanvas2DRenderer,
+    })
+
+    const switching = host.switchTo('webgpu')
+    host.dispose()
+    pending.resolve(late)
+    await switching
+
+    expect(lateDispose).toHaveBeenCalledOnce()
+  })
+
+  it('degrades the active WebGPU renderer after device loss', async () => {
+    const webgpu = makeRenderer('webgpu')
+    const webgl = makeRenderer('webgl')
+    const host = await createRendererHost('webgpu', {
+      createWebGPU: () => webgpu,
+      createWebGL: () => webgl,
+      createCanvas: createCanvas2DRenderer,
+    })
+
+    await host.handleDeviceLost('device reset')
+
+    expect(host.renderer).toBe(webgl)
+    expect(host.runtime).toEqual({
+      effective: 'webgl',
+      status: 'degraded',
+      error: 'device reset',
+    })
+  })
+})

--- a/packages/core/src/rendering/render/__tests__/webglRenderer.fallback.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webglRenderer.fallback.test.ts
@@ -92,7 +92,8 @@ describe('Canvas2D fallback', () => {
   })
 
   describe('drawLines — line type', () => {
-    it('draws a polyline on the fallback context when WebGL is unavailable', () => {
+    it('returns false without overlay fallback when lineSurface unavailable', () => {
+      // fail-closed: 折线不走 overlay fallbackCtx
       const surface = createMockSurfaceBackend()
       const glSurface = createMockSharedWebGLSurface()
       const renderer = createWebGLRenderer(surface, glSurface as any)
@@ -106,23 +107,18 @@ describe('Canvas2D fallback', () => {
       const verts = new Float32Array([10, 20, 30, 40, 50, 60])
       renderer.writeBuffer(vertexBuf, verts)
 
-      renderer.drawLines({
+      const ok = renderer.drawLines({
         pipeline,
         vertices: vertexBuf,
         vertexCount: 3,
         uniforms: { color: '#00ff00', scrollLeft: 5, lineWidth: 2 },
       })
 
-      expect(ctx.beginPath).toHaveBeenCalledTimes(1)
-      expect(ctx.moveTo).toHaveBeenCalledWith(5, 20)
-      expect(ctx.lineTo).toHaveBeenCalledWith(25, 40)
-      expect(ctx.lineTo).toHaveBeenCalledWith(45, 60)
-      expect(ctx.strokeStyle).toBe('#00ff00')
-      expect(ctx.lineWidth).toBe(2)
-      expect(ctx.stroke).toHaveBeenCalledTimes(1)
+      expect(ok).toBe(false)
+      expect(ctx.stroke).not.toHaveBeenCalled()
     })
 
-    it('no-ops on drawLines with no fallback context', () => {
+    it('returns false on drawLines with no lineSurface', () => {
       const surface = createMockSurfaceBackend()
       const glSurface = createMockSharedWebGLSurface()
       const renderer = createWebGLRenderer(surface, glSurface as any)
@@ -132,14 +128,12 @@ describe('Canvas2D fallback', () => {
       const vertexBuf = renderer.createBuffer('vertex', 256)
       renderer.writeBuffer(vertexBuf, new Float32Array([0, 0, 100, 100]))
 
-      expect(() =>
-        renderer.drawLines({ pipeline, vertices: vertexBuf, vertexCount: 2 }),
-      ).not.toThrow()
+      expect(renderer.drawLines({ pipeline, vertices: vertexBuf, vertexCount: 2 })).toBe(false)
     })
   })
 
   describe('drawLines — fill type', () => {
-    it('draws a filled band on the fallback context', () => {
+    it('returns false without overlay fallback when lineSurface unavailable', () => {
       const surface = createMockSurfaceBackend()
       const glSurface = createMockSharedWebGLSurface()
       const renderer = createWebGLRenderer(surface, glSurface as any)
@@ -153,28 +147,21 @@ describe('Canvas2D fallback', () => {
       const verts = new Float32Array([0, 100, 0, 50, 100, 100, 100, 50, 200, 100, 200, 50])
       renderer.writeBuffer(vertexBuf, verts)
 
-      renderer.drawLines({
+      const ok = renderer.drawLines({
         pipeline,
         vertices: vertexBuf,
         vertexCount: 6,
         uniforms: { color: '#0000ff', scrollLeft: 5 },
       })
 
-      expect(ctx.beginPath).toHaveBeenCalledTimes(1)
-      expect(ctx.moveTo).toHaveBeenCalledWith(-5, 100)
-      expect(ctx.lineTo).toHaveBeenCalledWith(95, 100)
-      expect(ctx.lineTo).toHaveBeenCalledWith(195, 100)
-      expect(ctx.lineTo).toHaveBeenCalledWith(195, 50)
-      expect(ctx.lineTo).toHaveBeenCalledWith(95, 50)
-      expect(ctx.lineTo).toHaveBeenCalledWith(-5, 50)
-      expect(ctx.closePath).toHaveBeenCalledTimes(1)
-      expect(ctx.fillStyle).toBe('#0000ff')
-      expect(ctx.fill).toHaveBeenCalledTimes(1)
+      expect(ok).toBe(false)
+      expect(ctx.fill).not.toHaveBeenCalled()
     })
   })
 
   describe('drawInstances', () => {
-    it('draws rectangles on the fallback context', () => {
+    it('returns false without drawing on overlay fallback when candleSurface unavailable', () => {
+      // fail-closed: candle 不走 overlay fallbackCtx，避免画到 overlay 却当 GPU 成功
       const surface = createMockSurfaceBackend()
       const glSurface = createMockSharedWebGLSurface()
       const renderer = createWebGLRenderer(surface, glSurface as any)
@@ -188,7 +175,7 @@ describe('Canvas2D fallback', () => {
       const rects = new Float32Array([10, 20, 30, 40, 60, 70, 20, 10])
       renderer.writeBuffer(instanceBuf, rects)
 
-      renderer.drawInstances({
+      const ok = renderer.drawInstances({
         pipeline,
         vertices: instanceBuf,
         instances: instanceBuf,
@@ -197,10 +184,8 @@ describe('Canvas2D fallback', () => {
         uniforms: { color: '#ff0000', scrollLeft: 5 },
       })
 
-      expect(ctx.fillRect).toHaveBeenCalledTimes(2)
-      expect(ctx.fillRect).toHaveBeenNthCalledWith(1, 5, 20, 30, 40)
-      expect(ctx.fillRect).toHaveBeenNthCalledWith(2, 55, 70, 20, 10)
-      expect(ctx.fillStyle).toBe('#ff0000')
+      expect(ok).toBe(false)
+      expect(ctx.fillRect).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/rendering/render/__tests__/webglRenderer.fallback.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webglRenderer.fallback.test.ts
@@ -54,51 +54,16 @@ function createMockSharedWebGLSurface() {
   }
 }
 
-function makeMockFallbackCtx() {
-  return {
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    closePath: vi.fn(),
-    fill: vi.fn(),
-    stroke: vi.fn(),
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 1,
-    fillRect: vi.fn(),
-  }
-}
-
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('Canvas2D fallback', () => {
-  it('setFallbackContext stores the context and dpr', () => {
-    const surface = createMockSurfaceBackend()
-    const glSurface = createMockSharedWebGLSurface()
-    const renderer = createWebGLRenderer(surface, glSurface as any)
-    const ctx = makeMockFallbackCtx()
-
-    expect(() => (renderer as any).setFallbackContext(ctx, 2)).not.toThrow()
-  })
-
-  it('setFallbackContext with null clears the fallback', () => {
-    const surface = createMockSurfaceBackend()
-    const glSurface = createMockSharedWebGLSurface()
-    const renderer = createWebGLRenderer(surface, glSurface as any)
-
-    expect(() => (renderer as any).setFallbackContext(null, 1)).not.toThrow()
-  })
-
+describe('fail-closed when GPU surfaces unavailable', () => {
   describe('drawLines — line type', () => {
-    it('returns false without overlay fallback when lineSurface unavailable', () => {
-      // fail-closed: 折线不走 overlay fallbackCtx
+    it('returns false when lineSurface unavailable', () => {
       const surface = createMockSurfaceBackend()
       const glSurface = createMockSharedWebGLSurface()
       const renderer = createWebGLRenderer(surface, glSurface as any)
-      const ctx = makeMockFallbackCtx()
-      ;(renderer as any).setFallbackContext(ctx, 1)
 
       renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
 
@@ -115,7 +80,6 @@ describe('Canvas2D fallback', () => {
       })
 
       expect(ok).toBe(false)
-      expect(ctx.stroke).not.toHaveBeenCalled()
     })
 
     it('returns false on drawLines with no lineSurface', () => {
@@ -133,12 +97,10 @@ describe('Canvas2D fallback', () => {
   })
 
   describe('drawLines — fill type', () => {
-    it('returns false without overlay fallback when lineSurface unavailable', () => {
+    it('returns false when lineSurface unavailable', () => {
       const surface = createMockSurfaceBackend()
       const glSurface = createMockSharedWebGLSurface()
       const renderer = createWebGLRenderer(surface, glSurface as any)
-      const ctx = makeMockFallbackCtx()
-      ;(renderer as any).setFallbackContext(ctx, 1)
 
       renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
 
@@ -155,18 +117,14 @@ describe('Canvas2D fallback', () => {
       })
 
       expect(ok).toBe(false)
-      expect(ctx.fill).not.toHaveBeenCalled()
     })
   })
 
   describe('drawInstances', () => {
-    it('returns false without drawing on overlay fallback when candleSurface unavailable', () => {
-      // fail-closed: candle 不走 overlay fallbackCtx，避免画到 overlay 却当 GPU 成功
+    it('returns false when candleSurface unavailable', () => {
       const surface = createMockSurfaceBackend()
       const glSurface = createMockSharedWebGLSurface()
       const renderer = createWebGLRenderer(surface, glSurface as any)
-      const ctx = makeMockFallbackCtx()
-      ;(renderer as any).setFallbackContext(ctx, 1)
 
       renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
 
@@ -185,17 +143,14 @@ describe('Canvas2D fallback', () => {
       })
 
       expect(ok).toBe(false)
-      expect(ctx.fillRect).not.toHaveBeenCalled()
     })
   })
 
   describe('dispose behaviour', () => {
-    it('after dispose, fallback draw calls are no-ops', () => {
+    it('after dispose, draw calls are no-ops / false', () => {
       const surface = createMockSurfaceBackend()
       const glSurface = createMockSharedWebGLSurface()
       const renderer = createWebGLRenderer(surface, glSurface as any)
-      const ctx = makeMockFallbackCtx()
-      ;(renderer as any).setFallbackContext(ctx, 1)
 
       const pipeline = renderer.createPipeline({ type: 'line' })
       const vertexBuf = renderer.createBuffer('vertex', 256)
@@ -206,7 +161,7 @@ describe('Canvas2D fallback', () => {
       expect(() =>
         renderer.drawLines({ pipeline, vertices: vertexBuf, vertexCount: 2 }),
       ).not.toThrow()
-      expect(ctx.stroke).not.toHaveBeenCalled()
+      expect(renderer.drawLines({ pipeline, vertices: vertexBuf, vertexCount: 2 })).toBe(false)
     })
   })
 })

--- a/packages/core/src/rendering/render/__tests__/webglRenderer.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webglRenderer.test.ts
@@ -198,7 +198,7 @@ describe('createWebGLRenderer', () => {
       renderer.writeBuffer(instanceBuf, rects)
 
       const vertices = renderer.createBuffer('vertex', 48)
-      renderer.drawInstances({
+      const ok = renderer.drawInstances({
         pipeline,
         vertices,
         instances: instanceBuf,
@@ -207,6 +207,7 @@ describe('createWebGLRenderer', () => {
         uniforms: { color: '#ff0000', scrollLeft: 0 },
       })
 
+      expect(ok).toBe(true)
       expect(mocks.mockDrawRectBuffer).toHaveBeenCalledTimes(1)
       const args = mocks.mockDrawRectBuffer.mock.calls[0]
       expect(args[0]).toBeInstanceOf(Float32Array)
@@ -215,36 +216,55 @@ describe('createWebGLRenderer', () => {
       expect(args[3]).toBe(0)
     })
 
-    it('no-ops when instanceCount is zero', () => {
+    it('returns true without GPU when instanceCount is zero', () => {
       const { renderer } = makeRenderer()
       renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
       const pipeline = renderer.createPipeline({ type: 'candle' })
       const buf = renderer.createBuffer('instance', 64)
       renderer.writeBuffer(buf, new Float32Array([0, 0, 50, 50]))
-      renderer.drawInstances({
+      const ok = renderer.drawInstances({
         pipeline,
         vertices: buf,
         instances: buf,
         instanceCount: 0,
         vertexCount: 6,
       })
+      expect(ok).toBe(true)
       expect(mocks.mockDrawRectBuffer).not.toHaveBeenCalled()
     })
 
-    it('no-ops when pipeline type mismatch (line -> instances)', () => {
+    it('returns false when pipeline type mismatch (line -> instances)', () => {
       const { renderer } = makeRenderer()
       renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
       const pipeline = renderer.createPipeline({ type: 'line' })
       const buf = renderer.createBuffer('instance', 64)
       renderer.writeBuffer(buf, new Float32Array([0, 0, 50, 50]))
-      renderer.drawInstances({
+      const ok = renderer.drawInstances({
         pipeline,
         vertices: buf,
         instances: buf,
         instanceCount: 1,
         vertexCount: 6,
       })
+      expect(ok).toBe(false)
       expect(mocks.mockDrawRectBuffer).not.toHaveBeenCalled()
+    })
+
+    it('returns false when drawRectBuffer fails', () => {
+      mocks.mockDrawRectBuffer.mockReturnValueOnce(false)
+      const { renderer } = makeRenderer()
+      renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+      const pipeline = renderer.createPipeline({ type: 'candle' })
+      const buf = renderer.createBuffer('instance', 64)
+      renderer.writeBuffer(buf, new Float32Array([0, 0, 50, 50]))
+      const ok = renderer.drawInstances({
+        pipeline,
+        vertices: buf,
+        instances: buf,
+        instanceCount: 1,
+        vertexCount: 6,
+      })
+      expect(ok).toBe(false)
     })
   })
 
@@ -258,7 +278,7 @@ describe('createWebGLRenderer', () => {
       const verts = new Float32Array([10, 20, 30, 40, 50, 60])
       renderer.writeBuffer(vertexBuf, verts)
 
-      renderer.drawLines({
+      const ok = renderer.drawLines({
         pipeline,
         vertices: vertexBuf,
         vertexCount: 3,
@@ -266,6 +286,7 @@ describe('createWebGLRenderer', () => {
         uniforms: { color: '#00ff00', scrollLeft: 10, lineWidth: 1 },
       })
 
+      expect(ok).toBe(true)
       expect(mocks.mockDrawLineStrips).toHaveBeenCalledTimes(1)
       const args = mocks.mockDrawLineStrips.mock.calls[0]
       expect(args[0]).toHaveLength(1)
@@ -273,6 +294,43 @@ describe('createWebGLRenderer', () => {
       expect(args[0][0].width).toBe(1)
       expect(args[0][0].points).toHaveLength(3)
       expect(args[1]).toBe(10)
+    })
+
+    it('batches multiple strips in one drawLineStrips call', () => {
+      const { renderer } = makeRenderer()
+      renderer.beginFrame({ x: 0, y: 0, width: 800, height: 600, dpr: 1 })
+      const pipeline = renderer.createPipeline({ type: 'line' })
+      const ok = renderer.drawLines({
+        pipeline,
+        strips: [
+          {
+            points: [
+              { x: 0, y: 0 },
+              { x: 1, y: 1 },
+            ],
+            color: '#f00',
+            width: 1,
+          },
+          {
+            points: [
+              { x: 0, y: 2 },
+              { x: 1, y: 3 },
+              { x: 2, y: 2 },
+            ],
+            color: '#0f0',
+            width: 2,
+          },
+        ],
+        uniforms: { scrollLeft: 5 },
+      })
+      expect(ok).toBe(true)
+      expect(mocks.mockDrawLineStrips).toHaveBeenCalledTimes(1)
+      const lines = mocks.mockDrawLineStrips.mock.calls[0]![0]
+      expect(lines).toHaveLength(2)
+      expect(lines[0].color).toBe('#f00')
+      expect(lines[1].color).toBe('#0f0')
+      expect(lines[1].width).toBe(2)
+      expect(mocks.mockDrawLineStrips.mock.calls[0]![1]).toBe(5)
     })
 
     it('delegates to line surface drawFilledBand for fill pipeline', () => {

--- a/packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { createWebGPURenderer } from '../createWebGPURenderer'
+import { createFrameMetrics, getFrameMetrics, resetFrameMetrics } from '../frameMetrics'
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -288,5 +289,81 @@ describe('createWebGPURenderer', () => {
     fake.lost.resolve(info)
     await Promise.resolve()
     expect(onDeviceLost).toHaveBeenCalledWith(info)
+  })
+
+  it('reuses strip ResourceTable buffers when geometry revision is unchanged', async () => {
+    resetFrameMetrics()
+    const fake = makeWebGPU()
+    const metrics = createFrameMetrics()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+      metrics,
+    })
+    renderer.surface.resize(200, 100, 1)
+    const pipeline = renderer.createPipeline({ type: 'line' })
+    const strips = [
+      {
+        points: [
+          { x: 0, y: 1 },
+          { x: 2, y: 3 },
+        ],
+        color: '#f00',
+        width: 1,
+      },
+    ]
+
+    renderer.beginFrame({ x: 0, y: 0, width: 200, height: 100, dpr: 1 })
+    expect(renderer.drawLines({ pipeline, strips, uniforms: { scrollLeft: 0 } })).toBe(true)
+    renderer.endFrame()
+    const createsAfterFirst = fake.device.createBuffer.mock.calls.length
+    // strip 点列 4 floats = 16 bytes；uniform 为 32 bytes
+    const vertexWritesAfterFirst = fake.queue.writeBuffer.mock.calls.filter((c) => c[4] === 16)
+      .length
+    const uniformWritesAfterFirst = fake.queue.writeBuffer.mock.calls.filter((c) => c[4] === 32)
+      .length
+
+    renderer.beginFrame({ x: 0, y: 0, width: 200, height: 100, dpr: 1 })
+    expect(renderer.drawLines({ pipeline, strips, uniforms: { scrollLeft: 12 } })).toBe(true)
+    renderer.endFrame()
+
+    // 几何未变：strip vertex 不新建、不重传；uniform 仍写
+    expect(fake.device.createBuffer.mock.calls.length).toBe(createsAfterFirst)
+    expect(
+      fake.queue.writeBuffer.mock.calls.filter((c) => c[4] === 16).length,
+    ).toBe(vertexWritesAfterFirst)
+    expect(
+      fake.queue.writeBuffer.mock.calls.filter((c) => c[4] === 32).length,
+    ).toBeGreaterThan(uniformWritesAfterFirst)
+    expect(getFrameMetrics().queueSubmitCount).toBe(1)
+  })
+
+  it('records submit and draw metrics on endFrame', async () => {
+    resetFrameMetrics()
+    const fake = makeWebGPU()
+    const metrics = createFrameMetrics()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+      metrics,
+    })
+    renderer.surface.resize(200, 100, 1)
+    renderer.beginFrame({ x: 0, y: 0, width: 200, height: 100, dpr: 1 })
+    const pipeline = renderer.createPipeline({ type: 'candle' })
+    const instances = renderer.createBuffer('instance', 16)
+    const vertices = renderer.createBuffer('vertex', 4)
+    renderer.drawInstances({
+      pipeline,
+      vertices,
+      instances,
+      instanceCount: 1,
+      vertexCount: 6,
+      uniforms: { color: '#f00', scrollLeft: 0 },
+    })
+    renderer.endFrame()
+    expect(getFrameMetrics()).toMatchObject({
+      queueSubmitCount: 1,
+      drawCallCount: 1,
+    })
   })
 })

--- a/packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createWebGPURenderer } from '../createWebGPURenderer'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function makeWebGPU() {
+  const passes: Array<ReturnType<typeof makePass>> = []
+  const renderPassDescriptors: GPURenderPassDescriptor[] = []
+  const pipelineDescriptors: GPURenderPipelineDescriptor[] = []
+  const buffers: Array<{ destroy: ReturnType<typeof vi.fn> }> = []
+  const lost = deferred<GPUDeviceLostInfo>()
+
+  function makePass() {
+    return {
+      setViewport: vi.fn(),
+      setScissorRect: vi.fn(),
+      setPipeline: vi.fn(),
+      setVertexBuffer: vi.fn(),
+      setBindGroup: vi.fn(),
+      draw: vi.fn(),
+      end: vi.fn(),
+    }
+  }
+
+  const queue = {
+    writeBuffer: vi.fn(),
+    submit: vi.fn(),
+    onSubmittedWorkDone: vi.fn(async () => {}),
+  }
+  const device = {
+    queue,
+    lost: lost.promise,
+    createBuffer: vi.fn(() => {
+      const buffer = { destroy: vi.fn() }
+      buffers.push(buffer)
+      return buffer
+    }),
+    createShaderModule: vi.fn((descriptor) => descriptor),
+    createRenderPipeline: vi.fn((descriptor: GPURenderPipelineDescriptor) => {
+      pipelineDescriptors.push(descriptor)
+      return { getBindGroupLayout: vi.fn(() => ({})) }
+    }),
+    createBindGroup: vi.fn((descriptor) => descriptor),
+    createTexture: vi.fn(() => ({
+      createView: vi.fn(() => ({ kind: 'msaa-view' })),
+      destroy: vi.fn(),
+    })),
+    createCommandEncoder: vi.fn(() => ({
+      beginRenderPass: vi.fn((descriptor: GPURenderPassDescriptor) => {
+        renderPassDescriptors.push(descriptor)
+        const pass = makePass()
+        passes.push(pass)
+        return pass
+      }),
+      finish: vi.fn(() => ({ kind: 'commands' })),
+    })),
+  }
+  const adapter = { requestDevice: vi.fn(async () => device) }
+  const gpu = {
+    requestAdapter: vi.fn(async () => adapter),
+    getPreferredCanvasFormat: vi.fn(() => 'bgra8unorm'),
+  }
+  const context = {
+    configure: vi.fn(),
+    unconfigure: vi.fn(),
+    getCurrentTexture: vi.fn(() => ({ createView: vi.fn(() => ({ kind: 'target-view' })) })),
+  }
+  const canvas = {
+    width: 1,
+    height: 1,
+    getContext: vi.fn(() => context),
+  } as unknown as HTMLCanvasElement
+
+  return {
+    gpu,
+    adapter,
+    device,
+    queue,
+    context,
+    canvas,
+    passes,
+    renderPassDescriptors,
+    pipelineDescriptors,
+    buffers,
+    lost,
+  }
+}
+
+describe('createWebGPURenderer', () => {
+  it('requests a device and reports MVP capabilities', async () => {
+    const fake = makeWebGPU()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+    })
+
+    expect(fake.gpu.requestAdapter).toHaveBeenCalledOnce()
+    expect(fake.adapter.requestDevice).toHaveBeenCalledOnce()
+    expect(renderer.caps).toMatchObject({ name: 'webgpu', compute: false, storageBuffer: false })
+    expect(() => renderer.createComputePipeline({})).toThrow('compute not supported')
+  })
+
+  it('uploads owned buffers and delays destruction until submitted work completes', async () => {
+    const fake = makeWebGPU()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+    })
+    const handle = renderer.createBuffer('instance', 16)
+    const data = new Float32Array([1, 2, 3, 4])
+
+    renderer.writeBuffer(handle, data)
+    renderer.destroyBuffer(handle)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(fake.queue.writeBuffer).toHaveBeenCalledWith(fake.buffers[0], 0, data.buffer, 0, 16)
+    expect(fake.queue.onSubmittedWorkDone).toHaveBeenCalledOnce()
+    expect(fake.buffers[0]?.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('draws rectangle instances into an MSAA region', async () => {
+    const fake = makeWebGPU()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+    })
+    renderer.surface.resize(200, 100, 2)
+    renderer.beginFrame({ x: 10, y: 5, width: 80, height: 40, dpr: 2 })
+    const vertices = renderer.createBuffer('vertex', 4)
+    const instances = renderer.createBuffer('instance', 16)
+    const pipeline = renderer.createPipeline({ type: 'candle' })
+
+    const drawn = renderer.drawInstances({
+      pipeline,
+      vertices,
+      instances,
+      instanceCount: 3,
+      vertexCount: 6,
+      uniforms: { color: '#ff0000', scrollLeft: 4 },
+    })
+
+    expect(drawn).toBe(true)
+    expect(fake.device.createTexture).toHaveBeenCalledWith(
+      expect.objectContaining({ sampleCount: 4, format: 'bgra8unorm' }),
+    )
+    expect(fake.passes[0]?.setViewport).toHaveBeenCalledWith(20, 10, 160, 80, 0, 1)
+    expect(fake.passes[0]?.setScissorRect).toHaveBeenCalledWith(20, 10, 160, 80)
+    expect(fake.passes[0]?.draw).toHaveBeenCalledWith(6, 3)
+    expect(fake.queue.submit).toHaveBeenCalledOnce()
+  })
+
+  it('preserves earlier rectangle batches within the same frame', async () => {
+    const fake = makeWebGPU()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+    })
+    renderer.surface.resize(200, 100, 1)
+    renderer.beginFrame({ x: 0, y: 0, width: 200, height: 100, dpr: 1 })
+    const vertices = renderer.createBuffer('vertex', 4)
+    const instances = renderer.createBuffer('instance', 16)
+    const pipeline = renderer.createPipeline({ type: 'candle' })
+    const params = {
+      pipeline,
+      vertices,
+      instances,
+      instanceCount: 1,
+      vertexCount: 6,
+      uniforms: { color: '#ff0000' },
+    }
+
+    expect(renderer.drawInstances(params)).toBe(true)
+    expect(renderer.drawInstances(params)).toBe(true)
+
+    expect(fake.renderPassDescriptors[0]?.colorAttachments[0]).toMatchObject({
+      loadOp: 'clear',
+      storeOp: 'store',
+    })
+    expect(fake.renderPassDescriptors[1]?.colorAttachments[0]).toMatchObject({
+      loadOp: 'load',
+      storeOp: 'store',
+    })
+  })
+
+  it('draws multiple line strips in one render pass', async () => {
+    const fake = makeWebGPU()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+    })
+    renderer.surface.resize(200, 100, 1)
+    renderer.beginFrame({ x: 0, y: 0, width: 200, height: 100, dpr: 1 })
+    const pipeline = renderer.createPipeline({ type: 'line' })
+
+    const drawn = renderer.drawLines({
+      pipeline,
+      strips: [
+        {
+          points: [
+            { x: 0, y: 1 },
+            { x: 2, y: 3 },
+          ],
+          color: '#f00',
+          width: 1,
+        },
+        {
+          points: [
+            { x: 4, y: 5 },
+            { x: 6, y: 7 },
+          ],
+          color: '#0f0',
+          width: 2,
+        },
+      ],
+      uniforms: { scrollLeft: 12 },
+    })
+
+    expect(drawn).toBe(true)
+    expect(fake.passes).toHaveLength(1)
+    expect(fake.passes[0]?.draw).toHaveBeenCalledTimes(2)
+    const uniformWrites = fake.queue.writeBuffer.mock.calls.filter((call) => call[4] === 32)
+    expect(uniformWrites).toHaveLength(2)
+    for (const call of uniformWrites) {
+      expect(new Float32Array(call[2] as ArrayBuffer)[2]).toBe(12)
+    }
+    expect(fake.queue.submit).toHaveBeenCalledOnce()
+  })
+
+  it('uses triangle-strip for filled bands and reports device loss', async () => {
+    const fake = makeWebGPU()
+    const onDeviceLost = vi.fn()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+      onDeviceLost,
+    })
+    renderer.surface.resize(100, 100, 1)
+    renderer.beginFrame({ x: 0, y: 0, width: 100, height: 100, dpr: 1 })
+    const vertices = renderer.createBuffer('vertex', 32)
+    const pipeline = renderer.createPipeline({ type: 'fill' })
+
+    expect(renderer.drawLines({ pipeline, vertices, vertexCount: 4 })).toBe(true)
+    expect(
+      fake.pipelineDescriptors.some((item) => item.primitive?.topology === 'triangle-strip'),
+    ).toBe(true)
+
+    const info = { reason: 'unknown', message: 'device reset' } as GPUDeviceLostInfo
+    fake.lost.resolve(info)
+    await Promise.resolve()
+    expect(onDeviceLost).toHaveBeenCalledWith(info)
+  })
+})

--- a/packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts
@@ -148,6 +148,8 @@ describe('createWebGPURenderer', () => {
     })
 
     expect(drawn).toBe(true)
+    expect(fake.queue.submit).not.toHaveBeenCalled()
+    renderer.endFrame()
     expect(fake.device.createTexture).toHaveBeenCalledWith(
       expect.objectContaining({ sampleCount: 4, format: 'bgra8unorm' }),
     )
@@ -155,6 +157,34 @@ describe('createWebGPURenderer', () => {
     expect(fake.passes[0]?.setScissorRect).toHaveBeenCalledWith(20, 10, 160, 80)
     expect(fake.passes[0]?.draw).toHaveBeenCalledWith(6, 3)
     expect(fake.queue.submit).toHaveBeenCalledOnce()
+  })
+
+  it('records multiple draws and submits once on endFrame', async () => {
+    const fake = makeWebGPU()
+    const renderer = await createWebGPURenderer({
+      gpu: fake.gpu as unknown as GPU,
+      canvas: fake.canvas,
+    })
+    renderer.surface.resize(200, 100, 1)
+    renderer.beginFrame({ x: 0, y: 0, width: 200, height: 100, dpr: 1 })
+    const pipeline = renderer.createPipeline({ type: 'candle' })
+    const instances = renderer.createBuffer('instance', 16)
+    renderer.writeBuffer(instances, new Float32Array([0, 0, 10, 20]))
+    const vertices = renderer.createBuffer('vertex', 4)
+    const params = {
+      pipeline,
+      vertices,
+      instances,
+      instanceCount: 1,
+      vertexCount: 6,
+      uniforms: { color: '#f00', scrollLeft: 0 },
+    }
+
+    expect(renderer.drawInstances(params)).toBe(true)
+    expect(renderer.drawInstances(params)).toBe(true)
+    expect(fake.queue.submit).not.toHaveBeenCalled()
+    renderer.endFrame()
+    expect(fake.queue.submit).toHaveBeenCalledTimes(1)
   })
 
   it('preserves earlier rectangle batches within the same frame', async () => {
@@ -179,15 +209,14 @@ describe('createWebGPURenderer', () => {
 
     expect(renderer.drawInstances(params)).toBe(true)
     expect(renderer.drawInstances(params)).toBe(true)
+    renderer.endFrame()
 
+    expect(fake.renderPassDescriptors).toHaveLength(1)
     expect(fake.renderPassDescriptors[0]?.colorAttachments[0]).toMatchObject({
       loadOp: 'clear',
       storeOp: 'store',
     })
-    expect(fake.renderPassDescriptors[1]?.colorAttachments[0]).toMatchObject({
-      loadOp: 'load',
-      storeOp: 'store',
-    })
+    expect(fake.passes[0]?.draw).toHaveBeenCalledTimes(2)
   })
 
   it('draws multiple line strips in one render pass', async () => {
@@ -224,6 +253,8 @@ describe('createWebGPURenderer', () => {
     })
 
     expect(drawn).toBe(true)
+    expect(fake.queue.submit).not.toHaveBeenCalled()
+    renderer.endFrame()
     expect(fake.passes).toHaveLength(1)
     expect(fake.passes[0]?.draw).toHaveBeenCalledTimes(2)
     const uniformWrites = fake.queue.writeBuffer.mock.calls.filter((call) => call[4] === 32)
@@ -248,6 +279,7 @@ describe('createWebGPURenderer', () => {
     const pipeline = renderer.createPipeline({ type: 'fill' })
 
     expect(renderer.drawLines({ pipeline, vertices, vertexCount: 4 })).toBe(true)
+    renderer.endFrame()
     expect(
       fake.pipelineDescriptors.some((item) => item.primitive?.topology === 'triangle-strip'),
     ).toBe(true)

--- a/packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webgpuRenderer.test.ts
@@ -76,6 +76,7 @@ function makeWebGPU() {
   const canvas = {
     width: 1,
     height: 1,
+    style: { width: '', height: '' },
     getContext: vi.fn(() => context),
   } as unknown as HTMLCanvasElement
 

--- a/packages/core/src/rendering/render/__tests__/webgpuResourceTable.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webgpuResourceTable.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createFrameMetrics } from '../frameMetrics'
+import { createWebGPUResourceTable } from '../webgpuResourceTable'
+
+function makeDevice() {
+  const buffers: Array<{ destroy: ReturnType<typeof vi.fn>; size: number }> = []
+  const queue = {
+    writeBuffer: vi.fn(),
+  }
+  const device = {
+    queue,
+    createBuffer: vi.fn(({ size }: { size: number }) => {
+      const buffer = { destroy: vi.fn(), size }
+      buffers.push(buffer)
+      return buffer
+    }),
+  }
+  return { device, queue, buffers }
+}
+
+describe('createWebGPUResourceTable', () => {
+  it('reuses buffer when revision unchanged', () => {
+    const fake = makeDevice()
+    const metrics = createFrameMetrics()
+    metrics.beginFrame()
+    const table = createWebGPUResourceTable({
+      device: fake.device as unknown as GPUDevice,
+      metrics,
+    })
+    const data = new Float32Array([1, 2, 3, 4])
+    const a = table.ensureUploaded({ key: 'k', revision: 1, data, usage: 'vertex' })
+    const b = table.ensureUploaded({ key: 'k', revision: 1, data, usage: 'vertex' })
+    expect(a.buffer).toBe(b.buffer)
+    expect(fake.device.createBuffer).toHaveBeenCalledTimes(1)
+    expect(fake.queue.writeBuffer).toHaveBeenCalledTimes(1)
+  })
+
+  it('uploads again when revision changes', () => {
+    const fake = makeDevice()
+    const metrics = createFrameMetrics()
+    metrics.beginFrame()
+    const table = createWebGPUResourceTable({
+      device: fake.device as unknown as GPUDevice,
+      metrics,
+    })
+    table.ensureUploaded({
+      key: 'k',
+      revision: 1,
+      data: new Float32Array([1, 2, 3, 4]),
+      usage: 'vertex',
+    })
+    table.ensureUploaded({
+      key: 'k',
+      revision: 2,
+      data: new Float32Array([5, 6, 7, 8]),
+      usage: 'vertex',
+    })
+    expect(fake.device.createBuffer).toHaveBeenCalledTimes(1)
+    expect(fake.queue.writeBuffer).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/core/src/rendering/render/__tests__/webgpuSurfaceBackend.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webgpuSurfaceBackend.test.ts
@@ -11,6 +11,7 @@ function makeSurface() {
   const canvas = {
     width: 1,
     height: 1,
+    style: { width: '', height: '' },
     getContext: vi.fn(() => context),
   } as unknown as HTMLCanvasElement
   const device = {} as GPUDevice
@@ -41,24 +42,69 @@ describe('createWebGPUSurfaceBackend', () => {
     expect(surface.getBoundRegion()).toEqual({ x: 10, y: 20, width: 100, height: 50, dpr: 1.5 })
   })
 
-  it('composites only the requested physical region and restores context state', () => {
+  it('sets CSS size on resize for hybrid DOM mounting', () => {
     const { canvas, surface } = makeSurface()
+
+    surface.resize(320, 180, 1.5)
+
+    expect(canvas.style.width).toBe('320px')
+    expect(canvas.style.height).toBe('180px')
+  })
+
+  it('compositeTo is a no-op under hybrid DOM (M2)', () => {
+    const { surface } = makeSurface()
     const target = {
-      globalAlpha: 0.8,
-      imageSmoothingEnabled: true,
       save: vi.fn(),
       restore: vi.fn(),
       setTransform: vi.fn(),
       drawImage: vi.fn(),
     } as unknown as CanvasRenderingContext2D
-    const region = { x: 10, y: 20, width: 100, height: 50, dpr: 2 }
 
-    surface.compositeTo(target, region, { alpha: 0.5, imageSmoothingEnabled: false })
+    surface.compositeTo(target, { x: 10, y: 20, width: 100, height: 50, dpr: 2 })
 
-    expect(target.save).toHaveBeenCalledOnce()
-    expect(target.setTransform).toHaveBeenCalledWith(1, 0, 0, 1, 0, 0)
-    expect(target.drawImage).toHaveBeenCalledWith(canvas, 20, 40, 200, 100, 0, 0, 200, 100)
-    expect(target.restore).toHaveBeenCalledOnce()
+    expect(target.drawImage).not.toHaveBeenCalled()
+  })
+
+  it('clearRegion submits a transparent clear of the WebGPU canvas', () => {
+    const context = {
+      configure: vi.fn(),
+      unconfigure: vi.fn(),
+      getCurrentTexture: vi.fn(() => ({ createView: vi.fn(() => ({ id: 'view' })) })),
+    }
+    const canvas = {
+      width: 100,
+      height: 50,
+      style: { width: '', height: '' },
+      getContext: vi.fn(() => context),
+    } as unknown as HTMLCanvasElement
+    const pass = { end: vi.fn() }
+    const encoder = {
+      beginRenderPass: vi.fn(() => pass),
+      finish: vi.fn(() => ({ kind: 'commands' })),
+    }
+    const queue = { submit: vi.fn() }
+    const device = {
+      createCommandEncoder: vi.fn(() => encoder),
+      queue,
+    } as unknown as GPUDevice
+    const surface = createWebGPUSurfaceBackend({ canvas, device, format: 'bgra8unorm' })
+
+    surface.clearRegion({ x: 0, y: 0, width: 100, height: 50, dpr: 1 })
+
+    expect(device.createCommandEncoder).toHaveBeenCalledOnce()
+    expect(encoder.beginRenderPass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        colorAttachments: [
+          expect.objectContaining({
+            clearValue: { r: 0, g: 0, b: 0, a: 0 },
+            loadOp: 'clear',
+            storeOp: 'store',
+          }),
+        ],
+      }),
+    )
+    expect(pass.end).toHaveBeenCalledOnce()
+    expect(queue.submit).toHaveBeenCalledOnce()
   })
 
   it('unconfigures once and rejects work after dispose', () => {

--- a/packages/core/src/rendering/render/__tests__/webgpuSurfaceBackend.test.ts
+++ b/packages/core/src/rendering/render/__tests__/webgpuSurfaceBackend.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createWebGPUSurfaceBackend } from '../createWebGPUSurfaceBackend'
+
+function makeSurface() {
+  const context = {
+    configure: vi.fn(),
+    unconfigure: vi.fn(),
+    getCurrentTexture: vi.fn(() => ({ createView: vi.fn(() => ({ id: 'view' })) })),
+  }
+  const canvas = {
+    width: 1,
+    height: 1,
+    getContext: vi.fn(() => context),
+  } as unknown as HTMLCanvasElement
+  const device = {} as GPUDevice
+  const surface = createWebGPUSurfaceBackend({ canvas, device, format: 'bgra8unorm' })
+  return { canvas, context, device, surface }
+}
+
+describe('createWebGPUSurfaceBackend', () => {
+  it('configures a premultiplied WebGPU canvas', () => {
+    const { context, device } = makeSurface()
+
+    expect(context.configure).toHaveBeenCalledWith({
+      device,
+      format: 'bgra8unorm',
+      alphaMode: 'premultiplied',
+      usage: 0x10,
+    })
+  })
+
+  it('resizes the backing canvas using DPR and binds a logical region', () => {
+    const { canvas, surface } = makeSurface()
+
+    surface.resize(320, 180, 1.5)
+
+    expect(canvas.width).toBe(480)
+    expect(canvas.height).toBe(270)
+    expect(surface.bindRegion({ x: 10, y: 20, width: 100, height: 50, dpr: 1.5 })).toBe(true)
+    expect(surface.getBoundRegion()).toEqual({ x: 10, y: 20, width: 100, height: 50, dpr: 1.5 })
+  })
+
+  it('composites only the requested physical region and restores context state', () => {
+    const { canvas, surface } = makeSurface()
+    const target = {
+      globalAlpha: 0.8,
+      imageSmoothingEnabled: true,
+      save: vi.fn(),
+      restore: vi.fn(),
+      setTransform: vi.fn(),
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D
+    const region = { x: 10, y: 20, width: 100, height: 50, dpr: 2 }
+
+    surface.compositeTo(target, region, { alpha: 0.5, imageSmoothingEnabled: false })
+
+    expect(target.save).toHaveBeenCalledOnce()
+    expect(target.setTransform).toHaveBeenCalledWith(1, 0, 0, 1, 0, 0)
+    expect(target.drawImage).toHaveBeenCalledWith(canvas, 20, 40, 200, 100, 0, 0, 200, 100)
+    expect(target.restore).toHaveBeenCalledOnce()
+  })
+
+  it('unconfigures once and rejects work after dispose', () => {
+    const { context, surface } = makeSurface()
+
+    surface.dispose()
+    surface.dispose()
+
+    expect(context.unconfigure).toHaveBeenCalledOnce()
+    expect(surface.isAvailable()).toBe(false)
+    expect(surface.bindRegion({ x: 0, y: 0, width: 10, height: 10, dpr: 1 })).toBe(false)
+  })
+})

--- a/packages/core/src/rendering/render/createCanvas2DRenderer.ts
+++ b/packages/core/src/rendering/render/createCanvas2DRenderer.ts
@@ -1,0 +1,83 @@
+import type {
+  BufferHandle,
+  BufferUsage,
+  ComputePipelineHandle,
+  DispatchComputeParams,
+  DrawInstancesParams,
+  DrawLinesParams,
+  PipelineHandle,
+  Renderer,
+} from './Renderer'
+import type { SurfaceBackend } from './SurfaceBackend'
+
+export function createCanvas2DRenderer(): Renderer {
+  let disposed = false
+  const buffers = new WeakSet<object>()
+  const pipelines = new WeakSet<object>()
+
+  const surface: SurfaceBackend = {
+    isAvailable: () => false,
+    resize: () => {},
+    bindRegion: () => false,
+    clearRegion: () => {},
+    compositeTo: () => {},
+    dispose: () => {},
+  }
+
+  function assertActive(): void {
+    if (disposed) throw new Error('Renderer is disposed')
+  }
+
+  return {
+    surface,
+    caps: {
+      compute: false,
+      storageBuffer: false,
+      maxInstances: 0,
+      name: 'canvas2d',
+    },
+    createBuffer(_usage: BufferUsage, _sizeBytes: number): BufferHandle {
+      assertActive()
+      const handle = {}
+      buffers.add(handle)
+      return handle as BufferHandle
+    },
+    writeBuffer(handle: BufferHandle): void {
+      if (disposed || !buffers.has(handle as object)) return
+    },
+    destroyBuffer(handle: BufferHandle): void {
+      if (disposed) return
+      buffers.delete(handle as object)
+    },
+    createPipeline(_descriptor: unknown): PipelineHandle {
+      assertActive()
+      const handle = {}
+      pipelines.add(handle)
+      return handle as PipelineHandle
+    },
+    destroyPipeline(handle: PipelineHandle): void {
+      if (disposed) return
+      pipelines.delete(handle as object)
+    },
+    createComputePipeline(_descriptor: unknown): ComputePipelineHandle {
+      throw new Error('compute not supported on Canvas2D backend (caps.compute === false)')
+    },
+    destroyComputePipeline(_handle: ComputePipelineHandle): void {},
+    beginFrame(): void {},
+    drawInstances(_params: DrawInstancesParams): boolean {
+      return false
+    },
+    drawLines(_params: DrawLinesParams): boolean {
+      return false
+    },
+    dispatchCompute(_params: DispatchComputeParams): void {
+      throw new Error('dispatchCompute requires a backend with caps.compute === true')
+    },
+    endFrame(): void {},
+    dispose(): void {
+      if (disposed) return
+      disposed = true
+      surface.dispose()
+    },
+  }
+}

--- a/packages/core/src/rendering/render/createDefaultRendererHost.ts
+++ b/packages/core/src/rendering/render/createDefaultRendererHost.ts
@@ -1,0 +1,74 @@
+import { SharedWebGLSurface } from '../../engine/renderers/webgl/sharedWebGLSurface'
+import { createCanvas2DRenderer } from './createCanvas2DRenderer'
+import { createWebGLRenderer } from './createWebGLRenderer'
+import { createWebGLSurfaceBackend } from './createWebGLSurfaceBackend'
+import { createWebGPURenderer } from './createWebGPURenderer'
+import {
+  createRendererHost,
+  createRendererHostFromRenderer,
+  type RendererBackend,
+  type RendererHost,
+  type RendererHostDependencies,
+  type RendererHostListeners,
+} from './rendererHost'
+import type { Renderer } from './Renderer'
+
+function createWebGLBackendRenderer(): Renderer {
+  const shared = new SharedWebGLSurface()
+  const surface = createWebGLSurfaceBackend(shared)
+  if (!surface.isAvailable()) {
+    surface.dispose()
+    throw new Error('WebGL2 unavailable')
+  }
+  return createWebGLRenderer(surface, shared)
+}
+
+function createDependencies(hostRef: { current: RendererHost | null }): RendererHostDependencies {
+  return {
+    createWebGPU: () =>
+      createWebGPURenderer({
+        onDeviceLost: (info) => {
+          void hostRef.current?.handleDeviceLost(info.message || 'WebGPU device lost')
+        },
+      }),
+    createWebGL: createWebGLBackendRenderer,
+    createCanvas: createCanvas2DRenderer,
+  }
+}
+
+export async function createDefaultRendererHost(
+  preference: RendererBackend,
+  listeners: RendererHostListeners = {},
+): Promise<RendererHost> {
+  const hostRef = { current: null as RendererHost | null }
+  const host = await createRendererHost(preference, createDependencies(hostRef))
+  hostRef.current = host
+  host.setListeners(listeners)
+  return host
+}
+
+export function createDefaultRendererHostSync(
+  listeners: RendererHostListeners = {},
+): RendererHost {
+  const hostRef = { current: null as RendererHost | null }
+  const deps = createDependencies(hostRef)
+  let renderer: Renderer
+  let effective: RendererBackend
+  let error: string | null = null
+  try {
+    renderer = createWebGLBackendRenderer()
+    effective = 'webgl'
+  } catch (cause) {
+    renderer = createCanvas2DRenderer()
+    effective = 'canvas'
+    error = cause instanceof Error ? cause.message : String(cause)
+  }
+  const host = createRendererHostFromRenderer(
+    'webgl',
+    { renderer, effective, error },
+    deps,
+  )
+  hostRef.current = host
+  host.setListeners(listeners)
+  return host
+}

--- a/packages/core/src/rendering/render/createWebGLRenderer.ts
+++ b/packages/core/src/rendering/render/createWebGLRenderer.ts
@@ -148,57 +148,63 @@ export function createWebGLRenderer(surface: SurfaceBackend, gl: SharedWebGLSurf
       if (candleSurface) {
         candleSurface.setRegion(toWebGLRegion(region))
         candleSurface.resize(region.width, region.height, region.dpr)
+        candleSurface.clear()
       }
       if (lineSurface) {
         lineSurface.setRegion(toWebGLRegion(region))
         lineSurface.resize(region.width, region.height, region.dpr)
+        lineSurface.clear()
       }
     },
 
-    drawInstances(params: DrawInstancesParams): void {
-      if (disposed) return
+    drawInstances(params: DrawInstancesParams): boolean {
+      if (disposed) return false
       const pipelineMeta_rec = pipelineMeta.get(params.pipeline as object)
-      if (!pipelineMeta_rec || pipelineMeta_rec.type !== 'candle') return
-
-      const instanceMeta = bufferMeta.get(params.instances as object)
-      if (!instanceMeta || !instanceMeta.data) return
+      if (!pipelineMeta_rec || pipelineMeta_rec.type !== 'candle') return false
 
       const rectCount = params.instanceCount
-      if (rectCount <= 0) return
+      if (rectCount <= 0) return true
+
+      const instanceMeta = bufferMeta.get(params.instances as object)
+      if (!instanceMeta || !instanceMeta.data) return false
 
       const floats = new Float32Array(instanceMeta.data, 0, rectCount * 4)
       const color = (params.uniforms?.color as string) ?? '#000000'
       const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
 
-      if (candleSurface) {
-        candleSurface.drawRectBuffer(floats, rectCount, color, scrollLeft)
-        return
-      }
-
-      if (fallbackCtx) {
-        const ctx = fallbackCtx
-        ctx.fillStyle = color
-        for (let i = 0; i < rectCount; i++) {
-          const x = floats[i * 4] - scrollLeft
-          const y = floats[i * 4 + 1]
-          const w = Math.max(0, floats[i * 4 + 2])
-          const h = floats[i * 4 + 3]
-          ctx.fillRect(x, y, w, h)
-        }
-      }
+      // candle 路径 fail-closed：只用 candleSurface，不回落到 overlay fallbackCtx
+      if (!candleSurface) return false
+      return candleSurface.drawRectBuffer(floats, rectCount, color, scrollLeft)
     },
 
-    drawLines(params: DrawLinesParams): void {
-      if (disposed) return
+    drawLines(params: DrawLinesParams): boolean {
+      if (disposed) return false
       const pipelineMeta_rec = pipelineMeta.get(params.pipeline as object)
-      if (!pipelineMeta_rec) return
+      if (!pipelineMeta_rec) return false
 
+      const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
+      // 折线/填充 fail-closed：只用 lineSurface，不回落到 overlay fallbackCtx
+      if (!lineSurface) return false
+
+      // 批量 strips：一次 drawLineStrips（单次 MSAA clear），多周期 MA 必须走此路径
+      if (params.strips && params.strips.length > 0) {
+        if (pipelineMeta_rec.type === 'fill') return false
+        const lines = params.strips
+          .filter((s) => s.points.length >= 2)
+          .map((s) => ({
+            points: s.points.map((p) => ({ x: p.x, y: p.y })),
+            color: s.color,
+            width: s.width ?? 1,
+          }))
+        if (lines.length === 0) return true
+        return lineSurface.drawLineStrips(lines, scrollLeft)
+      }
+
+      if (!params.vertices || params.vertexCount == null || params.vertexCount < 2) return false
       const vertexMeta = bufferMeta.get(params.vertices as object)
-      if (!vertexMeta || !vertexMeta.data) return
-      if (params.vertexCount < 2) return
+      if (!vertexMeta || !vertexMeta.data) return false
 
       const color = (params.uniforms?.color as string) ?? '#000000'
-      const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
 
       if (pipelineMeta_rec.type === 'fill') {
         const floats = new Float32Array(vertexMeta.data, 0, params.vertexCount * 2)
@@ -210,61 +216,16 @@ export function createWebGLRenderer(surface: SurfaceBackend, gl: SharedWebGLSurf
           upperPoints.push({ x: floats[offset], y: floats[offset + 1] })
           lowerPoints.push({ x: floats[offset + 2], y: floats[offset + 3] })
         }
-
-        if (lineSurface) {
-          lineSurface.drawFilledBand({ upperPoints, lowerPoints }, color, scrollLeft)
-          return
-        }
-
-        if (fallbackCtx) {
-          const ctx = fallbackCtx
-          ctx.beginPath()
-          ctx.moveTo(upperPoints[0].x - scrollLeft, upperPoints[0].y)
-          for (let i = 1; i < upperPoints.length; i++) {
-            ctx.lineTo(upperPoints[i].x - scrollLeft, upperPoints[i].y)
-          }
-          for (let i = lowerPoints.length - 1; i >= 0; i--) {
-            ctx.lineTo(lowerPoints[i].x - scrollLeft, lowerPoints[i].y)
-          }
-          ctx.closePath()
-          ctx.fillStyle = color
-          ctx.fill()
-        }
-        return
+        return lineSurface.drawFilledBand({ upperPoints, lowerPoints }, color, scrollLeft)
       }
 
       const floats = new Float32Array(vertexMeta.data, 0, params.vertexCount * 2)
-
-      if (lineSurface) {
-        const points: Array<{ x: number; y: number }> = []
-        for (let i = 0; i < params.vertexCount; i++) {
-          points.push({ x: floats[i * 2], y: floats[i * 2 + 1] })
-        }
-        const lineWidth = (params.uniforms?.lineWidth as number) ?? 1
-        const lines = [{ points, color, width: lineWidth }]
-        lineSurface.drawLineStrips(lines, scrollLeft)
-        return
+      const points: Array<{ x: number; y: number }> = []
+      for (let i = 0; i < params.vertexCount; i++) {
+        points.push({ x: floats[i * 2], y: floats[i * 2 + 1] })
       }
-
-      if (fallbackCtx) {
-        const ctx = fallbackCtx
-        const lineWidth = (params.uniforms?.lineWidth as number) ?? 1
-        const dashPattern = params.uniforms?.dashPattern as number[] | undefined
-        ctx.beginPath()
-        ctx.moveTo(floats[0] - scrollLeft, floats[1])
-        for (let i = 1; i < params.vertexCount; i++) {
-          ctx.lineTo(floats[i * 2] - scrollLeft, floats[i * 2 + 1])
-        }
-        ctx.strokeStyle = color
-        ctx.lineWidth = lineWidth
-        if (dashPattern && dashPattern.length > 0) {
-          ctx.setLineDash(dashPattern)
-        }
-        ctx.stroke()
-        if (dashPattern && dashPattern.length > 0) {
-          ctx.setLineDash([])
-        }
-      }
+      const lineWidth = (params.uniforms?.lineWidth as number) ?? 1
+      return lineSurface.drawLineStrips([{ points, color, width: lineWidth }], scrollLeft)
     },
 
     dispatchCompute(_params: DispatchComputeParams): void {

--- a/packages/core/src/rendering/render/createWebGLRenderer.ts
+++ b/packages/core/src/rendering/render/createWebGLRenderer.ts
@@ -50,8 +50,6 @@ export function createWebGLRenderer(surface: SurfaceBackend, gl: SharedWebGLSurf
   let disposed = false
   let candleSurface: CandleWebGLSurface | null = null
   let lineSurface: LineWebGLSurface | null = null
-  let fallbackCtx: CanvasRenderingContext2D | null = null
-  let fallbackDpr = 1
 
   const candle = new CandleWebGLSurface(gl)
   if (candle.isAvailable()) candleSurface = candle
@@ -79,11 +77,6 @@ export function createWebGLRenderer(surface: SurfaceBackend, gl: SharedWebGLSurf
 
     get caps(): RendererCapabilities {
       return handleCaps
-    },
-
-    setFallbackContext(ctx: CanvasRenderingContext2D | null, dpr: number): void {
-      fallbackCtx = ctx
-      fallbackDpr = dpr
     },
 
     createBuffer(usage: BufferUsage, sizeBytes: number): BufferHandle {
@@ -172,7 +165,7 @@ export function createWebGLRenderer(surface: SurfaceBackend, gl: SharedWebGLSurf
       const color = (params.uniforms?.color as string) ?? '#000000'
       const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
 
-      // candle 路径 fail-closed：只用 candleSurface，不回落到 overlay fallbackCtx
+      // candle 路径 fail-closed：无 surface 则 false，由业务层 2D 兜底
       if (!candleSurface) return false
       return candleSurface.drawRectBuffer(floats, rectCount, color, scrollLeft)
     },
@@ -183,7 +176,7 @@ export function createWebGLRenderer(surface: SurfaceBackend, gl: SharedWebGLSurf
       if (!pipelineMeta_rec) return false
 
       const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
-      // 折线/填充 fail-closed：只用 lineSurface，不回落到 overlay fallbackCtx
+      // 折线/填充 fail-closed：无 surface 则 false，由业务层 2D 兜底
       if (!lineSurface) return false
 
       // 批量 strips：一次 drawLineStrips（单次 MSAA clear），多周期 MA 必须走此路径

--- a/packages/core/src/rendering/render/createWebGPURenderer.ts
+++ b/packages/core/src/rendering/render/createWebGPURenderer.ts
@@ -10,6 +10,8 @@ import type {
   Renderer,
 } from './Renderer'
 import { createWebGPUSurfaceBackend, type WebGPUSurfaceBackend } from './createWebGPUSurfaceBackend'
+import { createFrameMetrics } from './frameMetrics'
+import { createWebGPUResourceTable } from './webgpuResourceTable'
 
 type PipelineType = 'candle' | 'line' | 'fill'
 
@@ -26,6 +28,8 @@ export type CreateWebGPURendererOptions = {
   gpu?: GPU
   canvas?: HTMLCanvasElement
   onDeviceLost?: (info: GPUDeviceLostInfo) => void
+  /** 可选帧指标探针；默认使用模块级 createFrameMetrics */
+  metrics?: ReturnType<typeof createFrameMetrics>
 }
 
 const GPU_BUFFER_COPY_DST = globalThis.GPUBufferUsage?.COPY_DST ?? 0x0008
@@ -177,6 +181,16 @@ function linePoints(strip: DrawLineStrip): Float32Array {
   return values
 }
 
+/** 几何 revision：按 float32 位型哈希，避免截断精度导致漏 upload */
+function geometryRevision(values: Float32Array): number {
+  const bits = new Uint32Array(values.buffer, values.byteOffset, values.length)
+  let h = values.length >>> 0
+  for (let i = 0; i < bits.length; i++) {
+    h = Math.imul(h ^ bits[i]!, 16777619) >>> 0
+  }
+  return h
+}
+
 export async function createWebGPURenderer(
   options: CreateWebGPURendererOptions = {},
 ): Promise<Renderer> {
@@ -189,6 +203,8 @@ export async function createWebGPURenderer(
   if (!canvas) throw new Error('WebGPU canvas unavailable')
   const format = gpu.getPreferredCanvasFormat()
   const rawSurface = createWebGPUSurfaceBackend({ canvas, device, format })
+  const metrics = options.metrics ?? createFrameMetrics()
+  const resourceTable = createWebGPUResourceTable({ device, metrics })
 
   type PendingDraw =
     | {
@@ -208,7 +224,6 @@ export async function createWebGPURenderer(
         vertexCount: number
         color: unknown
         scrollLeft: number
-        temporary?: BufferRecord
       }
 
   let disposed = false
@@ -217,15 +232,40 @@ export async function createWebGPURenderer(
   let msaaHeight = 0
   let currentRegion: import('./SurfaceBackend').SurfaceRegion | null = null
   let pendingDraws: PendingDraw[] = []
-  let frameTemporaryRecords: BufferRecord[] = []
+  let metricsFrameOpen = false
+  let stripSeq = 0
+  /** 本帧 touch 的 strip ResourceTable key；flush 后 prune 未 touch 的 */
+  const stripKeysThisFrame = new Set<string>()
+  const stripKeysKnown = new Set<string>()
   const buffers = new WeakMap<object, BufferRecord>()
   const bufferRecords = new Set<BufferRecord>()
   const pipelines = new WeakMap<object, PipelineRecord>()
   const pipelineCache = new Map<string, GPURenderPipeline>()
+  /** 帧内 uniform 环：跨帧复用，flush 后游标归零 */
+  const uniformPool: BufferRecord[] = []
+  let uniformPoolUsed = 0
 
   void device.lost.then((info) => {
     if (!disposed) options.onDeviceLost?.(info)
   })
+
+  function openMetricsFrame(): void {
+    if (metricsFrameOpen) return
+    metrics.beginFrame()
+    metricsFrameOpen = true
+    stripSeq = 0
+    stripKeysThisFrame.clear()
+    uniformPoolUsed = 0
+  }
+
+  function pruneUnusedStripKeys(): void {
+    for (const key of stripKeysKnown) {
+      if (stripKeysThisFrame.has(key)) continue
+      resourceTable.destroyKey(key)
+      stripKeysKnown.delete(key)
+    }
+    for (const key of stripKeysThisFrame) stripKeysKnown.add(key)
+  }
 
   function createBufferRecord(usage: BufferUsage, sizeBytes: number): BufferRecord {
     const size = Math.max(4, Math.ceil(sizeBytes / 4) * 4)
@@ -234,12 +274,33 @@ export async function createWebGPURenderer(
       size,
     }
     bufferRecords.add(record)
+    metrics.recordBufferCreate()
     return record
   }
 
   function deferDestroy(record: BufferRecord): void {
     bufferRecords.delete(record)
     void device.queue.onSubmittedWorkDone().then(() => record.buffer.destroy())
+  }
+
+  function acquireUniform(byteLength: number): BufferRecord {
+    if (uniformPoolUsed < uniformPool.length) {
+      const existing = uniformPool[uniformPoolUsed]!
+      if (existing.size >= byteLength) {
+        uniformPoolUsed += 1
+        return existing
+      }
+    }
+    const record = createBufferRecord('uniform', byteLength)
+    if (uniformPoolUsed < uniformPool.length) {
+      const old = uniformPool[uniformPoolUsed]!
+      deferDestroy(old)
+      uniformPool[uniformPoolUsed] = record
+    } else {
+      uniformPool.push(record)
+    }
+    uniformPoolUsed += 1
+    return record
   }
 
   function getPipeline(kind: 'candle' | 'line-strip' | 'line-wide' | 'fill'): GPURenderPipeline {
@@ -303,7 +364,7 @@ export async function createWebGPURenderer(
     colorValue: unknown,
     scrollLeft: number,
     region: import('./SurfaceBackend').SurfaceRegion,
-  ): { record: BufferRecord; bindGroup: GPUBindGroup } | null {
+  ): { bindGroup: GPUBindGroup } | null {
     const color = parseColor(colorValue ?? '#000000')
     if (!color) return null
     const values = new Float32Array([
@@ -316,13 +377,14 @@ export async function createWebGPURenderer(
       color[2],
       color[3],
     ])
-    const record = createBufferRecord('uniform', values.byteLength)
+    const record = acquireUniform(values.byteLength)
     device.queue.writeBuffer(record.buffer, 0, values.buffer, 0, values.byteLength)
+    metrics.recordUpload(values.byteLength)
     const bindGroup = device.createBindGroup({
       layout: pipeline.getBindGroupLayout(0),
       entries: [{ binding: 0, resource: { buffer: record.buffer } }],
     })
-    return { record, bindGroup }
+    return { bindGroup }
   }
 
   function beginPass(
@@ -361,14 +423,11 @@ export async function createWebGPURenderer(
     return `${region.x},${region.y},${region.width},${region.height},${region.dpr}`
   }
 
-  function flushPendingDraws(): void {
-    if (pendingDraws.length === 0) {
-      frameTemporaryRecords = []
-      return
-    }
-    const encoder = device.createCommandEncoder()
-    const temporaryUniforms: BufferRecord[] = []
-    try {
+  function flushPendingDraws(options?: { composite?: boolean }): void {
+    const hadDraws = pendingDraws.length > 0
+    if (hadDraws) {
+      openMetricsFrame()
+      const encoder = device.createCommandEncoder()
       const groups = new Map<string, PendingDraw[]>()
       for (const draw of pendingDraws) {
         const key = regionKey(draw.region)
@@ -387,34 +446,46 @@ export async function createWebGPURenderer(
         for (const draw of draws) {
           const uniform = createUniform(draw.pipeline, draw.color, draw.scrollLeft, draw.region)
           if (!uniform) continue
-          temporaryUniforms.push(uniform.record)
           pass.setPipeline(draw.pipeline)
           if (draw.kind === 'instances') {
             pass.setVertexBuffer(0, draw.instanceBuffer)
             pass.setBindGroup(0, uniform.bindGroup)
             pass.draw(6, draw.instanceCount)
+            metrics.recordDraw()
           } else {
             pass.setVertexBuffer(0, draw.vertexBuffer)
             pass.setBindGroup(0, uniform.bindGroup)
             pass.draw(draw.vertexCount, 1)
+            metrics.recordDraw()
           }
         }
         pass.end()
       }
       device.queue.submit([encoder.finish()])
-    } finally {
-      for (const record of temporaryUniforms) deferDestroy(record)
-      for (const record of frameTemporaryRecords) deferDestroy(record)
+      metrics.recordSubmit()
       pendingDraws = []
-      frameTemporaryRecords = []
+    }
+
+    if (options?.composite) {
+      if (metricsFrameOpen || hadDraws) {
+        openMetricsFrame()
+        metrics.recordComposite()
+      }
+    }
+
+    // endFrame 收口：prune 未 touch 的 strip 资源；composite 中途 flush 保持 frame open
+    if (!options?.composite && metricsFrameOpen) {
+      pruneUnusedStripKeys()
+      metrics.endFrame()
+      metricsFrameOpen = false
     }
   }
 
-  // Flush before composite so M1 mid-frame compositeTo still sees GPU output.
+  // M1 保留即时 composite 语义（与 2D 交错）；M2 混合 DOM 后再去掉
   const surface: WebGPUSurfaceBackend = {
     ...rawSurface,
     compositeTo(targetCtx, region, compositeOptions) {
-      flushPendingDraws()
+      flushPendingDraws({ composite: true })
       rawSurface.compositeTo(targetCtx, region, compositeOptions)
     },
   }
@@ -424,6 +495,7 @@ export async function createWebGPURenderer(
     caps: { compute: false, storageBuffer: false, maxInstances: 1_000_000, name: 'webgpu' },
     createBuffer(usage, sizeBytes): BufferHandle {
       if (disposed) throw new Error('Renderer is disposed')
+      openMetricsFrame()
       const handle = {}
       buffers.set(handle, createBufferRecord(usage, sizeBytes))
       return handle as BufferHandle
@@ -432,6 +504,7 @@ export async function createWebGPURenderer(
       if (disposed) return
       const record = buffers.get(handle as object)
       if (!record || offsetBytes < 0 || offsetBytes + data.byteLength > record.size) return
+      openMetricsFrame()
       device.queue.writeBuffer(
         record.buffer,
         offsetBytes,
@@ -439,11 +512,14 @@ export async function createWebGPURenderer(
         data.byteOffset,
         data.byteLength,
       )
+      metrics.recordUpload(data.byteLength)
     },
     destroyBuffer(handle): void {
       if (disposed) return
       const record = buffers.get(handle as object)
       if (!record) return
+      // 不立即 destroy：helper 可跨帧复用同一 handle；显式 dispose 才释放
+      // 兼容仍调用 destroyBuffer 的旧路径：仅解除 handle 映射，GPU buffer 延迟回收
       buffers.delete(handle as object)
       deferDestroy(record)
     },
@@ -466,6 +542,7 @@ export async function createWebGPURenderer(
     destroyComputePipeline(_handle): void {},
     beginFrame(region): void {
       if (!disposed) {
+        openMetricsFrame()
         currentRegion = { ...region }
         rawSurface.bindRegion(region)
       }
@@ -483,6 +560,7 @@ export async function createWebGPURenderer(
       const instanceRecord = buffers.get(params.instances as object)
       if (pipelineRecord?.type !== 'candle' || !instanceRecord || !currentRegion) return false
       try {
+        openMetricsFrame()
         pendingDraws.push({
           kind: 'instances',
           region: { ...currentRegion },
@@ -503,6 +581,7 @@ export async function createWebGPURenderer(
       if (!pipelineRecord || pipelineRecord.type === 'candle') return false
       if (params.strips && params.strips.length === 0) return true
       try {
+        openMetricsFrame()
         if (params.strips) {
           const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
           for (const strip of params.strips) {
@@ -510,18 +589,23 @@ export async function createWebGPURenderer(
             const wide = (strip.width ?? 1) > 1
             const values = wide ? buildWideLine(strip) : linePoints(strip)
             if (!values) return false
-            const vertexRecord = createBufferRecord('vertex', values.byteLength)
-            device.queue.writeBuffer(vertexRecord.buffer, 0, values.buffer, 0, values.byteLength)
-            frameTemporaryRecords.push(vertexRecord)
+            // 帧内序号作 key：同顺序跨帧复用；revision 未变则不 upload
+            const key = `strip/${stripSeq++}`
+            stripKeysThisFrame.add(key)
+            const uploaded = resourceTable.ensureUploaded({
+              key,
+              revision: geometryRevision(values),
+              data: values,
+              usage: 'vertex',
+            })
             pendingDraws.push({
               kind: 'lines',
               region: { ...currentRegion },
               pipeline: getPipeline(wide ? 'line-wide' : 'line-strip'),
-              vertexBuffer: vertexRecord.buffer,
+              vertexBuffer: uploaded.buffer,
               vertexCount: values.length / 2,
               color: strip.color,
               scrollLeft,
-              temporary: vertexRecord,
             })
           }
           return true
@@ -554,9 +638,13 @@ export async function createWebGPURenderer(
       if (disposed) return
       disposed = true
       pendingDraws = []
-      frameTemporaryRecords = []
+      stripKeysThisFrame.clear()
+      stripKeysKnown.clear()
       msaaTexture?.destroy()
       msaaTexture = null
+      resourceTable.destroyAll()
+      for (const record of uniformPool) record.buffer.destroy()
+      uniformPool.length = 0
       for (const record of bufferRecords) record.buffer.destroy()
       bufferRecords.clear()
       rawSurface.dispose()

--- a/packages/core/src/rendering/render/createWebGPURenderer.ts
+++ b/packages/core/src/rendering/render/createWebGPURenderer.ts
@@ -481,12 +481,11 @@ export async function createWebGPURenderer(
     }
   }
 
-  // M1 保留即时 composite 语义（与 2D 交错）；M2 混合 DOM 后再去掉
+  // M2：compositeTo 为 no-op（可见 GPU canvas）；仅 endFrame submit
   const surface: WebGPUSurfaceBackend = {
     ...rawSurface,
-    compositeTo(targetCtx, region, compositeOptions) {
-      flushPendingDraws({ composite: true })
-      rawSurface.compositeTo(targetCtx, region, compositeOptions)
+    compositeTo(_targetCtx, _region, _compositeOptions) {
+      // 禁止中途 flush，保证每 chart 帧单次 queue.submit
     },
   }
 

--- a/packages/core/src/rendering/render/createWebGPURenderer.ts
+++ b/packages/core/src/rendering/render/createWebGPURenderer.ts
@@ -1,0 +1,492 @@
+import type {
+  BufferHandle,
+  BufferUsage,
+  ComputePipelineHandle,
+  DispatchComputeParams,
+  DrawInstancesParams,
+  DrawLineStrip,
+  DrawLinesParams,
+  PipelineHandle,
+  Renderer,
+} from './Renderer'
+import { createWebGPUSurfaceBackend, type WebGPUSurfaceBackend } from './createWebGPUSurfaceBackend'
+
+type PipelineType = 'candle' | 'line' | 'fill'
+
+type BufferRecord = {
+  buffer: GPUBuffer
+  size: number
+}
+
+type PipelineRecord = {
+  type: PipelineType
+}
+
+export type CreateWebGPURendererOptions = {
+  gpu?: GPU
+  canvas?: HTMLCanvasElement
+  onDeviceLost?: (info: GPUDeviceLostInfo) => void
+}
+
+const GPU_BUFFER_COPY_DST = globalThis.GPUBufferUsage?.COPY_DST ?? 0x0008
+const GPU_BUFFER_INDEX = globalThis.GPUBufferUsage?.INDEX ?? 0x0010
+const GPU_BUFFER_VERTEX = globalThis.GPUBufferUsage?.VERTEX ?? 0x0020
+const GPU_BUFFER_UNIFORM = globalThis.GPUBufferUsage?.UNIFORM ?? 0x0040
+const GPU_BUFFER_STORAGE = globalThis.GPUBufferUsage?.STORAGE ?? 0x0080
+const GPU_TEXTURE_RENDER_ATTACHMENT = globalThis.GPUTextureUsage?.RENDER_ATTACHMENT ?? 0x10
+
+const RECT_SHADER = `
+struct Uniforms {
+  resolution: vec2f,
+  scrollLeft: f32,
+  padding: f32,
+  color: vec4f,
+}
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+@vertex
+fn vertexMain(@builtin(vertex_index) vertexIndex: u32, @location(0) rect: vec4f) -> @builtin(position) vec4f {
+  let corners = array<vec2f, 6>(
+    vec2f(0.0, 0.0), vec2f(1.0, 0.0), vec2f(0.0, 1.0),
+    vec2f(0.0, 1.0), vec2f(1.0, 0.0), vec2f(1.0, 1.0)
+  );
+  let unit = corners[vertexIndex];
+  let position = vec2f(rect.x - uniforms.scrollLeft + unit.x * rect.z, rect.y + unit.y * rect.w);
+  let clip = vec2f(position.x / uniforms.resolution.x * 2.0 - 1.0, 1.0 - position.y / uniforms.resolution.y * 2.0);
+  return vec4f(clip, 0.0, 1.0);
+}
+
+@fragment
+fn fragmentMain() -> @location(0) vec4f {
+  return uniforms.color;
+}
+`
+
+const LINE_SHADER = `
+struct Uniforms {
+  resolution: vec2f,
+  scrollLeft: f32,
+  padding: f32,
+  color: vec4f,
+}
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+@vertex
+fn vertexMain(@location(0) point: vec2f) -> @builtin(position) vec4f {
+  let position = vec2f(point.x - uniforms.scrollLeft, point.y);
+  let clip = vec2f(position.x / uniforms.resolution.x * 2.0 - 1.0, 1.0 - position.y / uniforms.resolution.y * 2.0);
+  return vec4f(clip, 0.0, 1.0);
+}
+
+@fragment
+fn fragmentMain() -> @location(0) vec4f {
+  return uniforms.color;
+}
+`
+
+const BLEND: GPUBlendState = {
+  color: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+  alpha: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+}
+
+function bufferUsage(usage: BufferUsage): GPUBufferUsageFlags {
+  if (usage === 'index') return GPU_BUFFER_INDEX | GPU_BUFFER_COPY_DST
+  if (usage === 'uniform') return GPU_BUFFER_UNIFORM | GPU_BUFFER_COPY_DST
+  if (usage === 'storage') return GPU_BUFFER_STORAGE | GPU_BUFFER_COPY_DST
+  return GPU_BUFFER_VERTEX | GPU_BUFFER_COPY_DST
+}
+
+function parseColor(value: unknown): readonly [number, number, number, number] | null {
+  if (typeof value !== 'string') return null
+  const color = value.trim().toLowerCase()
+  let rgba: [number, number, number, number] | null = null
+  if (color.startsWith('#')) {
+    const hex = color.slice(1)
+    if (hex.length === 3) {
+      rgba = [
+        Number.parseInt(hex[0]! + hex[0]!, 16) / 255,
+        Number.parseInt(hex[1]! + hex[1]!, 16) / 255,
+        Number.parseInt(hex[2]! + hex[2]!, 16) / 255,
+        1,
+      ]
+    } else if (hex.length === 6) {
+      rgba = [
+        Number.parseInt(hex.slice(0, 2), 16) / 255,
+        Number.parseInt(hex.slice(2, 4), 16) / 255,
+        Number.parseInt(hex.slice(4, 6), 16) / 255,
+        1,
+      ]
+    }
+  } else {
+    const match = color.match(/^rgba?\(([^)]+)\)$/)
+    if (match) {
+      const values = match[1]!.split(',').map((part) => Number(part.trim()))
+      if ((values.length === 3 || values.length === 4) && values.every(Number.isFinite)) {
+        rgba = [values[0]! / 255, values[1]! / 255, values[2]! / 255, values[3] ?? 1]
+      }
+    }
+  }
+  if (!rgba || rgba.some((component) => !Number.isFinite(component))) return null
+  return [rgba[0] * rgba[3], rgba[1] * rgba[3], rgba[2] * rgba[3], rgba[3]]
+}
+
+function buildWideLine(strip: DrawLineStrip): Float32Array | null {
+  const width = strip.width ?? 1
+  if (strip.points.length < 2 || width <= 0) return null
+  const output = new Float32Array((strip.points.length - 1) * 12)
+  let offset = 0
+  for (let index = 0; index < strip.points.length - 1; index++) {
+    const start = strip.points[index]!
+    const end = strip.points[index + 1]!
+    const dx = end.x - start.x
+    const dy = end.y - start.y
+    const length = Math.sqrt(dx * dx + dy * dy)
+    if (length <= 0) continue
+    const nx = (-dy / length) * width * 0.5
+    const ny = (dx / length) * width * 0.5
+    output.set(
+      [
+        start.x + nx,
+        start.y + ny,
+        start.x - nx,
+        start.y - ny,
+        end.x + nx,
+        end.y + ny,
+        end.x + nx,
+        end.y + ny,
+        start.x - nx,
+        start.y - ny,
+        end.x - nx,
+        end.y - ny,
+      ],
+      offset,
+    )
+    offset += 12
+  }
+  return offset === 0 ? null : output.subarray(0, offset)
+}
+
+function linePoints(strip: DrawLineStrip): Float32Array {
+  const values = new Float32Array(strip.points.length * 2)
+  for (let index = 0; index < strip.points.length; index++) {
+    values[index * 2] = strip.points[index]!.x
+    values[index * 2 + 1] = strip.points[index]!.y
+  }
+  return values
+}
+
+export async function createWebGPURenderer(
+  options: CreateWebGPURendererOptions = {},
+): Promise<Renderer> {
+  const gpu = options.gpu ?? globalThis.navigator?.gpu
+  if (!gpu) throw new Error('WebGPU unavailable')
+  const adapter = await gpu.requestAdapter()
+  if (!adapter) throw new Error('WebGPU adapter unavailable')
+  const device = await adapter.requestDevice()
+  const canvas = options.canvas ?? globalThis.document?.createElement('canvas')
+  if (!canvas) throw new Error('WebGPU canvas unavailable')
+  const format = gpu.getPreferredCanvasFormat()
+  const surface = createWebGPUSurfaceBackend({ canvas, device, format })
+
+  let disposed = false
+  let msaaTexture: GPUTexture | null = null
+  let msaaWidth = 0
+  let msaaHeight = 0
+  let clearPending = true
+  const buffers = new WeakMap<object, BufferRecord>()
+  const bufferRecords = new Set<BufferRecord>()
+  const pipelines = new WeakMap<object, PipelineRecord>()
+  const pipelineCache = new Map<string, GPURenderPipeline>()
+
+  void device.lost.then((info) => {
+    if (!disposed) options.onDeviceLost?.(info)
+  })
+
+  function createBufferRecord(usage: BufferUsage, sizeBytes: number): BufferRecord {
+    const size = Math.max(4, Math.ceil(sizeBytes / 4) * 4)
+    const record = {
+      buffer: device.createBuffer({ size, usage: bufferUsage(usage) }),
+      size,
+    }
+    bufferRecords.add(record)
+    return record
+  }
+
+  function deferDestroy(record: BufferRecord): void {
+    bufferRecords.delete(record)
+    void device.queue.onSubmittedWorkDone().then(() => record.buffer.destroy())
+  }
+
+  function getPipeline(kind: 'candle' | 'line-strip' | 'line-wide' | 'fill'): GPURenderPipeline {
+    const cached = pipelineCache.get(kind)
+    if (cached) return cached
+    const isCandle = kind === 'candle'
+    const module = device.createShaderModule({ code: isCandle ? RECT_SHADER : LINE_SHADER })
+    const topology: GPUPrimitiveTopology =
+      kind === 'line-strip' ? 'line-strip' : kind === 'fill' ? 'triangle-strip' : 'triangle-list'
+    const pipeline = device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'vertexMain',
+        buffers: [
+          {
+            arrayStride: isCandle ? 16 : 8,
+            stepMode: isCandle ? 'instance' : 'vertex',
+            attributes: [
+              {
+                shaderLocation: 0,
+                offset: 0,
+                format: isCandle ? 'float32x4' : 'float32x2',
+              },
+            ],
+          },
+        ],
+      },
+      fragment: {
+        module,
+        entryPoint: 'fragmentMain',
+        targets: [{ format, blend: BLEND }],
+      },
+      primitive: { topology },
+      multisample: { count: 4 },
+    })
+    pipelineCache.set(kind, pipeline)
+    return pipeline
+  }
+
+  function ensureMsaaView(): GPUTextureView | null {
+    const width = canvas.width
+    const height = canvas.height
+    if (width <= 0 || height <= 0) return null
+    if (!msaaTexture || width !== msaaWidth || height !== msaaHeight) {
+      msaaTexture?.destroy()
+      msaaTexture = device.createTexture({
+        size: { width, height },
+        sampleCount: 4,
+        format,
+        usage: GPU_TEXTURE_RENDER_ATTACHMENT,
+      })
+      msaaWidth = width
+      msaaHeight = height
+    }
+    return msaaTexture.createView()
+  }
+
+  function createUniform(
+    pipeline: GPURenderPipeline,
+    colorValue: unknown,
+    scrollLeft: number,
+  ): { record: BufferRecord; bindGroup: GPUBindGroup } | null {
+    const region = surface.getBoundRegion()
+    const color = parseColor(colorValue ?? '#000000')
+    if (!region || !color) return null
+    const values = new Float32Array([
+      region.width,
+      region.height,
+      scrollLeft,
+      0,
+      color[0],
+      color[1],
+      color[2],
+      color[3],
+    ])
+    const record = createBufferRecord('uniform', values.byteLength)
+    device.queue.writeBuffer(record.buffer, 0, values.buffer, 0, values.byteLength)
+    const bindGroup = device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer: record.buffer } }],
+    })
+    return { record, bindGroup }
+  }
+
+  function beginPass(): { encoder: GPUCommandEncoder; pass: GPURenderPassEncoder } | null {
+    const region = surface.getBoundRegion()
+    const view = surface.getCurrentTextureView()
+    const msaaView = ensureMsaaView()
+    if (!region || !view || !msaaView) return null
+    const encoder = device.createCommandEncoder()
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: msaaView,
+          resolveTarget: view,
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
+          loadOp: clearPending ? 'clear' : 'load',
+          storeOp: 'store',
+        },
+      ],
+    })
+    const x = Math.max(0, Math.round(region.x * region.dpr))
+    const y = Math.max(0, Math.round(region.y * region.dpr))
+    const width = Math.min(canvas.width - x, Math.round(region.width * region.dpr))
+    const height = Math.min(canvas.height - y, Math.round(region.height * region.dpr))
+    if (width <= 0 || height <= 0) {
+      pass.end()
+      return null
+    }
+    clearPending = false
+    pass.setViewport(x, y, width, height, 0, 1)
+    pass.setScissorRect(x, y, width, height)
+    return { encoder, pass }
+  }
+
+  const renderer: Renderer = {
+    surface,
+    caps: { compute: false, storageBuffer: false, maxInstances: 1_000_000, name: 'webgpu' },
+    createBuffer(usage, sizeBytes): BufferHandle {
+      if (disposed) throw new Error('Renderer is disposed')
+      const handle = {}
+      buffers.set(handle, createBufferRecord(usage, sizeBytes))
+      return handle as BufferHandle
+    },
+    writeBuffer(handle, data, offsetBytes = 0): void {
+      if (disposed) return
+      const record = buffers.get(handle as object)
+      if (!record || offsetBytes < 0 || offsetBytes + data.byteLength > record.size) return
+      device.queue.writeBuffer(
+        record.buffer,
+        offsetBytes,
+        data.buffer as ArrayBuffer,
+        data.byteOffset,
+        data.byteLength,
+      )
+    },
+    destroyBuffer(handle): void {
+      if (disposed) return
+      const record = buffers.get(handle as object)
+      if (!record) return
+      buffers.delete(handle as object)
+      deferDestroy(record)
+    },
+    createPipeline(descriptor): PipelineHandle {
+      if (disposed) throw new Error('Renderer is disposed')
+      const type = (descriptor as { type?: PipelineType })?.type
+      if (type !== 'candle' && type !== 'line' && type !== 'fill') {
+        throw new Error('Unsupported WebGPU pipeline type')
+      }
+      const handle = {}
+      pipelines.set(handle, { type })
+      return handle as PipelineHandle
+    },
+    destroyPipeline(handle): void {
+      if (!disposed) pipelines.delete(handle as object)
+    },
+    createComputePipeline(_descriptor): ComputePipelineHandle {
+      throw new Error('compute not supported on WebGPU MVP backend (caps.compute === false)')
+    },
+    destroyComputePipeline(_handle): void {},
+    beginFrame(region): void {
+      if (!disposed) {
+        clearPending = true
+        surface.bindRegion(region)
+      }
+    },
+    drawInstances(params: DrawInstancesParams): boolean {
+      if (
+        disposed ||
+        params.instanceCount < 0 ||
+        params.instanceCount > renderer.caps.maxInstances
+      ) {
+        return false
+      }
+      if (params.instanceCount === 0) return true
+      const pipelineRecord = pipelines.get(params.pipeline as object)
+      const instanceRecord = buffers.get(params.instances as object)
+      if (pipelineRecord?.type !== 'candle' || !instanceRecord) return false
+      try {
+        const pipeline = getPipeline('candle')
+        const uniform = createUniform(
+          pipeline,
+          params.uniforms?.color,
+          (params.uniforms?.scrollLeft as number) ?? 0,
+        )
+        const frame = beginPass()
+        if (!uniform || !frame) return false
+        frame.pass.setPipeline(pipeline)
+        frame.pass.setVertexBuffer(0, instanceRecord.buffer)
+        frame.pass.setBindGroup(0, uniform.bindGroup)
+        frame.pass.draw(6, params.instanceCount)
+        frame.pass.end()
+        device.queue.submit([frame.encoder.finish()])
+        deferDestroy(uniform.record)
+        return true
+      } catch {
+        return false
+      }
+    },
+    drawLines(params: DrawLinesParams): boolean {
+      if (disposed) return false
+      const pipelineRecord = pipelines.get(params.pipeline as object)
+      if (!pipelineRecord || pipelineRecord.type === 'candle') return false
+      if (params.strips && params.strips.length === 0) return true
+      try {
+        const frame = beginPass()
+        if (!frame) return false
+        const temporaryRecords: BufferRecord[] = []
+
+        if (params.strips) {
+          const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
+          for (const strip of params.strips) {
+            if (strip.points.length < 2) return false
+            const wide = (strip.width ?? 1) > 1
+            const values = wide ? buildWideLine(strip) : linePoints(strip)
+            if (!values) return false
+            const vertexRecord = createBufferRecord('vertex', values.byteLength)
+            device.queue.writeBuffer(vertexRecord.buffer, 0, values.buffer, 0, values.byteLength)
+            temporaryRecords.push(vertexRecord)
+            const pipeline = getPipeline(wide ? 'line-wide' : 'line-strip')
+            const uniform = createUniform(pipeline, strip.color, scrollLeft)
+            if (!uniform) return false
+            temporaryRecords.push(uniform.record)
+            frame.pass.setPipeline(pipeline)
+            frame.pass.setVertexBuffer(0, vertexRecord.buffer)
+            frame.pass.setBindGroup(0, uniform.bindGroup)
+            frame.pass.draw(values.length / 2, 1)
+          }
+        } else {
+          if (pipelineRecord.type !== 'fill' || !params.vertices || !params.vertexCount)
+            return false
+          const vertexRecord = buffers.get(params.vertices as object)
+          if (!vertexRecord || params.vertexCount < 3) return false
+          const pipeline = getPipeline('fill')
+          const uniform = createUniform(
+            pipeline,
+            params.uniforms?.color,
+            (params.uniforms?.scrollLeft as number) ?? 0,
+          )
+          if (!uniform) return false
+          temporaryRecords.push(uniform.record)
+          frame.pass.setPipeline(pipeline)
+          frame.pass.setVertexBuffer(0, vertexRecord.buffer)
+          frame.pass.setBindGroup(0, uniform.bindGroup)
+          frame.pass.draw(params.vertexCount, 1)
+        }
+
+        frame.pass.end()
+        device.queue.submit([frame.encoder.finish()])
+        for (const record of temporaryRecords) deferDestroy(record)
+        return true
+      } catch {
+        return false
+      }
+    },
+    dispatchCompute(_params: DispatchComputeParams): void {
+      throw new Error('dispatchCompute requires a backend with caps.compute === true')
+    },
+    endFrame(): void {},
+    dispose(): void {
+      if (disposed) return
+      disposed = true
+      msaaTexture?.destroy()
+      msaaTexture = null
+      for (const record of bufferRecords) record.buffer.destroy()
+      bufferRecords.clear()
+      surface.dispose()
+    },
+  }
+
+  return renderer
+}

--- a/packages/core/src/rendering/render/createWebGPURenderer.ts
+++ b/packages/core/src/rendering/render/createWebGPURenderer.ts
@@ -188,13 +188,36 @@ export async function createWebGPURenderer(
   const canvas = options.canvas ?? globalThis.document?.createElement('canvas')
   if (!canvas) throw new Error('WebGPU canvas unavailable')
   const format = gpu.getPreferredCanvasFormat()
-  const surface = createWebGPUSurfaceBackend({ canvas, device, format })
+  const rawSurface = createWebGPUSurfaceBackend({ canvas, device, format })
+
+  type PendingDraw =
+    | {
+        kind: 'instances'
+        region: import('./SurfaceBackend').SurfaceRegion
+        pipeline: GPURenderPipeline
+        instanceBuffer: GPUBuffer
+        instanceCount: number
+        color: unknown
+        scrollLeft: number
+      }
+    | {
+        kind: 'lines'
+        region: import('./SurfaceBackend').SurfaceRegion
+        pipeline: GPURenderPipeline
+        vertexBuffer: GPUBuffer
+        vertexCount: number
+        color: unknown
+        scrollLeft: number
+        temporary?: BufferRecord
+      }
 
   let disposed = false
   let msaaTexture: GPUTexture | null = null
   let msaaWidth = 0
   let msaaHeight = 0
-  let clearPending = true
+  let currentRegion: import('./SurfaceBackend').SurfaceRegion | null = null
+  let pendingDraws: PendingDraw[] = []
+  let frameTemporaryRecords: BufferRecord[] = []
   const buffers = new WeakMap<object, BufferRecord>()
   const bufferRecords = new Set<BufferRecord>()
   const pipelines = new WeakMap<object, PipelineRecord>()
@@ -279,10 +302,10 @@ export async function createWebGPURenderer(
     pipeline: GPURenderPipeline,
     colorValue: unknown,
     scrollLeft: number,
+    region: import('./SurfaceBackend').SurfaceRegion,
   ): { record: BufferRecord; bindGroup: GPUBindGroup } | null {
-    const region = surface.getBoundRegion()
     const color = parseColor(colorValue ?? '#000000')
-    if (!region || !color) return null
+    if (!color) return null
     const values = new Float32Array([
       region.width,
       region.height,
@@ -302,19 +325,21 @@ export async function createWebGPURenderer(
     return { record, bindGroup }
   }
 
-  function beginPass(): { encoder: GPUCommandEncoder; pass: GPURenderPassEncoder } | null {
-    const region = surface.getBoundRegion()
-    const view = surface.getCurrentTextureView()
+  function beginPass(
+    encoder: GPUCommandEncoder,
+    region: import('./SurfaceBackend').SurfaceRegion,
+    loadOp: 'clear' | 'load',
+  ): GPURenderPassEncoder | null {
+    const view = rawSurface.getCurrentTextureView()
     const msaaView = ensureMsaaView()
-    if (!region || !view || !msaaView) return null
-    const encoder = device.createCommandEncoder()
+    if (!view || !msaaView) return null
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
           view: msaaView,
           resolveTarget: view,
           clearValue: { r: 0, g: 0, b: 0, a: 0 },
-          loadOp: clearPending ? 'clear' : 'load',
+          loadOp,
           storeOp: 'store',
         },
       ],
@@ -327,10 +352,71 @@ export async function createWebGPURenderer(
       pass.end()
       return null
     }
-    clearPending = false
     pass.setViewport(x, y, width, height, 0, 1)
     pass.setScissorRect(x, y, width, height)
-    return { encoder, pass }
+    return pass
+  }
+
+  function regionKey(region: import('./SurfaceBackend').SurfaceRegion): string {
+    return `${region.x},${region.y},${region.width},${region.height},${region.dpr}`
+  }
+
+  function flushPendingDraws(): void {
+    if (pendingDraws.length === 0) {
+      frameTemporaryRecords = []
+      return
+    }
+    const encoder = device.createCommandEncoder()
+    const temporaryUniforms: BufferRecord[] = []
+    try {
+      const groups = new Map<string, PendingDraw[]>()
+      for (const draw of pendingDraws) {
+        const key = regionKey(draw.region)
+        const list = groups.get(key)
+        if (list) list.push(draw)
+        else groups.set(key, [draw])
+      }
+
+      let isFirstPass = true
+      for (const draws of groups.values()) {
+        const region = draws[0]!.region
+        rawSurface.bindRegion(region)
+        const pass = beginPass(encoder, region, isFirstPass ? 'clear' : 'load')
+        isFirstPass = false
+        if (!pass) continue
+        for (const draw of draws) {
+          const uniform = createUniform(draw.pipeline, draw.color, draw.scrollLeft, draw.region)
+          if (!uniform) continue
+          temporaryUniforms.push(uniform.record)
+          pass.setPipeline(draw.pipeline)
+          if (draw.kind === 'instances') {
+            pass.setVertexBuffer(0, draw.instanceBuffer)
+            pass.setBindGroup(0, uniform.bindGroup)
+            pass.draw(6, draw.instanceCount)
+          } else {
+            pass.setVertexBuffer(0, draw.vertexBuffer)
+            pass.setBindGroup(0, uniform.bindGroup)
+            pass.draw(draw.vertexCount, 1)
+          }
+        }
+        pass.end()
+      }
+      device.queue.submit([encoder.finish()])
+    } finally {
+      for (const record of temporaryUniforms) deferDestroy(record)
+      for (const record of frameTemporaryRecords) deferDestroy(record)
+      pendingDraws = []
+      frameTemporaryRecords = []
+    }
+  }
+
+  // Flush before composite so M1 mid-frame compositeTo still sees GPU output.
+  const surface: WebGPUSurfaceBackend = {
+    ...rawSurface,
+    compositeTo(targetCtx, region, compositeOptions) {
+      flushPendingDraws()
+      rawSurface.compositeTo(targetCtx, region, compositeOptions)
+    },
   }
 
   const renderer: Renderer = {
@@ -380,8 +466,8 @@ export async function createWebGPURenderer(
     destroyComputePipeline(_handle): void {},
     beginFrame(region): void {
       if (!disposed) {
-        clearPending = true
-        surface.bindRegion(region)
+        currentRegion = { ...region }
+        rawSurface.bindRegion(region)
       }
     },
     drawInstances(params: DrawInstancesParams): boolean {
@@ -395,38 +481,28 @@ export async function createWebGPURenderer(
       if (params.instanceCount === 0) return true
       const pipelineRecord = pipelines.get(params.pipeline as object)
       const instanceRecord = buffers.get(params.instances as object)
-      if (pipelineRecord?.type !== 'candle' || !instanceRecord) return false
+      if (pipelineRecord?.type !== 'candle' || !instanceRecord || !currentRegion) return false
       try {
-        const pipeline = getPipeline('candle')
-        const uniform = createUniform(
-          pipeline,
-          params.uniforms?.color,
-          (params.uniforms?.scrollLeft as number) ?? 0,
-        )
-        const frame = beginPass()
-        if (!uniform || !frame) return false
-        frame.pass.setPipeline(pipeline)
-        frame.pass.setVertexBuffer(0, instanceRecord.buffer)
-        frame.pass.setBindGroup(0, uniform.bindGroup)
-        frame.pass.draw(6, params.instanceCount)
-        frame.pass.end()
-        device.queue.submit([frame.encoder.finish()])
-        deferDestroy(uniform.record)
+        pendingDraws.push({
+          kind: 'instances',
+          region: { ...currentRegion },
+          pipeline: getPipeline('candle'),
+          instanceBuffer: instanceRecord.buffer,
+          instanceCount: params.instanceCount,
+          color: params.uniforms?.color,
+          scrollLeft: (params.uniforms?.scrollLeft as number) ?? 0,
+        })
         return true
       } catch {
         return false
       }
     },
     drawLines(params: DrawLinesParams): boolean {
-      if (disposed) return false
+      if (disposed || !currentRegion) return false
       const pipelineRecord = pipelines.get(params.pipeline as object)
       if (!pipelineRecord || pipelineRecord.type === 'candle') return false
       if (params.strips && params.strips.length === 0) return true
       try {
-        const frame = beginPass()
-        if (!frame) return false
-        const temporaryRecords: BufferRecord[] = []
-
         if (params.strips) {
           const scrollLeft = (params.uniforms?.scrollLeft as number) ?? 0
           for (const strip of params.strips) {
@@ -436,38 +512,33 @@ export async function createWebGPURenderer(
             if (!values) return false
             const vertexRecord = createBufferRecord('vertex', values.byteLength)
             device.queue.writeBuffer(vertexRecord.buffer, 0, values.buffer, 0, values.byteLength)
-            temporaryRecords.push(vertexRecord)
-            const pipeline = getPipeline(wide ? 'line-wide' : 'line-strip')
-            const uniform = createUniform(pipeline, strip.color, scrollLeft)
-            if (!uniform) return false
-            temporaryRecords.push(uniform.record)
-            frame.pass.setPipeline(pipeline)
-            frame.pass.setVertexBuffer(0, vertexRecord.buffer)
-            frame.pass.setBindGroup(0, uniform.bindGroup)
-            frame.pass.draw(values.length / 2, 1)
+            frameTemporaryRecords.push(vertexRecord)
+            pendingDraws.push({
+              kind: 'lines',
+              region: { ...currentRegion },
+              pipeline: getPipeline(wide ? 'line-wide' : 'line-strip'),
+              vertexBuffer: vertexRecord.buffer,
+              vertexCount: values.length / 2,
+              color: strip.color,
+              scrollLeft,
+              temporary: vertexRecord,
+            })
           }
-        } else {
-          if (pipelineRecord.type !== 'fill' || !params.vertices || !params.vertexCount)
-            return false
-          const vertexRecord = buffers.get(params.vertices as object)
-          if (!vertexRecord || params.vertexCount < 3) return false
-          const pipeline = getPipeline('fill')
-          const uniform = createUniform(
-            pipeline,
-            params.uniforms?.color,
-            (params.uniforms?.scrollLeft as number) ?? 0,
-          )
-          if (!uniform) return false
-          temporaryRecords.push(uniform.record)
-          frame.pass.setPipeline(pipeline)
-          frame.pass.setVertexBuffer(0, vertexRecord.buffer)
-          frame.pass.setBindGroup(0, uniform.bindGroup)
-          frame.pass.draw(params.vertexCount, 1)
+          return true
         }
 
-        frame.pass.end()
-        device.queue.submit([frame.encoder.finish()])
-        for (const record of temporaryRecords) deferDestroy(record)
+        if (pipelineRecord.type !== 'fill' || !params.vertices || !params.vertexCount) return false
+        const vertexRecord = buffers.get(params.vertices as object)
+        if (!vertexRecord || params.vertexCount < 3) return false
+        pendingDraws.push({
+          kind: 'lines',
+          region: { ...currentRegion },
+          pipeline: getPipeline('fill'),
+          vertexBuffer: vertexRecord.buffer,
+          vertexCount: params.vertexCount,
+          color: params.uniforms?.color,
+          scrollLeft: (params.uniforms?.scrollLeft as number) ?? 0,
+        })
         return true
       } catch {
         return false
@@ -476,15 +547,19 @@ export async function createWebGPURenderer(
     dispatchCompute(_params: DispatchComputeParams): void {
       throw new Error('dispatchCompute requires a backend with caps.compute === true')
     },
-    endFrame(): void {},
+    endFrame(): void {
+      if (!disposed) flushPendingDraws()
+    },
     dispose(): void {
       if (disposed) return
       disposed = true
+      pendingDraws = []
+      frameTemporaryRecords = []
       msaaTexture?.destroy()
       msaaTexture = null
       for (const record of bufferRecords) record.buffer.destroy()
       bufferRecords.clear()
-      surface.dispose()
+      rawSurface.dispose()
     },
   }
 

--- a/packages/core/src/rendering/render/createWebGPURenderer.ts
+++ b/packages/core/src/rendering/render/createWebGPURenderer.ts
@@ -436,27 +436,50 @@ export async function createWebGPURenderer(
         else groups.set(key, [draw])
       }
 
-      let isFirstPass = true
-      for (const draws of groups.values()) {
-        const region = draws[0]!.region
-        rawSurface.bindRegion(region)
-        const pass = beginPass(encoder, region, isFirstPass ? 'clear' : 'load')
-        isFirstPass = false
-        if (!pass) continue
-        for (const draw of draws) {
-          const uniform = createUniform(draw.pipeline, draw.color, draw.scrollLeft, draw.region)
-          if (!uniform) continue
-          pass.setPipeline(draw.pipeline)
-          if (draw.kind === 'instances') {
-            pass.setVertexBuffer(0, draw.instanceBuffer)
-            pass.setBindGroup(0, uniform.bindGroup)
-            pass.draw(6, draw.instanceCount)
-            metrics.recordDraw()
-          } else {
-            pass.setVertexBuffer(0, draw.vertexBuffer)
-            pass.setBindGroup(0, uniform.bindGroup)
-            pass.draw(draw.vertexCount, 1)
-            metrics.recordDraw()
+      // 单 RenderPass：所有 region 组共享一次 clear + resolve，避免 MSAA 多 pass 驱动问题
+      const view = rawSurface.getCurrentTextureView()
+      const msaaView = ensureMsaaView()
+      if (view && msaaView) {
+        const pass = encoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: msaaView,
+              resolveTarget: view,
+              clearValue: { r: 0, g: 0, b: 0, a: 0 },
+              loadOp: 'clear',
+              storeOp: 'store',
+            },
+          ],
+        })
+
+        for (const draws of groups.values()) {
+          const region = draws[0]!.region
+          rawSurface.bindRegion(region)
+
+          const x = Math.max(0, Math.round(region.x * region.dpr))
+          const y = Math.max(0, Math.round(region.y * region.dpr))
+          const width = Math.min(canvas.width - x, Math.round(region.width * region.dpr))
+          const height = Math.min(canvas.height - y, Math.round(region.height * region.dpr))
+          if (width > 0 && height > 0) {
+            pass.setViewport(x, y, width, height, 0, 1)
+            pass.setScissorRect(x, y, width, height)
+
+            for (const draw of draws) {
+              const uniform = createUniform(draw.pipeline, draw.color, draw.scrollLeft, draw.region)
+              if (!uniform) continue
+              pass.setPipeline(draw.pipeline)
+              if (draw.kind === 'instances') {
+                pass.setVertexBuffer(0, draw.instanceBuffer)
+                pass.setBindGroup(0, uniform.bindGroup)
+                pass.draw(6, draw.instanceCount)
+                metrics.recordDraw()
+              } else {
+                pass.setVertexBuffer(0, draw.vertexBuffer)
+                pass.setBindGroup(0, uniform.bindGroup)
+                pass.draw(draw.vertexCount, 1)
+                metrics.recordDraw()
+              }
+            }
           }
         }
         pass.end()

--- a/packages/core/src/rendering/render/createWebGPUSurfaceBackend.ts
+++ b/packages/core/src/rendering/render/createWebGPUSurfaceBackend.ts
@@ -1,0 +1,95 @@
+import type { CompositeOptions, SurfaceBackend, SurfaceRegion } from './SurfaceBackend'
+
+export type WebGPUSurfaceBackend = SurfaceBackend & {
+  readonly canvas: HTMLCanvasElement
+  readonly device: GPUDevice
+  readonly format: GPUTextureFormat
+  getBoundRegion(): SurfaceRegion | null
+  getCurrentTextureView(): GPUTextureView | null
+}
+
+export type WebGPUSurfaceBackendOptions = {
+  canvas: HTMLCanvasElement
+  device: GPUDevice
+  format: GPUTextureFormat
+}
+
+export function createWebGPUSurfaceBackend(
+  options: WebGPUSurfaceBackendOptions,
+): WebGPUSurfaceBackend {
+  const { canvas, device, format } = options
+  const context = canvas.getContext('webgpu')
+  if (!context) throw new Error('WebGPU canvas context unavailable')
+
+  const renderAttachmentUsage = globalThis.GPUTextureUsage?.RENDER_ATTACHMENT ?? 0x10
+  context.configure({
+    device,
+    format,
+    alphaMode: 'premultiplied',
+    usage: renderAttachmentUsage,
+  })
+
+  let disposed = false
+  let boundRegion: SurfaceRegion | null = null
+
+  return {
+    canvas,
+    device,
+    format,
+    isAvailable(): boolean {
+      return !disposed
+    },
+    resize(widthLogical: number, heightLogical: number, dpr: number): void {
+      if (disposed) return
+      const width = Math.max(1, Math.round(widthLogical * dpr))
+      const height = Math.max(1, Math.round(heightLogical * dpr))
+      if (canvas.width !== width) canvas.width = width
+      if (canvas.height !== height) canvas.height = height
+    },
+    bindRegion(region: SurfaceRegion): boolean {
+      if (disposed || region.width <= 0 || region.height <= 0 || region.dpr <= 0) return false
+      boundRegion = { ...region }
+      return true
+    },
+    clearRegion(_region: SurfaceRegion): void {},
+    compositeTo(
+      targetCtx: CanvasRenderingContext2D,
+      region: SurfaceRegion,
+      compositeOptions?: CompositeOptions,
+    ): void {
+      if (disposed || region.width <= 0 || region.height <= 0) return
+      const sx = Math.round(region.x * region.dpr)
+      const sy = Math.round(region.y * region.dpr)
+      const sw = Math.round(region.width * region.dpr)
+      const sh = Math.round(region.height * region.dpr)
+
+      targetCtx.save()
+      targetCtx.setTransform(1, 0, 0, 1, 0, 0)
+      if (compositeOptions?.alpha !== undefined) {
+        targetCtx.globalAlpha *= compositeOptions.alpha
+      }
+      if (compositeOptions?.imageSmoothingEnabled !== undefined) {
+        targetCtx.imageSmoothingEnabled = compositeOptions.imageSmoothingEnabled
+      }
+      targetCtx.drawImage(canvas, sx, sy, sw, sh, 0, 0, sw, sh)
+      targetCtx.restore()
+    },
+    getBoundRegion(): SurfaceRegion | null {
+      return boundRegion ? { ...boundRegion } : null
+    },
+    getCurrentTextureView(): GPUTextureView | null {
+      if (disposed) return null
+      try {
+        return context.getCurrentTexture().createView()
+      } catch {
+        return null
+      }
+    },
+    dispose(): void {
+      if (disposed) return
+      disposed = true
+      boundRegion = null
+      context.unconfigure()
+    },
+  }
+}

--- a/packages/core/src/rendering/render/createWebGPUSurfaceBackend.ts
+++ b/packages/core/src/rendering/render/createWebGPUSurfaceBackend.ts
@@ -45,34 +45,45 @@ export function createWebGPUSurfaceBackend(
       const height = Math.max(1, Math.round(heightLogical * dpr))
       if (canvas.width !== width) canvas.width = width
       if (canvas.height !== height) canvas.height = height
+      // 可见 DOM 合成：CSS 尺寸跟逻辑 plot，buffer 跟物理像素
+      if (canvas.style) {
+        canvas.style.width = `${Math.max(0, widthLogical)}px`
+        canvas.style.height = `${Math.max(0, heightLogical)}px`
+      }
     },
     bindRegion(region: SurfaceRegion): boolean {
       if (disposed || region.width <= 0 || region.height <= 0 || region.dpr <= 0) return false
       boundRegion = { ...region }
       return true
     },
-    clearRegion(_region: SurfaceRegion): void {},
+    clearRegion(_region: SurfaceRegion): void {
+      if (disposed) return
+      // 空数据/清屏：提交透明 clear，避免 hybrid 可见 canvas 残留上一帧
+      try {
+        const view = context.getCurrentTexture().createView()
+        const encoder = device.createCommandEncoder()
+        const pass = encoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view,
+              clearValue: { r: 0, g: 0, b: 0, a: 0 },
+              loadOp: 'clear',
+              storeOp: 'store',
+            },
+          ],
+        })
+        pass.end()
+        device.queue.submit([encoder.finish()])
+      } catch {
+        // device lost / texture unavailable：忽略，下帧 beginFrame 会重建
+      }
+    },
     compositeTo(
-      targetCtx: CanvasRenderingContext2D,
-      region: SurfaceRegion,
-      compositeOptions?: CompositeOptions,
+      _targetCtx: CanvasRenderingContext2D,
+      _region: SurfaceRegion,
+      _compositeOptions?: CompositeOptions,
     ): void {
-      if (disposed || region.width <= 0 || region.height <= 0) return
-      const sx = Math.round(region.x * region.dpr)
-      const sy = Math.round(region.y * region.dpr)
-      const sw = Math.round(region.width * region.dpr)
-      const sh = Math.round(region.height * region.dpr)
-
-      targetCtx.save()
-      targetCtx.setTransform(1, 0, 0, 1, 0, 0)
-      if (compositeOptions?.alpha !== undefined) {
-        targetCtx.globalAlpha *= compositeOptions.alpha
-      }
-      if (compositeOptions?.imageSmoothingEnabled !== undefined) {
-        targetCtx.imageSmoothingEnabled = compositeOptions.imageSmoothingEnabled
-      }
-      targetCtx.drawImage(canvas, sx, sy, sw, sh, 0, 0, sw, sh)
-      targetCtx.restore()
+      // M2：WebGPU 可见 canvas 直接参与 DOM 分层，禁止 GPU→2D drawImage
     },
     getBoundRegion(): SurfaceRegion | null {
       return boundRegion ? { ...boundRegion } : null

--- a/packages/core/src/rendering/render/frameMetrics.ts
+++ b/packages/core/src/rendering/render/frameMetrics.ts
@@ -1,0 +1,54 @@
+export type FrameMetricsSnapshot = {
+  bufferCreateCount: number
+  bufferUploadBytes: number
+  drawCallCount: number
+  queueSubmitCount: number
+  compositeCount: number
+}
+
+function empty(): FrameMetricsSnapshot {
+  return {
+    bufferCreateCount: 0,
+    bufferUploadBytes: 0,
+    drawCallCount: 0,
+    queueSubmitCount: 0,
+    compositeCount: 0,
+  }
+}
+
+let snapshot: FrameMetricsSnapshot = empty()
+
+export function resetFrameMetrics(): void {
+  snapshot = empty()
+}
+
+export function getFrameMetrics(): FrameMetricsSnapshot {
+  return { ...snapshot }
+}
+
+export function createFrameMetrics() {
+  let current = empty()
+  return {
+    beginFrame(): void {
+      current = empty()
+    },
+    recordBufferCreate(): void {
+      current.bufferCreateCount += 1
+    },
+    recordUpload(bytes: number): void {
+      current.bufferUploadBytes += bytes
+    },
+    recordDraw(): void {
+      current.drawCallCount += 1
+    },
+    recordSubmit(): void {
+      current.queueSubmitCount += 1
+    },
+    recordComposite(): void {
+      current.compositeCount += 1
+    },
+    endFrame(): void {
+      snapshot = { ...current }
+    },
+  }
+}

--- a/packages/core/src/rendering/render/index.ts
+++ b/packages/core/src/rendering/render/index.ts
@@ -9,6 +9,30 @@ export type { SurfaceBackend, SurfaceRegion, CompositeOptions } from './SurfaceB
 
 export { createWebGLSurfaceBackend } from './createWebGLSurfaceBackend'
 export { createWebGLRenderer } from './createWebGLRenderer'
+export { createWebGPUSurfaceBackend } from './createWebGPUSurfaceBackend'
+export { createWebGPURenderer } from './createWebGPURenderer'
+export { createCanvas2DRenderer } from './createCanvas2DRenderer'
+export { createRendererHost, createRendererHostFromRenderer } from './rendererHost'
+export {
+  createDefaultRendererHost,
+  createDefaultRendererHostSync,
+} from './createDefaultRendererHost'
+
+export type {
+  RendererBackend,
+  RendererBackendStatus,
+  RendererBackendRuntime,
+  RendererFactory,
+  RendererHostDependencies,
+  RendererHostListeners,
+  RendererHost,
+} from './rendererHost'
+
+export type {
+  WebGPUSurfaceBackend,
+  WebGPUSurfaceBackendOptions,
+} from './createWebGPUSurfaceBackend'
+export type { CreateWebGPURendererOptions } from './createWebGPURenderer'
 
 export type {
   Renderer,

--- a/packages/core/src/rendering/render/index.ts
+++ b/packages/core/src/rendering/render/index.ts
@@ -33,6 +33,12 @@ export type {
   WebGPUSurfaceBackendOptions,
 } from './createWebGPUSurfaceBackend'
 export type { CreateWebGPURendererOptions } from './createWebGPURenderer'
+export {
+  createFrameMetrics,
+  getFrameMetrics,
+  resetFrameMetrics,
+} from './frameMetrics'
+export type { FrameMetricsSnapshot } from './frameMetrics'
 
 export type {
   Renderer,

--- a/packages/core/src/rendering/render/rendererHost.ts
+++ b/packages/core/src/rendering/render/rendererHost.ts
@@ -1,0 +1,210 @@
+import type { Renderer } from './Renderer'
+
+export type RendererBackend = 'webgpu' | 'webgl' | 'canvas'
+
+export type RendererBackendStatus = 'initializing' | 'ready' | 'switching' | 'degraded' | 'failed'
+
+export type RendererBackendRuntime = {
+  effective: RendererBackend
+  status: RendererBackendStatus
+  error: string | null
+}
+
+export type RendererFactory = () => Renderer | Promise<Renderer>
+
+export type RendererHostDependencies = {
+  createWebGPU: RendererFactory
+  createWebGL: RendererFactory
+  createCanvas: RendererFactory
+  onRuntimeChange?: (runtime: Readonly<RendererBackendRuntime>) => void
+  requestRedraw?: () => void
+}
+
+export type RendererHostListeners = Pick<
+  RendererHostDependencies,
+  'onRuntimeChange' | 'requestRedraw'
+>
+
+export interface RendererHost {
+  readonly renderer: Renderer
+  readonly runtime: Readonly<RendererBackendRuntime>
+  resize(widthLogical: number, heightLogical: number, dpr: number): void
+  switchTo(preference: RendererBackend): Promise<void>
+  handleDeviceLost(error: string): Promise<void>
+  setListeners(listeners: RendererHostListeners): void
+  dispose(): void
+}
+
+export type PreparedRenderer = {
+  renderer: Renderer
+  effective: RendererBackend
+  error: string | null
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function prepareRenderer(
+  preference: RendererBackend,
+  deps: RendererHostDependencies,
+): Promise<PreparedRenderer> {
+  const attempts: Array<[RendererBackend, RendererFactory]> =
+    preference === 'webgpu'
+      ? [
+          ['webgpu', deps.createWebGPU],
+          ['webgl', deps.createWebGL],
+          ['canvas', deps.createCanvas],
+        ]
+      : preference === 'webgl'
+        ? [
+            ['webgl', deps.createWebGL],
+            ['canvas', deps.createCanvas],
+          ]
+        : [['canvas', deps.createCanvas]]
+  let firstError: string | null = null
+
+  for (const [effective, factory] of attempts) {
+    try {
+      return {
+        renderer: await factory(),
+        effective,
+        error: firstError,
+      }
+    } catch (error) {
+      firstError ??= errorMessage(error)
+    }
+  }
+
+  throw new Error(firstError ?? `Unable to create ${preference} renderer`)
+}
+
+export async function createRendererHost(
+  preference: RendererBackend,
+  deps: RendererHostDependencies,
+): Promise<RendererHost> {
+  const initial = await prepareRenderer(preference, deps)
+  return createRendererHostFromRenderer(preference, initial, deps)
+}
+
+export function createRendererHostFromRenderer(
+  preference: RendererBackend,
+  initial: PreparedRenderer,
+  deps: RendererHostDependencies,
+): RendererHost {
+  let activeRenderer = initial.renderer
+  let runtime: RendererBackendRuntime = {
+    effective: initial.effective,
+    status: initial.effective === preference ? 'ready' : 'degraded',
+    error: initial.error,
+  }
+  let generation = 0
+  let disposed = false
+  let surfaceSize: { widthLogical: number; heightLogical: number; dpr: number } | null = null
+  let listeners: RendererHostListeners = {
+    onRuntimeChange: deps.onRuntimeChange,
+    requestRedraw: deps.requestRedraw,
+  }
+
+  function publish(next: RendererBackendRuntime): void {
+    runtime = next
+    listeners.onRuntimeChange?.(runtime)
+  }
+
+  const host: RendererHost = {
+    get renderer() {
+      return activeRenderer
+    },
+    get runtime() {
+      return runtime
+    },
+    resize(widthLogical, heightLogical, dpr): void {
+      if (disposed) return
+      surfaceSize = { widthLogical, heightLogical, dpr }
+      activeRenderer.surface.resize(widthLogical, heightLogical, dpr)
+    },
+    async switchTo(nextPreference): Promise<void> {
+      if (disposed) return
+      const requestGeneration = ++generation
+      publish({ ...runtime, status: 'switching', error: null })
+
+      let prepared: PreparedRenderer
+      try {
+        prepared = await prepareRenderer(nextPreference, deps)
+      } catch (error) {
+        if (disposed || requestGeneration !== generation) return
+        publish({ ...runtime, status: 'degraded', error: errorMessage(error) })
+        return
+      }
+
+      if (disposed || requestGeneration !== generation) {
+        prepared.renderer.dispose()
+        return
+      }
+
+      if (surfaceSize) {
+        prepared.renderer.surface.resize(
+          surfaceSize.widthLogical,
+          surfaceSize.heightLogical,
+          surfaceSize.dpr,
+        )
+      }
+
+      const previous = activeRenderer
+      activeRenderer = prepared.renderer
+      publish({
+        effective: prepared.effective,
+        status: prepared.effective === nextPreference ? 'ready' : 'degraded',
+        error: prepared.error,
+      })
+      listeners.requestRedraw?.()
+      if (previous !== activeRenderer) previous.dispose()
+    },
+    async handleDeviceLost(error): Promise<void> {
+      if (disposed || runtime.effective !== 'webgpu') return
+      const requestGeneration = ++generation
+      publish({ ...runtime, status: 'degraded', error })
+
+      let prepared: PreparedRenderer
+      try {
+        prepared = await prepareRenderer('webgl', deps)
+      } catch (fallbackError) {
+        if (disposed || requestGeneration !== generation) return
+        publish({ ...runtime, status: 'failed', error: errorMessage(fallbackError) })
+        return
+      }
+
+      if (disposed || requestGeneration !== generation) {
+        prepared.renderer.dispose()
+        return
+      }
+
+      if (surfaceSize) {
+        prepared.renderer.surface.resize(
+          surfaceSize.widthLogical,
+          surfaceSize.heightLogical,
+          surfaceSize.dpr,
+        )
+      }
+
+      const previous = activeRenderer
+      activeRenderer = prepared.renderer
+      publish({ effective: prepared.effective, status: 'degraded', error })
+      listeners.requestRedraw?.()
+      if (previous !== activeRenderer) previous.dispose()
+    },
+    setListeners(nextListeners): void {
+      listeners = { ...nextListeners }
+      listeners.onRuntimeChange?.(runtime)
+    },
+    dispose(): void {
+      if (disposed) return
+      disposed = true
+      generation += 1
+      activeRenderer.dispose()
+    },
+  }
+
+  listeners.onRuntimeChange?.(runtime)
+  return host
+}

--- a/packages/core/src/rendering/render/webgpuResourceTable.ts
+++ b/packages/core/src/rendering/render/webgpuResourceTable.ts
@@ -1,0 +1,87 @@
+import type { createFrameMetrics } from './frameMetrics'
+
+type Metrics = ReturnType<typeof createFrameMetrics>
+
+export type ResourceUsage = 'vertex' | 'instance' | 'uniform'
+
+export type EnsureUploadedParams = {
+  key: string
+  revision: number
+  data: Float32Array
+  usage: ResourceUsage
+}
+
+export type GpuResourceHandle = {
+  buffer: GPUBuffer
+  capacity: number
+  lastRevision: number
+}
+
+export type WebGPUResourceTable = {
+  ensureUploaded(params: EnsureUploadedParams): GpuResourceHandle
+  destroyKey(key: string): void
+  destroyAll(): void
+}
+
+const GPU_BUFFER_COPY_DST = globalThis.GPUBufferUsage?.COPY_DST ?? 0x0008
+const GPU_BUFFER_VERTEX = globalThis.GPUBufferUsage?.VERTEX ?? 0x0020
+const GPU_BUFFER_UNIFORM = globalThis.GPUBufferUsage?.UNIFORM ?? 0x0040
+
+function gpuUsage(usage: ResourceUsage): GPUBufferUsageFlags {
+  if (usage === 'uniform') return GPU_BUFFER_UNIFORM | GPU_BUFFER_COPY_DST
+  return GPU_BUFFER_VERTEX | GPU_BUFFER_COPY_DST
+}
+
+function growCapacity(needed: number, existing: number): number {
+  let capacity = Math.max(4, existing || 4)
+  while (capacity < needed) capacity = Math.ceil(capacity * 1.5)
+  return Math.ceil(capacity / 4) * 4
+}
+
+export function createWebGPUResourceTable(options: {
+  device: GPUDevice
+  metrics?: Metrics
+}): WebGPUResourceTable {
+  const { device, metrics } = options
+  const resources = new Map<string, GpuResourceHandle>()
+
+  return {
+    ensureUploaded({ key, revision, data, usage }): GpuResourceHandle {
+      const byteLength = data.byteLength
+      let resource = resources.get(key)
+      if (!resource || resource.capacity < byteLength) {
+        resource?.buffer.destroy()
+        const capacity = growCapacity(byteLength, resource?.capacity ?? 0)
+        const buffer = device.createBuffer({
+          size: capacity,
+          usage: gpuUsage(usage),
+        })
+        metrics?.recordBufferCreate()
+        resource = { buffer, capacity, lastRevision: -1 }
+        resources.set(key, resource)
+      }
+      if (resource.lastRevision !== revision) {
+        device.queue.writeBuffer(
+          resource.buffer,
+          0,
+          data.buffer as ArrayBuffer,
+          data.byteOffset,
+          data.byteLength,
+        )
+        metrics?.recordUpload(byteLength)
+        resource.lastRevision = revision
+      }
+      return resource
+    },
+    destroyKey(key): void {
+      const resource = resources.get(key)
+      if (!resource) return
+      resource.buffer.destroy()
+      resources.delete(key)
+    },
+    destroyAll(): void {
+      for (const resource of resources.values()) resource.buffer.destroy()
+      resources.clear()
+    },
+  }
+}

--- a/packages/core/src/rendering/scene/__tests__/layerFromPlugin.test.ts
+++ b/packages/core/src/rendering/scene/__tests__/layerFromPlugin.test.ts
@@ -70,6 +70,33 @@ describe('createLayerFromPlugin', () => {
     expect(plugin.draw).toHaveBeenCalledWith(context)
   })
 
+  it('injects PaintContext.renderer as RenderContext.sceneRenderer before draw', () => {
+    const plugin = makeMockPlugin({
+      draw: vi.fn((c: RenderContext) => {
+        expect(c.sceneRenderer).toBe(stubPaintCtx.renderer)
+      }),
+    })
+    const context = makeMockContext()
+    const layer = createLayerFromPlugin(plugin, () => context, 'main')
+    layer.paint(stubPaintCtx)
+    expect(plugin.draw).toHaveBeenCalledOnce()
+  })
+
+  it('isolates plugin.draw errors so paint does not throw', () => {
+    const plugin = makeMockPlugin({
+      draw: vi.fn(() => {
+        throw new Error('draw boom')
+      }),
+    })
+    const context = makeMockContext()
+    const layer = createLayerFromPlugin(plugin, () => context, 'main')
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => layer.paint(stubPaintCtx)).not.toThrow()
+    expect(plugin.draw).toHaveBeenCalledOnce()
+    err.mockRestore()
+  })
+
   it('skips plugin.draw when getContext returns null', () => {
     const plugin = makeMockPlugin()
     const getContext = vi.fn(() => null)
@@ -93,7 +120,7 @@ describe('createLayerFromPlugin', () => {
     expect(plugin.draw).not.toHaveBeenCalled()
   })
 
-  it('calls plugin.onUninstall on dispose', () => {
+  it('does not call plugin.onUninstall on dispose (owned by removeRenderer)', () => {
     const onUninstall = vi.fn()
     const plugin = makeMockPlugin({ onUninstall })
     const getContext = vi.fn(() => makeMockContext())
@@ -101,7 +128,7 @@ describe('createLayerFromPlugin', () => {
 
     layer.dispose()
 
-    expect(onUninstall).toHaveBeenCalledOnce()
+    expect(onUninstall).not.toHaveBeenCalled()
   })
 
   it('does not throw when dispose is called without onUninstall', () => {

--- a/packages/core/src/rendering/scene/__tests__/retainedScene.test.ts
+++ b/packages/core/src/rendering/scene/__tests__/retainedScene.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { createRetainedScene } from '../retainedScene'
+
+describe('createRetainedScene', () => {
+  it('upserts by key and replaces geometry when revision changes', () => {
+    const scene = createRetainedScene()
+    scene.beginFrame(1)
+    scene.upsert({
+      kind: 'rects',
+      key: 'main/candle/upBody',
+      revision: 1,
+      instances: new Float32Array([0, 0, 1, 2]),
+      count: 1,
+      color: '#0f0',
+      scrollLeft: 0,
+      z: 10,
+      paneId: 'main',
+    })
+    scene.upsert({
+      kind: 'rects',
+      key: 'main/candle/upBody',
+      revision: 2,
+      instances: new Float32Array([1, 1, 1, 2]),
+      count: 1,
+      color: '#0f0',
+      scrollLeft: 5,
+      z: 10,
+      paneId: 'main',
+    })
+    const nodes = scene.collectVisible('main')
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.revision).toBe(2)
+    expect(nodes[0]?.scrollLeft).toBe(5)
+  })
+
+  it('prunes keys not touched for N frames', () => {
+    const scene = createRetainedScene({ staleFrames: 2 })
+    scene.beginFrame(1)
+    scene.upsert({
+      kind: 'rects',
+      key: 'a',
+      revision: 1,
+      instances: new Float32Array(4),
+      count: 1,
+      color: '#fff',
+      scrollLeft: 0,
+      z: 0,
+      paneId: 'main',
+    })
+    scene.endFrame()
+    scene.beginFrame(2)
+    scene.endFrame()
+    scene.beginFrame(3)
+    const removed = scene.prune()
+    expect(removed).toEqual(['a'])
+    expect(scene.collectVisible('main')).toEqual([])
+  })
+})

--- a/packages/core/src/rendering/scene/createLayerFromPlugin.ts
+++ b/packages/core/src/rendering/scene/createLayerFromPlugin.ts
@@ -29,10 +29,17 @@ export function createLayerFromPlugin(
       if (paneRole === 'sub' && ctx.paneId !== targetPaneId) return
       const context = getContext()
       if (!context) return
-      plugin.draw(context)
+      // 注入本帧 Scene Renderer，供已迁路径（candle 等）走统一画笔
+      context.sceneRenderer = ctx.renderer
+      try {
+        plugin.draw(context)
+      } catch (e) {
+        // 隔离单层异常，避免中断同 pane 后续 Layer（对齐旧 Manager.render）
+        console.error(`[RendererPlugin] ${plugin.name} draw error:`, e)
+      }
     },
     dispose() {
-      plugin.onUninstall?.()
+      // onUninstall 由 removeRenderer / Manager.unregister 单点负责，避免双调
     },
   }
 }

--- a/packages/core/src/rendering/scene/layerRegistry.ts
+++ b/packages/core/src/rendering/scene/layerRegistry.ts
@@ -15,11 +15,9 @@ import { KLineChartError } from '../../errors'
  *    avoids forcing every consumer through a single "register + auto-add"
  *    pipeline that would be hard to compose with config-driven scenes.
  *
- * This PR does NOT pre-register any factories — that's a follow-up PR
- * once the legacy WebGL renderers have adapters that satisfy the `Layer`
- * interface. This file ships the registry mechanism plus the canonical
- * `typeId` constants so the rest of the codebase can reference layer types
- * by symbol rather than magic string.
+ * Factories are registered by chart wiring / plugins; this file ships the
+ * registry mechanism plus the canonical `typeId` constants so the rest of
+ * the codebase can reference layer types by symbol rather than magic string.
  */
 
 import type { Layer, LayerRole } from './types'
@@ -98,7 +96,7 @@ export function createLayerRegistry(): LayerRegistry {
  * string literal types without an enum import — useful for config blobs.
  */
 export const BUILTIN_LAYER_TYPES = {
-  // Existing in v0 (handled by legacy renderers)
+  // Built-in chart layers
   CANDLE: 'builtin:candle',
   VOLUME: 'builtin:volume',
   INDICATOR_MA: 'builtin:indicator:ma',

--- a/packages/core/src/rendering/scene/retainedScene.ts
+++ b/packages/core/src/rendering/scene/retainedScene.ts
@@ -1,0 +1,101 @@
+export type SceneNodeKey = string
+
+export type RectsNode = {
+  kind: 'rects'
+  key: SceneNodeKey
+  revision: number
+  instances: Float32Array
+  count: number
+  color: string
+  scrollLeft: number
+  z: number
+  paneId: string
+}
+
+export type LinesNode = {
+  kind: 'lines'
+  key: SceneNodeKey
+  revision: number
+  strips: ReadonlyArray<{
+    points: ReadonlyArray<{ x: number; y: number }>
+    color: string
+    width?: number
+  }>
+  scrollLeft: number
+  z: number
+  paneId: string
+}
+
+export type BandNode = {
+  kind: 'band'
+  key: SceneNodeKey
+  revision: number
+  upper: ReadonlyArray<{ x: number; y: number }>
+  lower: ReadonlyArray<{ x: number; y: number }>
+  color: string
+  alpha: number
+  scrollLeft: number
+  z: number
+  paneId: string
+}
+
+export type SceneNode = RectsNode | LinesNode | BandNode
+
+type StoredNode = SceneNode & {
+  lastTouchedFrame: number
+}
+
+export type RetainedSceneOptions = {
+  staleFrames?: number
+}
+
+export type RetainedScene = {
+  beginFrame(frameNumber: number): void
+  upsert(node: SceneNode): void
+  collectVisible(paneId?: string): SceneNode[]
+  endFrame(): void
+  prune(): string[]
+  clear(): void
+}
+
+export function createRetainedScene(options: RetainedSceneOptions = {}): RetainedScene {
+  const staleFrames = options.staleFrames ?? 2
+  const nodes = new Map<SceneNodeKey, StoredNode>()
+  let frameNumber = 0
+
+  return {
+    beginFrame(nextFrameNumber): void {
+      frameNumber = nextFrameNumber
+    },
+    upsert(node): void {
+      nodes.set(node.key, {
+        ...node,
+        lastTouchedFrame: frameNumber,
+      })
+    },
+    collectVisible(paneId): SceneNode[] {
+      const result: SceneNode[] = []
+      for (const stored of nodes.values()) {
+        if (paneId !== undefined && stored.paneId !== paneId) continue
+        const { lastTouchedFrame: _lastTouchedFrame, ...node } = stored
+        result.push(node)
+      }
+      result.sort((a, b) => a.z - b.z || a.key.localeCompare(b.key))
+      return result
+    },
+    endFrame(): void {},
+    prune(): string[] {
+      const removed: string[] = []
+      for (const [key, stored] of nodes) {
+        if (frameNumber - stored.lastTouchedFrame >= staleFrames) {
+          nodes.delete(key)
+          removed.push(key)
+        }
+      }
+      return removed
+    },
+    clear(): void {
+      nodes.clear()
+    },
+  }
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -12,7 +12,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "lib": ["ES2022", "DOM"],
-    "types": ["vite/client"],
+    "types": ["vite/client", "@webgpu/types"],
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/react/src/__tests__/_mockController.ts
+++ b/packages/react/src/__tests__/_mockController.ts
@@ -57,6 +57,11 @@ export function createMockChartController(
     symbols: createSignal([] as ReadonlyArray<SymbolSpec>),
     theme,
     settings,
+    rendererRuntime: createSignal({
+      effective: 'webgl' as const,
+      status: 'ready' as const,
+      error: null,
+    }),
     chartMode: createSignal('kline' as const),
     indicators: createSignal<ReadonlyArray<IndicatorInstance>>([]),
     subPanes: createSignal<ReadonlyArray<SubPaneInfo>>([]),

--- a/packages/vue/src/__tests__/_mockController.ts
+++ b/packages/vue/src/__tests__/_mockController.ts
@@ -95,6 +95,11 @@ export function createMockChartController(
     symbols: createSignal([] as ReadonlyArray<SymbolSpec>),
     theme,
     settings,
+    rendererRuntime: createSignal({
+      effective: 'webgl' as const,
+      status: 'ready' as const,
+      error: null,
+    }),
     chartMode: createSignal('kline' as const),
     indicators: createSignal<ReadonlyArray<IndicatorInstance>>([]),
     subPanes: createSignal<ReadonlyArray<SubPaneInfo>>([]),

--- a/packages/vue/src/components/ChartSettingsDialog.vue
+++ b/packages/vue/src/components/ChartSettingsDialog.vue
@@ -57,6 +57,12 @@
                 />
               </template>
             </div>
+            <div
+              v-if="item.key === 'rendererBackend' && runtimeHint"
+              class="settings-item runtime-hint"
+            >
+              <span>{{ runtimeHint }}</span>
+            </div>
           </template>
         </div>
       </section>
@@ -265,9 +271,11 @@
   import {
     DEFAULT_SETTINGS,
     SETTINGS_STORAGE_KEY,
+    migrateStoredSettings,
     type ChartSettings,
     type SettingItem,
   } from '@363045841yyt/klinechart-core/config'
+  import type { RendererBackendRuntime } from '@363045841yyt/klinechart-core/controllers'
   import { ref, computed, watch } from 'vue'
 
   import { getOpenSourceCredits } from '../credits/openSourceCredits'
@@ -279,6 +287,7 @@
   const props = defineProps<{
     show: boolean
     initialSettings?: ChartSettings
+    rendererRuntime?: RendererBackendRuntime | null
   }>()
 
   const emit = defineEmits<{
@@ -325,7 +334,7 @@
     try {
       const saved = localStorage.getItem(SETTINGS_STORAGE_KEY)
       if (saved) {
-        const parsed = JSON.parse(saved)
+        const parsed = migrateStoredSettings(JSON.parse(saved) as Record<string, unknown>)
         const result: ChartSettings = {}
         DEFAULT_SETTINGS.forEach((item) => {
           ;(result as Record<string, unknown>)[item.key] = parsed[item.key] ?? item.default
@@ -341,6 +350,20 @@
     defaults.colorPresetSettings = {}
     return defaults
   }
+
+  const runtimeHint = computed(() => {
+    const runtime = props.rendererRuntime
+    if (!runtime) return ''
+    const status =
+      runtime.status === 'ready'
+        ? ''
+        : runtime.status === 'switching'
+          ? '切换中'
+          : runtime.status === 'degraded'
+            ? '已降级'
+            : runtime.status
+    return status ? `当前有效：${runtime.effective}（${status}）` : `当前有效：${runtime.effective}`
+  })
 
   const settings = ref<ChartSettings>(loadSettings())
 
@@ -483,6 +506,19 @@
 
   .settings-item:hover {
     background: var(--klc-color-tag-bg-hover);
+  }
+
+  .settings-item.runtime-hint {
+    min-height: 28px;
+    padding-top: 0;
+    padding-bottom: 8px;
+    font-size: 12px;
+    color: var(--klc-color-axis-text);
+    cursor: default;
+  }
+
+  .settings-item.runtime-hint:hover {
+    background: transparent;
   }
 
   a.settings-item.credit-item {

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -1042,7 +1042,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
           return true
         }
         if (drawingController.value?.onPointerMove(event, container)) {
-          drawings.value = drawingController.value.getDrawings()
+          // 预览/拖拽只在会话层；UI 列表仍订 kernel.drawings，此处不镜像会话态
           return true
         }
         return false

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -34,6 +34,7 @@
         :is-fullscreen="effectiveIsFullscreen"
         :alert-controller="controller"
         :effective-settings="chartSettings"
+        :renderer-runtime="rendererRuntime"
         :drawing-tool-id="drawingToolId"
         :is-range-select-mode="isRangeSelectMode"
         @select-tool="handleSelectTool"
@@ -212,9 +213,11 @@
 <script setup lang="ts">
   import {
     SETTINGS_STORAGE_KEY,
+    migrateStoredSettings,
     resolveSettings,
     type ChartSettings,
   } from '@363045841yyt/klinechart-core/config'
+  import type { RendererBackendRuntime } from '@363045841yyt/klinechart-core/controllers'
   import {
     createChartController,
     routerDataFetcher,
@@ -463,7 +466,10 @@ import MarkerTooltip from './MarkerTooltip.vue'
 
   function forcePercentAxis() {
     if (chartSettings.value.axisType === 'percent') return
-    const nextSettings = { ...chartSettings.value, axisType: 'percent' as const }
+    const nextSettings = migrateStoredSettings({
+      ...chartSettings.value,
+      axisType: 'percent',
+    })
     chartSettings.value = nextSettings
     controller.value?.updateSettingsFacade(resolveSettings(nextSettings))
     try {
@@ -572,6 +578,8 @@ import MarkerTooltip from './MarkerTooltip.vue'
 
   /** 镜像 kernel.drawingTool，供工具栏高亮 */
   const drawingToolId = shallowRef('cursor')
+  /** 镜像 kernel.rendererRuntime，供设置页显示有效后端 */
+  const rendererRuntime = shallowRef<RendererBackendRuntime | null>(null)
 
   const {
     mainActiveIndicators,
@@ -1214,6 +1222,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
       priceLabelWidth: props.priceLabelWidth,
       minKWidth: props.minKWidth,
       maxKWidth: props.maxKWidth,
+      settings: props.settings,
       mcp: props.mcp,
     })
     return ctrl
@@ -1291,6 +1300,11 @@ import MarkerTooltip from './MarkerTooltip.vue'
       drawingToolId.value = ctrl.drawingTool.peek()
     })
 
+    rendererRuntime.value = ctrl.rendererRuntime.peek()
+    const unsubscribeRendererRuntime = ctrl.rendererRuntime.subscribe(() => {
+      rendererRuntime.value = ctrl.rendererRuntime.peek()
+    })
+
     const unsubscribeIndicators = setupIndicatorSubscriptions(ctrl)
 
     const unsubscribeComparisonColors = ctrl.comparisonColors.subscribe(() => {
@@ -1351,6 +1365,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
       unsubscribePaneLayout()
       unsubscribeTheme()
       unsubscribeDrawingTool()
+      unsubscribeRendererRuntime()
       unsubscribeIndicators()
       unsubscribeComparisonColors()
       unsubscribeComparisonLoading()
@@ -1360,7 +1375,9 @@ import MarkerTooltip from './MarkerTooltip.vue'
   }
 
   function applyInitialSettings(ctrl: ChartController): void {
-    const toolbarSettings = toolbarRef.value?.getSettings() ?? {}
+    const toolbarSettings = migrateStoredSettings(
+      (toolbarRef.value?.getSettings() ?? {}) as Record<string, unknown>,
+    )
     const propSettings = props.settings ?? {}
     const merged = { ...toolbarSettings, ...propSettings }
     chartSettings.value = merged

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -791,6 +791,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
     _unsubTooltip = ctrl.interactionState.subscribe(() => {
       const el = tooltipContentRef.value
       if (!el) return
+      // 订阅整包 snapshot；内容更新仅依赖 hoveredIndex，索引未变时只动 display
       const snapshot = ctrl.interactionState.peek()
       const idx = snapshot.hoveredIndex
       const data = ctrl.getData()
@@ -1388,8 +1389,11 @@ import MarkerTooltip from './MarkerTooltip.vue'
 
   function setupInteractionCallbacks(ctrl: ChartController): void {
     ctrl.setTooltipAnchorPositioning(useAnchorPositioning.value)
+    // 引用相等短路：kernel interactionSnapshot 已字段级缓存
     ctrl.interactionState.subscribe(() => {
-      interactionState.value = ctrl.interactionState.peek()
+      const next = ctrl.interactionState.peek()
+      if (interactionState.value === next) return
+      interactionState.value = next
     })
 
     interactionState.value = ctrl.interactionState.peek()

--- a/packages/vue/src/components/LeftToolbar.vue
+++ b/packages/vue/src/components/LeftToolbar.vue
@@ -156,6 +156,7 @@
   <ChartSettingsDialog
     :show="showSettings"
     :initial-settings="appliedSettings"
+    :renderer-runtime="rendererRuntime"
     @close="showSettings = false"
     @confirm="handleConfirmSettings"
   />
@@ -172,8 +173,10 @@
   import {
     DEFAULT_SETTINGS,
     SETTINGS_STORAGE_KEY,
+    migrateStoredSettings,
     type ChartSettings,
   } from '@363045841yyt/klinechart-core/config'
+  import type { RendererBackendRuntime } from '@363045841yyt/klinechart-core/controllers'
   import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 
   import { useAlerts } from '../composables/useAlerts'
@@ -252,6 +255,7 @@
     isFullscreen?: boolean
     alertController?: ChartController | null
     effectiveSettings?: ChartSettings
+    rendererRuntime?: RendererBackendRuntime | null
     /** kernel drawingTool 镜像；高亮以它为准 */
     drawingToolId?: string
     /** range-select 本地模式 */
@@ -275,7 +279,7 @@
     try {
       const saved = localStorage.getItem(SETTINGS_STORAGE_KEY)
       if (saved) {
-        const parsed = JSON.parse(saved)
+        const parsed = migrateStoredSettings(JSON.parse(saved) as Record<string, unknown>)
         const result: ChartSettings = { ...parsed }
         DEFAULT_SETTINGS.forEach((item) => {
           ;(result as Record<string, unknown>)[item.key] = parsed[item.key] ?? item.default

--- a/packages/vue/src/composables/chart/useDrawingManager.ts
+++ b/packages/vue/src/composables/chart/useDrawingManager.ts
@@ -60,14 +60,9 @@ export function useDrawingManager(ctrl: Ref<ChartController | null>) {
       },
     })
 
-    let syncing = false
+    // UI 只镜像 kernel 已确认列表；预览/拖拽不进 Vue ref
     unsubDrawings = chartCtrl.drawings.subscribe(() => {
-      if (syncing) return
-      syncing = true
-      const full = chartCtrl.getFullDrawings()
-      drawingController.value?.setDrawings(full)
-      drawings.value = full as DrawingObject[]
-      syncing = false
+      drawings.value = chartCtrl.getFullDrawings() as DrawingObject[]
     })
     drawings.value = chartCtrl.getFullDrawings() as DrawingObject[]
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -192,11 +192,14 @@ export function useIndicators(controller: ChartController): {
 
 /**
  * Bridge the Chart's interactionState signal into a Vue shallowRef.
+ * 仅当 snapshot 引用变化时更新（kernel 侧已做字段级短路与引用缓存）。
  */
 export function useInteractionState(controller: ChartController): Ref<InteractionSnapshot> {
   const state = shallowRef(controller.interactionState.peek()) as Ref<InteractionSnapshot>
   const unsub = controller.interactionState.subscribe(() => {
-    state.value = controller.interactionState.peek()
+    const next = controller.interactionState.peek()
+    if (state.value === next) return
+    state.value = next
   })
   onScopeDispose(unsub)
   return state
@@ -216,11 +219,14 @@ export function usePaneRatios(controller: ChartController): Ref<Readonly<Record<
 
 /**
  * Bridge the Chart's viewport signal into a Vue shallowRef.
+ * 引用相等则跳过，配合 viewport 侧缓存减少滚动抖动更新。
  */
 export function useViewport(controller: ChartController): Ref<ChartViewport> {
   const vp = shallowRef(controller.viewport.peek()) as Ref<ChartViewport>
   const unsub = controller.viewport.subscribe(() => {
-    vp.value = controller.viewport.peek()
+    const next = controller.viewport.peek()
+    if (vp.value === next) return
+    vp.value = next
   })
   onScopeDispose(unsub)
   return vp

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,7 +322,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.9))(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       zone.js:
         specifier: ^0.15.0
         version: 0.15.1
@@ -342,6 +342,9 @@ importers:
       '@types/jsdom':
         specifier: ^28.0.0
         version: 28.0.1
+      '@webgpu/types':
+        specifier: ^0.1.71
+        version: 0.1.71
       publint:
         specifier: ^0.3.0
         version: 0.3.21
@@ -356,7 +359,7 @@ importers:
         version: 1.7.3(@babel/core@7.29.7)(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.9))(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     optionalDependencies:
       ajv:
         specifier: ^8.20.0
@@ -455,7 +458,7 @@ importers:
         version: 1.7.3(@babel/core@7.29.7)(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.9))(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/ui-schema:
     devDependencies:
@@ -464,7 +467,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.9))(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/vue:
     dependencies:
@@ -4914,9 +4917,16 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@webgpu/types@0.1.71':
+    resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -6408,6 +6418,9 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  exsolve@1.1.0:
+    resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
+
   externality@1.0.2:
     resolution: {integrity: sha512-LyExtJWKxtgVzmgtEHyQtLFpw1KFhQphF9nTG8TpAIVkiI/xQ3FJh75tRFLYl4hkn7BNIIdLJInuDAavX35pMw==}
 
@@ -6562,10 +6575,6 @@ packages:
     resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
     engines: {node: '>=14.14'}
 
-  fs-extra@11.3.5:
-    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
-    engines: {node: '>=14.14'}
-
   fs-extra@11.3.6:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
@@ -6687,8 +6696,8 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+  glob@7.2.0:
+    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
@@ -6899,6 +6908,10 @@ packages:
 
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
   image-meta@0.2.2:
@@ -8378,6 +8391,10 @@ packages:
 
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
+    engines: {node: '>=10.4.0'}
+
+  plist@3.1.1:
+    resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
 
   pluralize@8.0.0:
@@ -10934,7 +10951,7 @@ snapshots:
       tree-kill: 1.2.2
       tslib: 2.8.1
       typescript: 5.6.3
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
       webpack-dev-middleware: 7.4.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12))
       webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12))
       webpack-merge: 6.0.1
@@ -10977,7 +10994,7 @@ snapshots:
     dependencies:
       '@angular-devkit/architect': 0.1902.27(chokidar@4.0.3)
       rxjs: 7.8.1
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
       webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12))
     transitivePeerDependencies:
       - chokidar
@@ -12166,7 +12183,7 @@ snapshots:
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
-      glob: 7.2.3
+      glob: 7.2.0
       minimatch: 3.1.5
 
   '@electron/fuses@1.8.0':
@@ -12217,7 +12234,7 @@ snapshots:
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12238,9 +12255,9 @@ snapshots:
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3
       dir-compare: 4.2.0
-      fs-extra: 11.3.5
+      fs-extra: 11.3.6
       minimatch: 9.0.9
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13219,7 +13236,7 @@ snapshots:
     dependencies:
       '@angular/compiler-cli': 19.2.25(@angular/compiler@19.2.24)(typescript@5.6.3)
       typescript: 5.6.3
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   '@noble/hashes@1.4.0': {}
 
@@ -13429,8 +13446,8 @@ snapshots:
       defu: 6.1.7
       destr: 2.0.5
       errx: 0.1.0
-      exsolve: 1.0.8
-      ignore: 7.0.5
+      exsolve: 1.1.0
+      ignore: 7.0.6
       jiti: 2.7.0
       klona: 2.0.6
       mlly: 1.8.2
@@ -13901,7 +13918,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -14429,7 +14446,7 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 26.0.1
+      '@types/node': 25.9.4
       '@types/responselike': 1.0.3
 
   '@types/chai@5.2.3':
@@ -14484,7 +14501,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 25.9.4
 
   '@types/hast@3.0.4':
     dependencies:
@@ -14516,7 +14533,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 25.9.4
 
   '@types/mime@1.3.5': {}
 
@@ -14558,7 +14575,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 25.9.4
 
   '@types/retry@0.12.2': {}
 
@@ -14602,7 +14619,7 @@ snapshots:
       '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       eslint: 10.6.0(jiti@2.7.0)
-      ignore: 7.0.5
+      ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -14624,7 +14641,7 @@ snapshots:
   '@typescript-eslint/project-service@8.62.1(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/types': 8.63.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -15154,7 +15171,7 @@ snapshots:
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   '@vue/reactivity@3.5.38':
     dependencies:
@@ -15278,7 +15295,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@webgpu/types@0.1.71': {}
+
   '@xmldom/xmldom@0.8.13': {}
+
+  '@xmldom/xmldom@0.9.10': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -15310,9 +15331,9 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
-  acorn-import-phases@1.0.4(acorn@8.16.0):
+  acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -15610,7 +15631,7 @@ snapshots:
       '@babel/core': 7.26.10
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.26.10):
     dependencies:
@@ -15838,7 +15859,7 @@ snapshots:
       confbox: 0.2.4
       defu: 6.1.7
       dotenv: 17.4.2
-      exsolve: 1.0.8
+      exsolve: 1.1.0
       giget: 3.3.0
       jiti: 2.7.0
       ohash: 2.0.11
@@ -16153,7 +16174,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -16220,7 +16241,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   css-select@5.2.2:
     dependencies:
@@ -17126,6 +17147,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  exsolve@1.1.0: {}
+
   externality@1.0.2:
     dependencies:
       enhanced-resolve: 5.24.1
@@ -17287,18 +17310,11 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs-extra@11.3.5:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
-
   fs-extra@11.3.6:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -17427,7 +17443,7 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  glob@7.2.3:
+  glob@7.2.0:
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -17684,6 +17700,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  ignore@7.0.6: {}
 
   image-meta@0.2.2: {}
 
@@ -17991,7 +18009,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.20.0
+      '@types/node': 25.9.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -18122,7 +18140,7 @@ snapshots:
     dependencies:
       less: 4.2.2
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   less@4.2.2:
     dependencies:
@@ -18147,7 +18165,7 @@ snapshots:
     dependencies:
       webpack-sources: 3.5.0
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -18477,7 +18495,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   minimalistic-assert@1.0.1: {}
 
@@ -19441,7 +19459,7 @@ snapshots:
   pkg-types@2.3.1:
     dependencies:
       confbox: 0.2.4
-      exsolve: 1.0.8
+      exsolve: 1.1.0
       pathe: 2.0.3
 
   pkijs@3.4.0:
@@ -19456,6 +19474,12 @@ snapshots:
   plist@3.1.0:
     dependencies:
       '@xmldom/xmldom': 0.8.13
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
+  plist@3.1.1:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -19507,7 +19531,7 @@ snapshots:
       postcss: 8.5.12
       semver: 7.8.5
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
     transitivePeerDependencies:
       - typescript
 
@@ -19981,7 +20005,7 @@ snapshots:
 
   rimraf@2.6.3:
     dependencies:
-      glob: 7.2.3
+      glob: 7.2.0
 
   roarr@2.15.4:
     dependencies:
@@ -20038,7 +20062,7 @@ snapshots:
   rollup-plugin-visualizer@7.0.1(rolldown@1.1.5)(rollup@4.62.2):
     dependencies:
       open: 11.0.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       source-map: 0.7.6
       yargs: 18.0.0
     optionalDependencies:
@@ -20171,7 +20195,7 @@ snapshots:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.85.0
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   sass@1.85.0:
     dependencies:
@@ -20491,7 +20515,7 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   source-map-support@0.5.21:
     dependencies:
@@ -20775,8 +20799,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.39.0
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      terser: 5.48.0
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
     optionalDependencies:
       esbuild: 0.28.0
       lightningcss: 1.32.0
@@ -20787,7 +20811,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.39.0
+      terser: 5.48.0
       webpack: 5.105.0(esbuild@0.28.1)
     optionalDependencies:
       esbuild: 0.28.1
@@ -21024,7 +21048,7 @@ snapshots:
 
   unctx@2.5.0:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
       unplugin: 2.3.11
@@ -21629,7 +21653,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.9))(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.5(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.1.4(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.2.2)(sass@1.85.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -21856,7 +21880,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
     transitivePeerDependencies:
       - tslib
 
@@ -21891,7 +21915,7 @@ snapshots:
       webpack-dev-middleware: 7.4.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12))
       ws: 8.21.0
     optionalDependencies:
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -21910,9 +21934,50 @@ snapshots:
   webpack-subresource-integrity@5.1.0(webpack@5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12)
+      webpack: 5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.4
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.1
+      es-module-lexer: 2.2.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)(webpack@5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
 
   webpack@5.105.0(esbuild@0.28.1):
     dependencies:
@@ -21922,12 +21987,12 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.4
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.1
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.2.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -21955,47 +22020,6 @@ snapshots:
       - postcss
       - uglify-js
     optional: true
-
-  webpack@5.105.0(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.12):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.4
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.1
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.2
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12)(webpack@5.105.0(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.12))
-      watchpack: 2.5.2
-      webpack-sources: 3.5.0
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
 
   websocket-driver@0.7.5:
     dependencies:


### PR DESCRIPTION
Based on the provided summary, here is the formatted version with proper Markdown rendering and structure:

---

## Summary

Complete rewrite of the rendering pipeline from a dual-path (2D canvas + WebGL) architecture to a unified **single-path Scene + Renderer API**, along with a **WebGPU** backend, **FrameTransaction** reactive frame scheduling, and final SSOT migration cleanup.

## Major Changes

### 1. Single-Path Scene Renderer
- All rendering flows through a single `sceneRenderer` (instead of bifurcating between Canvas2D and WebGL paths).
- Indicator renderers (candle, MACD, volume, BOLL, lines, etc.) route through `drawInstances`/`drawLines` on the Renderer API.
- Removed dual-path compatibility layer and surface ladder (~400 lines deleted).

### 2. WebGPU Backend
- Full WebGPU renderer: `createWebGPURenderer`, `createWebGPUSurfaceBackend`, shader pipelines.
- Pending draw deferral: draws queue to `pendingDraws` and flush as a single `endFrame` submit.
- Resource reuse: `ResourceTable` for buffer/pipeline caching, per-batch instance buffer allocation.
- Hybrid DOM canvas: mounts WebGPU canvas over the 2D DOM canvas, skips `compositeTo` pass.

### 3. FrameTransaction Reactive Scheduling
- `FrameTransaction`: batches signal mutations into single-generation frame cycles.
- `ChartRenderer.draw` driven via FrameTransaction for predictable rendering.
- Interaction hover/kernel writes deferred until frame flush.
- Equality short-circuits on scroll, hover, and UI bridge signals.

### 4. Renderer API Migration
- `drawRectBatchesViaRenderer`: routes volume/MACD bar rects through Renderer API.
- `compositeSceneRenderer`: handles fill + line batches for BOLL, ENE, etc.
- Ichimoku cloud: batch consecutive same-color segments into single path.
- All indicators updated to use `sceneRenderer` instead of direct canvas context.

### 5. Bug Fixes & Optimizations
- Fixed: GPU instance buffer reuse across draw calls (MACD sub-pane overwriting candle instances).
- Fixed: FrameTransaction hover leave race condition.
- Fixed: reactivity edge cases in signal equality.
- Fixed: interaction state cleanup during frame flush.
- Ichimoku perf: batch same-color cloud segments.
- MSAA single RenderPass flush (avoids multi-pass driver bugs).

### 6. Infrastructure
- SSOT cleanup C: drawing, tool, theme final migration.
- Interaction state: separate from viewport geometry signals.
- Drawing state: session preview/drag out of kernel SSOT.
- Chart controller: `window.__chart` dev exposure.
- AGENTS.md: lesson learned on GPU buffer reuse.

## Test Status
- **1882 tests passing** (141 test files)
- New tests: `candle.sceneRenderer.test.ts`, `linesViaRenderer.test.ts`, `rectsViaRenderer.test.ts`, `frameTransaction.test.ts`, `webgpuRenderer.test.ts`, etc.
- 3 baseline snapshot updates (pre-existing token value changes)