### PR TITLE
fix(timeshare): geometry, baseline, session endpoints, multi-market

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,13 +224,13 @@ Providing `#legend` fully replaces the default Canvas legend. The slot scope is 
 ```vue
 <template>
   <KlineChart>
-    <template #legend="{ ohlc, indicators, comparisons, colors }">
-      <div class="my-legend" v-if="ohlc">
-        <span :style="{ color: ohlc.color }">
-          O {{ ohlc.open.toFixed(2) }}
-          H {{ ohlc.high.toFixed(2) }}
-          L {{ ohlc.low.toFixed(2) }}
-          C {{ ohlc.close.toFixed(2) }}
+    <template #legend="{ currentBar, indicators, comparisons, colors }">
+      <div class="my-legend" v-if="currentBar">
+        <span :style="{ color: currentBar.color }">
+          O {{ currentBar.open.toFixed(2) }}
+          H {{ currentBar.high.toFixed(2) }}
+          L {{ currentBar.low.toFixed(2) }}
+          C {{ currentBar.close.toFixed(2) }}
         </span>
         <span v-for="ind in indicators" :key="ind.name" class="my-legend__ind">
           {{ ind.name }}

--- a/README_CN.md
+++ b/README_CN.md
@@ -224,13 +224,13 @@ createApp(App).mount('#app')
 ```vue
 <template>
   <KlineChart>
-    <template #legend="{ ohlc, indicators, comparisons, colors }">
-      <div class="my-legend" v-if="ohlc">
-        <span :style="{ color: ohlc.color }">
-          O {{ ohlc.open.toFixed(2) }}
-          H {{ ohlc.high.toFixed(2) }}
-          L {{ ohlc.low.toFixed(2) }}
-          C {{ ohlc.close.toFixed(2) }}
+    <template #legend="{ currentBar, indicators, comparisons, colors }">
+      <div class="my-legend" v-if="currentBar">
+        <span :style="{ color: currentBar.color }">
+          O {{ currentBar.open.toFixed(2) }}
+          H {{ currentBar.high.toFixed(2) }}
+          L {{ currentBar.low.toFixed(2) }}
+          C {{ currentBar.close.toFixed(2) }}
         </span>
         <span v-for="ind in indicators" :key="ind.name" class="my-legend__ind">
           {{ ind.name }}

--- a/docs/fragments/_usage-vue.md
+++ b/docs/fragments/_usage-vue.md
@@ -94,13 +94,13 @@ Providing `#legend` fully replaces the default Canvas legend. The slot scope is 
 ```vue
 <template>
   <KlineChart>
-    <template #legend="{ ohlc, indicators, comparisons, colors }">
-      <div class="my-legend" v-if="ohlc">
-        <span :style="{ color: ohlc.color }">
-          O {{ ohlc.open.toFixed(2) }}
-          H {{ ohlc.high.toFixed(2) }}
-          L {{ ohlc.low.toFixed(2) }}
-          C {{ ohlc.close.toFixed(2) }}
+    <template #legend="{ currentBar, indicators, comparisons, colors }">
+      <div class="my-legend" v-if="currentBar">
+        <span :style="{ color: currentBar.color }">
+          O {{ currentBar.open.toFixed(2) }}
+          H {{ currentBar.high.toFixed(2) }}
+          L {{ currentBar.low.toFixed(2) }}
+          C {{ currentBar.close.toFixed(2) }}
         </span>
         <span v-for="ind in indicators" :key="ind.name" class="my-legend__ind">
           {{ ind.name }}

--- a/docs/fragments/_usage-vue.zh-CN.md
+++ b/docs/fragments/_usage-vue.zh-CN.md
@@ -94,13 +94,13 @@ createApp(App).mount('#app')
 ```vue
 <template>
   <KlineChart>
-    <template #legend="{ ohlc, indicators, comparisons, colors }">
-      <div class="my-legend" v-if="ohlc">
-        <span :style="{ color: ohlc.color }">
-          O {{ ohlc.open.toFixed(2) }}
-          H {{ ohlc.high.toFixed(2) }}
-          L {{ ohlc.low.toFixed(2) }}
-          C {{ ohlc.close.toFixed(2) }}
+    <template #legend="{ currentBar, indicators, comparisons, colors }">
+      <div class="my-legend" v-if="currentBar">
+        <span :style="{ color: currentBar.color }">
+          O {{ currentBar.open.toFixed(2) }}
+          H {{ currentBar.high.toFixed(2) }}
+          L {{ currentBar.low.toFixed(2) }}
+          C {{ currentBar.close.toFixed(2) }}
         </span>
         <span v-for="ind in indicators" :key="ind.name" class="my-legend__ind">
           {{ ind.name }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@363045841yyt/klinechart-core",
-  "version": "0.9.0-alpha.3",
+  "version": "0.9.0-alpha.4",
   "description": "Headless K-line chart engine + reactive controllers. Zero framework dependencies.",
   "license": "MIT",
   "repository": {

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -55,7 +55,6 @@ export type {
   LegendRenderMode,
   LegendLayout,
   LegendCurrentBar,
-  LegendOhlcRow,
   LegendTimeshareRow,
   LegendIndicatorRow,
   LegendComparisonRow,

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -54,6 +54,7 @@ export type {
   LegendTemplateContext,
   LegendRenderMode,
   LegendLayout,
+  LegendCurrentBar,
   LegendOhlcRow,
   LegendTimeshareRow,
   LegendIndicatorRow,

--- a/packages/core/src/data/__tests__/timeShareBuffer.test.ts
+++ b/packages/core/src/data/__tests__/timeShareBuffer.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { TimeShareBuffer } from '../timeShareBuffer'
+import type { TimeShareData } from '../../foundation/types/price'
+
+function point(price: number, ts = 1): TimeShareData {
+  return { timestamp: ts, price, average: price, volume: 1, amount: price }
+}
+
+describe('TimeShareBuffer', () => {
+  it('stores and returns preClose metadata', () => {
+    const buf = new TimeShareBuffer()
+    expect(buf.getPreClose()).toBeNull()
+    buf.setPreClose(10.5)
+    expect(buf.getPreClose()).toBe(10.5)
+    buf.setPreClose(null)
+    expect(buf.getPreClose()).toBeNull()
+  })
+
+  it('clears previous points when a new load starts (no stale date flash)', async () => {
+    const buf = new TimeShareBuffer()
+    buf.setInlineData([point(10), point(11)])
+    expect(buf.getRawData()).toHaveLength(2)
+
+    let resolveFetch!: (v: ReadonlyArray<TimeShareData>) => void
+    const pending = new Promise<ReadonlyArray<TimeShareData>>((resolve) => {
+      resolveFetch = resolve
+    })
+    buf.setFetcher(async () => pending)
+    buf.setQueryDate(20260101)
+    buf.load({ symbol: '000001', period: 'timeshare', source: 'gotdx' })
+
+    // 新 load 开始后旧点应被清空，避免显示另一天数据
+    expect(buf.getRawData()).toEqual([])
+    expect(buf.loading.peek()).toBe(true)
+
+    resolveFetch([point(12), point(13)])
+    await vi.waitFor(() => {
+      expect(buf.getRawData()).toHaveLength(2)
+    })
+    expect(buf.getRawData()[0]?.price).toBe(12)
+    expect(buf.loading.peek()).toBe(false)
+    buf.dispose()
+  })
+})

--- a/packages/core/src/data/timeShareBuffer.ts
+++ b/packages/core/src/data/timeShareBuffer.ts
@@ -21,6 +21,8 @@ export class TimeShareBuffer implements DataBufferLike {
   private _fetcher: TimeShareFetcherFn | null = null
   // 指定查询的历史日期（0 = 当天）
   private _queryDate = 0
+  // 昨收价（分时涨跌基准）；未设置时为 null
+  private _preClose: number | null = null
   // 请求序号，每次 load() 递增
   private _requestSeq = 0
   // 当前运行的 fetch Fiber 句柄，用于随时中断旧请求
@@ -64,6 +66,16 @@ export class TimeShareBuffer implements DataBufferLike {
     return this._queryDate
   }
 
+  getPreClose(): number | null {
+    return this._preClose
+  }
+
+  setPreClose(preClose: number | null): void {
+    if (preClose === null || (Number.isFinite(preClose) && preClose !== 0)) {
+      this._preClose = preClose
+    }
+  }
+
   load(spec: SymbolSpec): void {
     if (this._disposed) return
 
@@ -73,6 +85,9 @@ export class TimeShareBuffer implements DataBufferLike {
     }
 
     const requestSeq = ++this._requestSeq
+    // 新请求开始即清空旧点，避免历史日期切换时短暂显示另一天数据
+    this._data = []
+    this._dataSignal.set({ data: [], prependedCount: 0 })
     this._loadingSignal.set(true)
 
     const timeShareService: {

--- a/packages/core/src/engine/__tests__/chart.dpr.test.ts
+++ b/packages/core/src/engine/__tests__/chart.dpr.test.ts
@@ -522,6 +522,34 @@ describe('Chart pane layout regressions', () => {
     await chart.destroy()
   })
 
+  it('timeshare round-trip restores subPane paneId and ratios', async () => {
+    const chart = new Chart(createDom(1000, 600), defaultOptions)
+    chart.resize()
+    expect(chart.createSubPane('MACD_0', 'MACD')).toBe(true)
+    expect(chart.createSubPane('RSI_0', 'RSI')).toBe(true)
+    const ratiosBefore = { ...chart.kernel.pane.readonly.paneRatios.peek() }
+    const entriesBefore = chart.getSubPaneEntries().map((e) => ({
+      paneId: e.paneId,
+      indicatorId: e.indicatorId,
+    }))
+
+    const tsMode = (chart as unknown as { _timeShareMode: import('../modes/types').ChartModeHandler })
+      ._timeShareMode
+    const kMode = (chart as unknown as { _kLineMode: import('../modes/types').ChartModeHandler })
+      ._kLineMode
+    chart.setActiveMode(tsMode)
+    expect(chart.getSubPaneEntries()).toEqual([])
+    chart.setActiveMode(kMode)
+
+    const entriesAfter = chart.getSubPaneEntries().map((e) => ({
+      paneId: e.paneId,
+      indicatorId: e.indicatorId,
+    }))
+    expect(entriesAfter).toEqual(entriesBefore)
+    expect(chart.kernel.pane.readonly.paneRatios.peek()).toEqual(ratiosBefore)
+    await chart.destroy()
+  })
+
   it('removeDrawing drops id from kernel and clears selection', async () => {
     const chart = new Chart(createDom(1000, 600), defaultOptions)
     const d1 = {

--- a/packages/core/src/engine/chart.ts
+++ b/packages/core/src/engine/chart.ts
@@ -151,7 +151,13 @@ export class Chart {
     zoomLevel: number
     scaleTypes: Map<string, ScaleType>
     mainIndicators: Array<{ id: string; params: Record<string, number | boolean | string> }>
-    subPanes: Array<{ id: string; params: Record<string, unknown> }>
+    subPanes: Array<{
+      paneId: string
+      indicatorId: string
+      params: Record<string, unknown>
+    }>
+    paneRatios: Record<string, number>
+    candleEnabled: boolean
   } | null = null
 
   /** 上次预警评估的最新 K 线时间戳（用于去重） */
@@ -470,17 +476,21 @@ export class Chart {
     const prev = this._activeMode
 
     if (mode === this._timeShareMode) {
+      const candlePlugin = this.rendererPluginManager.getPlugin('candle')
       this._savedTimeShareState = {
         zoomLevel: this.kernel.zoom.readonly.zoomLevel.peek(),
         scaleTypes: new Map(this.kernel.pane.readonly.paneScaleTypes.peek()),
         mainIndicators: [],
         subPanes: [],
+        paneRatios: { ...this.kernel.pane.readonly.paneRatios.peek() },
+        candleEnabled: candlePlugin?.enabled !== false,
       }
       for (const [id, entry] of this.kernel.indicator.readonly.mainIndicators.peek()) {
         this._savedTimeShareState.mainIndicators.push({ id, params: { ...entry.params } })
       }
       this._savedTimeShareState.subPanes = this.indicatorManager.getSubPaneEntries().map((e) => ({
-        id: e.indicatorId,
+        paneId: e.paneId,
+        indicatorId: e.indicatorId,
         params: { ...e.params },
       }))
       // 分时强制 percent 进 kernel，再投影（不再由 updatePaneRange 每帧旁路写）
@@ -526,7 +536,7 @@ export class Chart {
 
     if (mode === this._timeShareMode) {
       for (const { id } of this._savedTimeShareState!.mainIndicators) {
-        if (id !== 'TIMESHARE') {
+        if (id !== 'TIMESHARE' && id !== 'timeShare') {
           this.indicatorManager.disableMainIndicator(id)
         }
       }
@@ -535,13 +545,26 @@ export class Chart {
       const saved = this._savedTimeShareState
       if (saved) {
         for (const { id, params } of saved.mainIndicators) {
-          if (id !== 'TIMESHARE') {
+          if (id !== 'TIMESHARE' && id !== 'timeShare') {
             this.indicatorManager.enableMainIndicator(id, params)
           }
         }
-        for (const { id, params } of saved.subPanes) {
-          this.indicatorManager.addIndicator(id, 'sub', params)
+        for (const { paneId, indicatorId, params } of saved.subPanes) {
+          this.indicatorManager.createSubPane(
+            paneId,
+            indicatorId as SubIndicatorType,
+            params as Record<string, number | boolean | string>,
+          )
         }
+        // 恢复进入分时前的 pane 比例（createSubPane 会重算 3:1 分配）
+        if (Object.keys(saved.paneRatios).length > 0) {
+          const specs = this.kernel.pane.readonly.paneSpecs.peek().map((pane) => ({
+            ...pane,
+            ratio: saved.paneRatios[pane.id] ?? pane.ratio,
+          }))
+          this.kernel.pane.actions.commitLayout(saved.paneRatios, specs)
+        }
+        this.setRendererEnabled('candle', saved.candleEnabled)
       }
       this._savedTimeShareState = null
     }

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -452,6 +452,16 @@ export class ChartDataManager {
     return buf ? buf.getRawData() : []
   }
 
+  getTimeSharePreClose(): number | null {
+    const buf = this.getActiveTimeShareBuffer()
+    return buf?.getPreClose() ?? null
+  }
+
+  setTimeSharePreClose(preClose: number | null): void {
+    const buf = this.getActiveTimeShareBuffer()
+    if (buf) buf.setPreClose(preClose)
+  }
+
   getTimeShareSignal(): ReadonlySignal<ReadonlyArray<TimeShareData>> {
     const buf = this.getActiveTimeShareBuffer()
     return (buf?.data ?? createSignal<ReadonlyArray<TimeShareData>>([])) as ReadonlySignal<

--- a/packages/core/src/engine/modes/__tests__/timeShareMath.test.ts
+++ b/packages/core/src/engine/modes/__tests__/timeShareMath.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  resolveTimeShareSlotTimestamp,
+  timeShareSlotCenterX,
+} from '../../../foundation/utils/timeShareAxisLabels'
+import {
+  ASHARE_TIMESHARE_SESSION_SLOTS,
+  computeTimeShareBarMetrics,
+  computeTimeSharePaneLayout,
+  computeTimeSharePriceRange,
+  computeTimeShareTimeLabelIndices,
+  computeTimeShareXLayout,
+  resolveTimeShareSessionSlots,
+  resolveTimeShareBaseline,
+} from '../timeShareMath'
+
+describe('resolveTimeShareBaseline', () => {
+  it('prefers finite non-zero preClose over first trade price', () => {
+    expect(resolveTimeShareBaseline({ preClose: 10.5, firstPrice: 11 })).toBe(10.5)
+  })
+
+  it('falls back to first price when preClose is missing or zero', () => {
+    expect(resolveTimeShareBaseline({ preClose: 0, firstPrice: 11 })).toBe(11)
+    expect(resolveTimeShareBaseline({ firstPrice: 11 })).toBe(11)
+    expect(resolveTimeShareBaseline({ preClose: null, firstPrice: 9 })).toBe(9)
+  })
+
+  it('returns null when no valid baseline exists', () => {
+    expect(resolveTimeShareBaseline({ preClose: 0, firstPrice: 0 })).toBeNull()
+    expect(resolveTimeShareBaseline({})).toBeNull()
+    expect(resolveTimeShareBaseline({ preClose: NaN, firstPrice: Infinity })).toBeNull()
+  })
+})
+
+describe('computeTimeSharePriceRange', () => {
+  it('uses preClose baseline and pads around max absolute percent move', () => {
+    // open gap up: first trade 11, preClose 10 → +10%; later 10.5 → 5%
+    const range = computeTimeSharePriceRange([11, 10.5, 10.2], 10)
+    expect(range).not.toBeNull()
+    // maxAbsPct=10, padding=max(1, 0.5)=1 → display 11%
+    expect(range!.maxPrice).toBeCloseTo(10 * 1.11, 8)
+    expect(range!.minPrice).toBeCloseTo(10 * 0.89, 8)
+  })
+
+  it('still applies minimum padding when all prices equal baseline (flat day)', () => {
+    const range = computeTimeSharePriceRange([10, 10, 10], 10)
+    expect(range).not.toBeNull()
+    // maxAbsPct=0, padding=min 0.5% → ±0.5%
+    expect(range!.maxPrice).toBeCloseTo(10.05, 8)
+    expect(range!.minPrice).toBeCloseTo(9.95, 8)
+  })
+
+  it('returns null for invalid baseline', () => {
+    expect(computeTimeSharePriceRange([10], 0)).toBeNull()
+    expect(computeTimeSharePriceRange([10], NaN)).toBeNull()
+  })
+})
+
+describe('resolveTimeShareSessionSlots', () => {
+  it('defaults to A-share 240 one-minute slots (sessions SSOT)', () => {
+    expect(ASHARE_TIMESHARE_SESSION_SLOTS).toBe(240)
+    expect(resolveTimeShareSessionSlots(0)).toBe(240)
+    expect(resolveTimeShareSessionSlots(60)).toBe(240)
+  })
+
+  it('does not expand when arrived points exceed session slots', () => {
+    expect(resolveTimeShareSessionSlots(300)).toBe(240)
+  })
+})
+
+describe('computeTimeShareBarMetrics', () => {
+  it('divides viewWidth by full session slots, not arrived point count', () => {
+    // 盘中仅 60 点：宽度仍按 240 槽划分，不把 60 点拉满屏
+    const partial = computeTimeShareBarMetrics(60, 320, 1)
+    const full = computeTimeShareBarMetrics(240, 320, 1)
+    expect(partial).not.toBeNull()
+    expect(full).not.toBeNull()
+    expect(partial!.kWidth).toBeCloseTo(full!.kWidth, 8)
+    expect(partial!.kGap).toBeCloseTo(full!.kGap, 8)
+    expect((partial!.kWidth + partial!.kGap) * 240).toBeCloseTo(320, 6)
+  })
+
+  it('fits full session into viewWidth even when per-bar width is sub-pixel (DPR=1 narrow)', () => {
+    const m = computeTimeShareBarMetrics(240, 320, 1)
+    expect(m).not.toBeNull()
+    const unit = m!.kWidth + m!.kGap
+    expect(unit * 240).toBeCloseTo(320, 6)
+    expect(m!.kWidth).toBeGreaterThan(0)
+    expect(m!.kGap).toBeGreaterThanOrEqual(0)
+  })
+
+  it('keeps full session visible at high DPR', () => {
+    const m = computeTimeShareBarMetrics(240, 320, 2)
+    expect(m).not.toBeNull()
+    expect((m!.kWidth + m!.kGap) * 240).toBeCloseTo(320, 6)
+  })
+
+  it('returns null for empty data or invalid width', () => {
+    expect(computeTimeShareBarMetrics(0, 320, 1)).toBeNull()
+    expect(computeTimeShareBarMetrics(10, 0, 1)).toBeNull()
+  })
+})
+
+describe('computeTimeShareXLayout', () => {
+  it('places partial-day points on session timeline leaving right-side blank', () => {
+    const layout = computeTimeShareXLayout({
+      arrivedCount: 60,
+      sessionSlots: 240,
+      totalWidth: 480,
+      dpr: 1,
+    })
+    expect(layout).not.toBeNull()
+    // step = 480/240 = 2；第 0 点中心 1，第 59 点中心 119，未到右缘 480
+    expect(layout!.centers[0]).toBeCloseTo(1, 6)
+    expect(layout!.centers[59]).toBeCloseTo(119, 6)
+    expect(layout!.centers[59]!).toBeLessThan(480 * 0.3)
+    expect(layout!.step).toBeCloseTo(2, 6)
+  })
+
+  it('fills full width only when arrivedCount covers full session', () => {
+    const layout = computeTimeShareXLayout({
+      arrivedCount: 240,
+      sessionSlots: 240,
+      totalWidth: 480,
+      dpr: 1,
+    })
+    expect(layout).not.toBeNull()
+    expect(layout!.centers[0]).toBeCloseTo(1, 6)
+    expect(layout!.centers[239]).toBeCloseTo(479, 6)
+  })
+})
+
+describe('computeTimeSharePaneLayout', () => {
+  it('splits price area above volume area without overlap', () => {
+    const layout = computeTimeSharePaneLayout(400, 0.25)
+    expect(layout.priceAreaHeight).toBe(300)
+    expect(layout.volumeAreaHeight).toBe(100)
+    expect(layout.priceTop).toBe(0)
+    expect(layout.volumeTop).toBe(300)
+    expect(layout.priceTop + layout.priceAreaHeight).toBe(layout.volumeTop)
+  })
+})
+
+describe('computeTimeShareTimeLabelIndices', () => {
+  it('only session closed-side endpoints: 9:30 / 13:00 / 15:00', () => {
+    const labels = computeTimeShareTimeLabelIndices({
+      axisWidth: 800,
+      sessionSlots: 240,
+    })
+    // 9:30 → 0；13:00 → 120；15:00 → 239
+    expect(labels).toEqual([0, 120, 239])
+  })
+
+  it('returns empty for invalid axis width', () => {
+    expect(
+      computeTimeShareTimeLabelIndices({
+        axisWidth: 0,
+        sessionSlots: 240,
+      }),
+    ).toEqual([])
+  })
+})
+
+describe('timeShare slot time/x helpers', () => {
+  it('maps A-share slots across lunch break', () => {
+    // 2026-07-21 local
+    const day = new Date(2026, 6, 21, 10, 0, 0, 0).getTime()
+    expect(new Date(resolveTimeShareSlotTimestamp(day, 0)).getHours()).toBe(9)
+    expect(new Date(resolveTimeShareSlotTimestamp(day, 0)).getMinutes()).toBe(30)
+    // slot 120 = 13:00
+    expect(new Date(resolveTimeShareSlotTimestamp(day, 120)).getHours()).toBe(13)
+    expect(new Date(resolveTimeShareSlotTimestamp(day, 120)).getMinutes()).toBe(0)
+    // slot 239 = 14:59
+    expect(new Date(resolveTimeShareSlotTimestamp(day, 239)).getHours()).toBe(14)
+    expect(new Date(resolveTimeShareSlotTimestamp(day, 239)).getMinutes()).toBe(59)
+  })
+
+  it('places last session slot near right edge of axis', () => {
+    const x0 = timeShareSlotCenterX(0, 480, 240, 1)
+    const xLast = timeShareSlotCenterX(239, 480, 240, 1)
+    expect(x0).toBeCloseTo(1, 6)
+    expect(xLast).toBeCloseTo(479, 6)
+  })
+})

--- a/packages/core/src/engine/modes/__tests__/timeShareMode.test.ts
+++ b/packages/core/src/engine/modes/__tests__/timeShareMode.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Pane } from '../../layout/pane'
+import { TimeShareMode } from '../timeShareMode'
+import type { TimeShareData } from '../../../foundation/types/price'
+
+function ts(price: number, i = 0): TimeShareData {
+  return { timestamp: i, price, average: price, volume: 1, amount: price }
+}
+
+function mockDm(points: TimeShareData[], preClose: number | null = null) {
+  return {
+    getTimeShareData: () => points,
+    getTimeSharePreClose: () => preClose,
+  } as unknown as import('../../data/chartDataManager').ChartDataManager
+}
+
+describe('TimeShareMode', () => {
+  it('computeKWidth fits full session into narrow view (no DPR truncation)', () => {
+    const mode = new TimeShareMode()
+    const m = mode.computeKWidth(240, 320, 1)
+    expect(m).not.toBeNull()
+    expect((m!.kWidth + m!.kGap) * 240).toBeCloseTo(320, 6)
+  })
+
+  it('computeKWidth for partial day matches full-session bar size', () => {
+    const mode = new TimeShareMode()
+    const partial = mode.computeKWidth(60, 320, 1)
+    const full = mode.computeKWidth(240, 320, 1)
+    expect(partial).not.toBeNull()
+    expect(full).not.toBeNull()
+    expect(partial!.kWidth).toBeCloseTo(full!.kWidth, 8)
+    expect(partial!.kGap).toBeCloseTo(full!.kGap, 8)
+  })
+
+  it('setMarketSession switches bar metrics to HK 330 slots', () => {
+    const mode = new TimeShareMode()
+    const ashare = mode.computeKWidth(100, 330, 1)!
+    mode.setMarketSession({
+      timeZone: 'Asia/Hong_Kong',
+      sessions: [
+        { open: 9 * 60 + 30, close: 12 * 60 },
+        { open: 13 * 60, close: 16 * 60 },
+      ],
+      slotMinutes: 1,
+    })
+    const hk = mode.computeKWidth(100, 330, 1)!
+    // A 股 240 槽 unit=330/240；港股 330 槽 unit=1
+    expect(ashare.kWidth + ashare.kGap).toBeCloseTo(330 / 240, 6)
+    expect(hk.kWidth + hk.kGap).toBeCloseTo(1, 6)
+  })
+
+  it('updatePaneRange uses preClose as basePrice and covers open gap', () => {
+    const mode = new TimeShareMode()
+    const pane = new Pane('main')
+    const setBase = vi.spyOn(pane.yAxis, 'setBasePrice')
+    const setRange = vi.spyOn(pane.yAxis, 'setRange')
+
+    // open gap: first trade 11, preClose 10
+    mode.updatePaneRange(pane, { start: 0, end: 3 }, mockDm([ts(11), ts(10.5), ts(10.2)], 10))
+
+    expect(setBase).toHaveBeenCalledWith(10)
+    expect(setRange).toHaveBeenCalled()
+    const range = setRange.mock.calls[0]![0] as { minPrice: number; maxPrice: number }
+    // maxAbs 10% + 1% padding → ±11%
+    expect(range.maxPrice).toBeCloseTo(11.1, 6)
+    expect(range.minPrice).toBeCloseTo(8.9, 6)
+  })
+
+  it('updatePaneRange still sets range on flat day', () => {
+    const mode = new TimeShareMode()
+    const pane = new Pane('main')
+    const setRange = vi.spyOn(pane.yAxis, 'setRange')
+
+    mode.updatePaneRange(pane, { start: 0, end: 2 }, mockDm([ts(10), ts(10)], 10))
+    expect(setRange).toHaveBeenCalled()
+    const range = setRange.mock.calls[0]![0] as { minPrice: number; maxPrice: number }
+    expect(range.maxPrice).toBeCloseTo(10.05, 6)
+    expect(range.minPrice).toBeCloseTo(9.95, 6)
+  })
+})

--- a/packages/core/src/engine/modes/timeShareMath.ts
+++ b/packages/core/src/engine/modes/timeShareMath.ts
@@ -1,0 +1,150 @@
+import {
+  ASHARE_MARKET_SESSION,
+  resolveMarketSessionSlots,
+  type MarketSessionConfig,
+} from '../../foundation/utils/timeShareAxisLabels'
+
+export type TimeShareBaselineInput = {
+  preClose?: number | null
+  firstPrice?: number | null
+}
+
+export function resolveTimeShareBaseline(input: TimeShareBaselineInput): number | null {
+  const candidates = [input.preClose, input.firstPrice]
+  for (const v of candidates) {
+    if (typeof v === 'number' && Number.isFinite(v) && v !== 0) return v
+  }
+  return null
+}
+
+export type TimeSharePriceRange = {
+  minPrice: number
+  maxPrice: number
+}
+
+/**
+ * 分时 Y 轴价格区间：以 baseline（昨收）为中心，对称覆盖可见最大绝对涨跌幅并加 padding。
+ * 全天平盘时仍保留最小 0.5% 边距，避免 range 退化。
+ */
+export function computeTimeSharePriceRange(
+  prices: ReadonlyArray<number | undefined | null>,
+  baseline: number,
+): TimeSharePriceRange | null {
+  if (!Number.isFinite(baseline) || baseline === 0) return null
+
+  let maxAbsPct = 0
+  for (const p of prices) {
+    if (typeof p !== 'number' || !Number.isFinite(p)) continue
+    const pct = Math.abs((p - baseline) / baseline) * 100
+    if (pct > maxAbsPct) maxAbsPct = pct
+  }
+
+  const padding = Math.max(maxAbsPct * 0.1, 0.5)
+  const displayPct = maxAbsPct + padding
+  return {
+    minPrice: baseline * (1 - displayPct / 100),
+    maxPrice: baseline * (1 + displayPct / 100),
+  }
+}
+
+/** A 股默认全天 1 分钟槽位数（兼容旧导出） */
+export const ASHARE_TIMESHARE_SESSION_SLOTS = resolveMarketSessionSlots(ASHARE_MARKET_SESSION)
+
+/**
+ * 全天交易槽位数：以 marketSession 为 SSOT，不因 arrivedCount 放大。
+ * @deprecated 优先用 resolveMarketSessionSlots(config)
+ */
+export function resolveTimeShareSessionSlots(
+  arrivedCount: number,
+  marketSession: MarketSessionConfig = ASHARE_MARKET_SESSION,
+): number {
+  void arrivedCount
+  return resolveMarketSessionSlots(marketSession)
+}
+
+/**
+ * 分时 bar 宽度：按全天 sessionSlots 均分 viewWidth，而非按已到达点数。
+ * 盘中部分数据时右侧留白；允许亚像素，避免窄屏截断。
+ */
+export function computeTimeShareBarMetrics(
+  dataLength: number,
+  viewWidth: number,
+  dpr: number,
+  marketSession: MarketSessionConfig = ASHARE_MARKET_SESSION,
+): { kWidth: number; kGap: number } | null {
+  if (dataLength <= 0 || viewWidth <= 0 || !(dpr > 0)) return null
+
+  const sessionSlots = resolveMarketSessionSlots(marketSession)
+  if (sessionSlots <= 0) return null
+  const unit = viewWidth / sessionSlots
+  const preferredGap = 1 / dpr
+  const kGap = Math.min(preferredGap, unit * 0.2)
+  const kWidth = Math.max(unit - kGap, unit * 0.01)
+  return { kWidth, kGap: unit - kWidth }
+}
+
+export type TimeShareXLayoutInput = {
+  arrivedCount: number
+  sessionSlots: number
+  totalWidth: number
+  dpr: number
+}
+
+export type TimeShareXLayout = {
+  step: number
+  centers: number[]
+  lefts: number[]
+  barWidth: number
+  kWidthPx: number
+}
+
+/**
+ * 分时 X 布局：step = totalWidth / sessionSlots，已到达点按 slot 索引落位，未到时段留白。
+ */
+export function computeTimeShareXLayout(input: TimeShareXLayoutInput): TimeShareXLayout | null {
+  const { arrivedCount, sessionSlots, totalWidth, dpr } = input
+  if (arrivedCount <= 0 || sessionSlots <= 0 || totalWidth <= 0 || !(dpr > 0)) return null
+
+  const step = totalWidth / sessionSlots
+  const centers: number[] = new Array(arrivedCount)
+  const lefts: number[] = new Array(arrivedCount)
+  for (let i = 0; i < arrivedCount; i++) {
+    centers[i] = Math.round((i + 0.5) * step * dpr) / dpr
+    lefts[i] = Math.round(i * step * dpr) / dpr
+  }
+
+  const logicalBarWidth = Math.max(step * 0.6, 1 / dpr)
+  const barWidthPx = Math.max(1, Math.round(logicalBarWidth * dpr))
+  const barWidth = barWidthPx / dpr
+  const kWidthPx = Math.max(1, Math.round(step * dpr))
+
+  return { step, centers, lefts, barWidth, kWidthPx }
+}
+
+export type TimeSharePaneLayout = {
+  priceTop: number
+  priceAreaHeight: number
+  volumeTop: number
+  volumeAreaHeight: number
+}
+
+export function computeTimeSharePaneLayout(
+  paneHeight: number,
+  volumeRatio: number,
+): TimeSharePaneLayout {
+  const ratio = Math.min(1, Math.max(0, volumeRatio))
+  const volumeAreaHeight = paneHeight * ratio
+  const priceAreaHeight = paneHeight - volumeAreaHeight
+  return {
+    priceTop: 0,
+    priceAreaHeight,
+    volumeTop: priceAreaHeight,
+    volumeAreaHeight,
+  }
+}
+
+export {
+  TIMESHARE_MIN_LABEL_SPACING_PX,
+  computeTimeShareTimeLabelIndices,
+  type TimeShareTimeLabelInput,
+} from '../../foundation/utils/timeShareAxisLabels'

--- a/packages/core/src/engine/modes/timeShareMode.ts
+++ b/packages/core/src/engine/modes/timeShareMode.ts
@@ -1,6 +1,14 @@
 import type { ChartDataManager } from '../data/chartDataManager'
 import type { Pane, VisibleRange } from '../layout/pane'
 
+import type { MarketSessionConfig } from '../../foundation/utils/timeShareAxisLabels'
+import { ASHARE_MARKET_SESSION } from '../../foundation/utils/timeShareAxisLabels'
+
+import {
+  computeTimeShareBarMetrics,
+  computeTimeSharePriceRange,
+  resolveTimeShareBaseline,
+} from './timeShareMath'
 import type { ChartModeHandler } from './types'
 
 export class TimeShareMode implements ChartModeHandler {
@@ -11,6 +19,17 @@ export class TimeShareMode implements ChartModeHandler {
   readonly allowVerticalScroll = false
   readonly allowRightAxisScale = false
   readonly useIndicatorScheduler = false
+
+  /** 市场 session；默认 A 股，可 setMarketSession 切换 */
+  private _marketSession: MarketSessionConfig = ASHARE_MARKET_SESSION
+
+  get marketSession(): MarketSessionConfig {
+    return this._marketSession
+  }
+
+  setMarketSession(config: MarketSessionConfig): void {
+    this._marketSession = config
+  }
 
   computeContentWidth(
     _dataLength: number,
@@ -27,17 +46,7 @@ export class TimeShareMode implements ChartModeHandler {
     viewWidth: number,
     dpr: number,
   ): { kWidth: number; kGap: number } | null {
-    if (dataLength <= 0 || viewWidth <= 0) return null
-
-    const kGapPx = 1
-    const totalGapPx = (dataLength + 1) * kGapPx
-    const availablePx = Math.max(1, viewWidth * dpr - totalGapPx)
-    const kWidthPx = Math.max(1, Math.floor(availablePx / dataLength))
-
-    return {
-      kWidth: kWidthPx / dpr,
-      kGap: kGapPx / dpr,
-    }
+    return computeTimeShareBarMetrics(dataLength, viewWidth, dpr, this._marketSession)
   }
 
   updatePaneRange(
@@ -47,30 +56,28 @@ export class TimeShareMode implements ChartModeHandler {
     _mergedIndicatorRange?: { min: number; max: number } | null,
   ): void {
     const tsData = dm.getTimeShareData()
-    const end = Math.min(range.end, tsData.length)
     if (tsData.length === 0) return
 
-    const baseline = tsData[0]?.price ?? 0
-    if (baseline === 0) return
+    const end = Math.min(range.end, tsData.length)
+    const start = Math.max(0, range.start)
+    // 优先昨收；缺失时回退首笔价
+    const baseline = resolveTimeShareBaseline({
+      preClose: dm.getTimeSharePreClose(),
+      firstPrice: tsData[0]?.price,
+    })
+    if (baseline === null) return
 
     // scaleType 由 kernel.paneScaleTypes 投影（进入 timeshare 时写 percent）；此处只设会话 basePrice
     pane.yAxis.setBasePrice(baseline)
 
-    let maxAbsPct = 0
-    for (let i = Math.max(0, range.start); i < end; i++) {
+    const prices: number[] = []
+    for (let i = start; i < end; i++) {
       const p = tsData[i]?.price
-      if (p !== undefined && Number.isFinite(p)) {
-        const pct = Math.abs((p - baseline) / baseline) * 100
-        if (pct > maxAbsPct) maxAbsPct = pct
-      }
+      if (p !== undefined) prices.push(p)
     }
-    if (maxAbsPct <= 0) return
-
-    const padding = Math.max(maxAbsPct * 0.1, 0.5)
-    const displayPct = maxAbsPct + padding
-    const minPrice = baseline * (1 - displayPct / 100)
-    const maxPrice = baseline * (1 + displayPct / 100)
-    pane.yAxis.setRange({ maxPrice, minPrice })
+    const priceRange = computeTimeSharePriceRange(prices, baseline)
+    if (!priceRange) return
+    pane.yAxis.setRange(priceRange)
   }
 
   onActivate(
@@ -103,6 +110,6 @@ export class TimeShareMode implements ChartModeHandler {
     _next: ChartModeHandler | null,
   ): void {
     chart.disableMainIndicator('timeShare')
-    chart.setRendererEnabled('candle', true)
+    // candle 可见性由 Chart.setActiveMode 按进入前快照恢复，此处不强制 true
   }
 }

--- a/packages/core/src/engine/render/chartRenderer.ts
+++ b/packages/core/src/engine/render/chartRenderer.ts
@@ -31,6 +31,9 @@ import { ChartIndicatorManager } from '../indicators/chartIndicatorManager'
 import { UpdateLevel } from '../layout/pane'
 import type { VisibleRange } from '../layout/pane'
 import { MarkerManager, type CustomMarkerEntity, type MarkerManagerDeps } from '../marker/registry'
+import { ASHARE_MARKET_SESSION } from '../../foundation/utils/timeShareAxisLabels'
+import { resolveMarketSessionSlots } from '../../foundation/utils/timeShareAxisLabels'
+import { computeTimeShareXLayout } from '../modes/timeShareMath'
 import type { ChartModeHandler } from '../modes/types'
 import { PaneRenderer } from '../paneRenderer'
 import { createTimeAxisRendererPlugin } from '../renderers/timeAxis'
@@ -588,29 +591,31 @@ export class ChartRenderer {
         kBarRects[i] = { x: barLeftPx / vp.dpr, width: barWidthPx / vp.dpr }
       }
 
-      // TimeShare 按 plotWidth 平分 bar，覆盖 calcKLinePositions 的结果
+      // TimeShare：按全天 sessionSlots 划分宽度，已到达点落在时间线上，未到时段右侧留白
       if (mode.debugName === 'TimeShare') {
-        const totalWidth = vp.plotWidth
         const count = kLineCenters.length
-        if (count > 0) {
-          const dpr = vp.dpr
-          const step = totalWidth / count
+        const marketSession =
+          'marketSession' in mode && mode.marketSession
+            ? (mode as { marketSession: typeof ASHARE_MARKET_SESSION }).marketSession
+            : ASHARE_MARKET_SESSION
+        const layout = computeTimeShareXLayout({
+          arrivedCount: count,
+          sessionSlots: resolveMarketSessionSlots(marketSession),
+          totalWidth: vp.plotWidth,
+          dpr: vp.dpr,
+        })
+        if (layout) {
+          const halfBarPx = Math.floor((layout.barWidth * vp.dpr) / 2)
           for (let i = 0; i < count; i++) {
-            kLineCenters[i] = Math.round((i + 0.5) * step * dpr) / dpr
-            kLinePositions[i] = Math.round(i * step * dpr) / dpr
-          }
-          kWidthPx = Math.round((totalWidth * dpr) / count)
-
-          const logicalBarWidth = Math.max(1, step * 0.6)
-          const barWidthPx = Math.round(logicalBarWidth * dpr)
-          const halfBarPx = Math.floor(barWidthPx / 2)
-          for (let i = 0; i < count; i++) {
-            const centerPx = Math.round(kLineCenters[i]! * dpr)
+            kLineCenters[i] = layout.centers[i]!
+            kLinePositions[i] = layout.lefts[i]!
+            const centerPx = Math.round(layout.centers[i]! * vp.dpr)
             kBarRects[i] = {
-              x: (centerPx - halfBarPx) / dpr,
-              width: barWidthPx / dpr,
+              x: (centerPx - halfBarPx) / vp.dpr,
+              width: layout.barWidth,
             }
           }
+          kWidthPx = layout.kWidthPx
         } else {
           kWidthPx = getPhysicalKLineConfig(opt.kWidth, opt.kGap, vp.dpr).kWidthPx
         }
@@ -826,7 +831,13 @@ export class ChartRenderer {
           plotWidth: vp.plotWidth,
           plotHeight: vp.plotHeight,
         },
-        settings: this.settings,
+        settings: {
+          ...this.settings,
+          // 分时昨收优先读 series 元数据，settings 作回退
+          preClose:
+            dataManager.getTimeSharePreClose() ??
+            (this.settings.preClose as number | undefined),
+        },
         yAxisLabels: sharedYAxisLabels,
         xAxisLabels: sharedXAxisLabels,
         yAxisRanges: sharedYAxisRanges,

--- a/packages/core/src/engine/renderers/Indicator/mainIndicatorLegend.ts
+++ b/packages/core/src/engine/renderers/Indicator/mainIndicatorLegend.ts
@@ -224,8 +224,8 @@ function paintLegendOnCanvas(overlayCtx: CanvasRenderingContext2D, legend: Legen
     }
   }
 
-  if (legend.ohlc) {
-    const k = legend.ohlc
+  if (legend.currentBar) {
+    const k = legend.currentBar
     if (!compact) {
       let x = legendX
       const y = rowY()

--- a/packages/core/src/engine/renderers/Indicator/mainIndicatorLegendContext.ts
+++ b/packages/core/src/engine/renderers/Indicator/mainIndicatorLegendContext.ts
@@ -19,12 +19,10 @@ export interface LegendLayout {
 /** 当前 K 线及图例派生的展示字段，保留 KLineData 自定义属性。 */
 export type LegendCurrentBar = Omit<KLineData, 'volume'> & {
   volume: number | null
+  // 成交量+单位格式化文本(eg. 1.23亿)
   volumeText: string | null
   color: string
 }
-
-/** @deprecated 使用 LegendCurrentBar */
-export type LegendOhlcRow = LegendCurrentBar
 
 export interface LegendTimeshareRow {
   price: number
@@ -114,9 +112,7 @@ export function buildLegendTemplateContext(
   const range = context.range
   const crosshairIndex = context.crosshairIndex
   const hasCrosshair = typeof crosshairIndex === 'number'
-  const targetIndex = hasCrosshair
-    ? crosshairIndex
-    : Math.min(range.end - 1, klineData.length - 1)
+  const targetIndex = hasCrosshair ? crosshairIndex : Math.min(range.end - 1, klineData.length - 1)
 
   const layout: LegendLayout = {
     x: legendX,
@@ -130,7 +126,11 @@ export function buildLegendTemplateContext(
   let timeshare: LegendTimeshareRow | null = null
   if (context.period === 'timeshare') {
     const tsData = context.data as TimeShareData[]
-    const preClose = (context.settings?.preClose as number) ?? tsData[0]?.price ?? 0
+    const rawPreClose = context.settings?.preClose as number | undefined
+    const preClose =
+      typeof rawPreClose === 'number' && Number.isFinite(rawPreClose) && rawPreClose !== 0
+        ? rawPreClose
+        : (tsData[0]?.price ?? 0)
     const item = tsData[targetIndex]
     if (item) {
       const changeAmount = item.price - preClose
@@ -262,7 +262,11 @@ function collectComparisonRows(
       percent,
       color,
       percentColor:
-        percent > 0 ? colors.candleUpBody : percent < 0 ? colors.candleDownBody : colors.text.primary,
+        percent > 0
+          ? colors.candleUpBody
+          : percent < 0
+            ? colors.candleDownBody
+            : colors.text.primary,
     })
   }
   return rows

--- a/packages/core/src/engine/renderers/Indicator/mainIndicatorLegendContext.ts
+++ b/packages/core/src/engine/renderers/Indicator/mainIndicatorLegendContext.ts
@@ -17,11 +17,14 @@ export interface LegendLayout {
 }
 
 /** 当前 K 线及图例派生的展示字段，保留 KLineData 自定义属性。 */
-export type LegendOhlcRow = Omit<KLineData, 'volume'> & {
+export type LegendCurrentBar = Omit<KLineData, 'volume'> & {
   volume: number | null
   volumeText: string | null
   color: string
 }
+
+/** @deprecated 使用 LegendCurrentBar */
+export type LegendOhlcRow = LegendCurrentBar
 
 export interface LegendTimeshareRow {
   price: number
@@ -63,11 +66,12 @@ export interface LegendTemplateContext {
     up: string
     down: string
   }
-  ohlc: LegendOhlcRow | null
+  /** 十字线指向的当前 K 线展示行（含 volumeText / color 与自定义字段） */
+  currentBar: LegendCurrentBar | null
   timeshare: LegendTimeshareRow | null
   indicators: ReadonlyArray<LegendIndicatorRow>
   comparisons: ReadonlyArray<LegendComparisonRow>
-  /** 当前索引处的 K 线（分时模式下可能无 close） */
+  /** 当前索引处的原始 K 线（分时模式下可能无 close） */
   bar: KLineData | TimeShareData | null
 }
 
@@ -145,12 +149,12 @@ export function buildLegendTemplateContext(
     }
   }
 
-  let ohlc: LegendOhlcRow | null = null
+  let currentBar: LegendCurrentBar | null = null
   if (hasCrosshair) {
     const k = klineData[targetIndex]
     if (k && typeof k.close === 'number') {
       const isUp = k.close >= k.open
-      ohlc = {
+      currentBar = {
         ...k,
         volume: typeof k.volume === 'number' ? k.volume : null,
         volumeText: typeof k.volume === 'number' ? formatVolumeShort(k.volume) : null,
@@ -173,7 +177,7 @@ export function buildLegendTemplateContext(
       up: colors.candleUpBody,
       down: colors.candleDownBody,
     },
-    ohlc,
+    currentBar,
     timeshare,
     indicators,
     comparisons,

--- a/packages/core/src/engine/renderers/__tests__/mainIndicatorLegend.renderer.test.ts
+++ b/packages/core/src/engine/renderers/__tests__/mainIndicatorLegend.renderer.test.ts
@@ -574,7 +574,7 @@ describe('MainIndicatorLegend external mode & context callback', () => {
     expect(legend).not.toBeNull()
     expect(legend.index).toBe(50)
     expect(legend.hasCrosshair).toBe(true)
-    expect(legend.ohlc).not.toBeNull()
+    expect(legend.currentBar).not.toBeNull()
     expect(legend.indicators.some((row: { name: string }) => row.name === 'MA')).toBe(true)
     expect(vi.mocked(ctx.fillText).mock.calls.length).toBeGreaterThan(0)
   })
@@ -601,7 +601,7 @@ describe('MainIndicatorLegend external mode & context callback', () => {
     expect(vi.mocked(ctx.fillText)).not.toHaveBeenCalled()
   })
 
-  it('retains custom KLineData fields in the ohlc slot context', () => {
+  it('retains custom KLineData fields in the currentBar slot context', () => {
     const onContext = vi.fn()
     const plugin = createMainIndicatorLegendRendererPlugin({
       yPaddingPx: 20,
@@ -619,7 +619,7 @@ describe('MainIndicatorLegend external mode & context callback', () => {
     plugin.draw(context)
 
     const legend = onContext.mock.calls[0]![0]
-    expect(legend.ohlc.turnoverRate).toBe(3.14)
-    expect(legend.ohlc.customLabel).toBe('featured')
+    expect(legend.currentBar.turnoverRate).toBe(3.14)
+    expect(legend.currentBar.customLabel).toBe('featured')
   })
 })

--- a/packages/core/src/engine/renderers/timeShare.ts
+++ b/packages/core/src/engine/renderers/timeShare.ts
@@ -8,6 +8,10 @@ import { RENDERER_PRIORITY } from '../../foundation/plugin/index'
 import { resolveThemeColors } from '../../foundation/tokens/index'
 import type { TimeShareData } from '../../foundation/types/price'
 import { Indicator } from '../indicators/indicatorDefinitionRegistry'
+import {
+  computeTimeSharePaneLayout,
+  resolveTimeShareBaseline,
+} from '../modes/timeShareMath'
 
 /** 成交量区域占 pane 高度的比例（底部） */
 const VOLUME_RATIO = 0.25
@@ -34,15 +38,17 @@ export function createTimeShareRendererPlugin(): RendererPluginWithHost {
         context.isAsiaMarket,
         context.colorPresetSettings,
       )
-      const preClose = (settings?.preClose as number) ?? tsData[0]?.price ?? 0
-      if (preClose === 0) return
+      const preClose = resolveTimeShareBaseline({
+        preClose: settings?.preClose as number | undefined,
+        firstPrice: tsData[0]?.price,
+      })
+      if (preClose === null) return
 
       const paneHeight = pane.height
-      const volumeAreaHeight = Math.round(paneHeight * VOLUME_RATIO * dpr) / dpr
-      const priceAreaHeight = paneHeight - volumeAreaHeight
+      const layout = computeTimeSharePaneLayout(paneHeight, VOLUME_RATIO)
+      const { volumeAreaHeight, priceAreaHeight } = layout
 
       const { start, end } = range
-      const visibleCount = Math.min(end - start, tsData.length - start)
       const itemCount = Math.min(end, tsData.length) - start
 
       const xPositions: number[] = []
@@ -51,16 +57,19 @@ export function createTimeShareRendererPlugin(): RendererPluginWithHost {
       const volumes: number[] = []
       let maxVolume = 0
 
+      // 价格 Y 映射到 price 子区域：pane.yAxis 仍按全高，再线性压到 priceAreaHeight
+      const scaleYToPriceArea = (y: number) => (y / Math.max(paneHeight, 1)) * priceAreaHeight
+
       for (let i = start; i < start + itemCount; i++) {
         const item = tsData[i]
         if (!item) continue
         const x = kLineCenters[i - start]
         if (x === undefined) continue
         xPositions.push(x)
-        yPrices.push(pane.yAxis.priceToY(item.price))
-        yAvgs.push(pane.yAxis.priceToY(item.average))
+        yPrices.push(scaleYToPriceArea(pane.yAxis.priceToY(item.price)))
+        yAvgs.push(scaleYToPriceArea(pane.yAxis.priceToY(item.average)))
         volumes.push(item.volume ?? 0)
-        maxVolume = Math.max(maxVolume, item.volume)
+        maxVolume = Math.max(maxVolume, item.volume ?? 0)
       }
 
       if (xPositions.length < 2) return
@@ -68,7 +77,13 @@ export function createTimeShareRendererPlugin(): RendererPluginWithHost {
       ctx.save()
       ctx.translate(-scrollLeft, 0)
 
-      const preCloseY = pane.yAxis.priceToY(preClose)
+      const preCloseY = scaleYToPriceArea(pane.yAxis.priceToY(preClose))
+
+      // 价格区裁剪，避免线/填充画进成交量区（translate 后世界 scrollLeft 映射到 0）
+      ctx.save()
+      ctx.beginPath()
+      ctx.rect(scrollLeft, 0, context.paneWidth, priceAreaHeight)
+      ctx.clip()
 
       drawPreCloseLine(ctx, xPositions, preCloseY, dpr, colors.timeSharePreClose)
 
@@ -85,6 +100,7 @@ export function createTimeShareRendererPlugin(): RendererPluginWithHost {
       drawSegmentLine(ctx, xPositions, yPrices, dpr, colors.timeSharePriceLine, 2)
 
       drawSegmentLine(ctx, xPositions, yAvgs, dpr, colors.timeShareAvgLine, 1.5)
+      ctx.restore()
 
       drawVolumeBars(
         ctx,

--- a/packages/core/src/engine/state/__tests__/settingsState.test.ts
+++ b/packages/core/src/engine/state/__tests__/settingsState.test.ts
@@ -43,4 +43,13 @@ describe('settingsState', () => {
       ;(snap as { showGridLines?: boolean }).showGridLines = false
     }).toThrow()
   })
+
+  it('preserves extension keys like preClose through resolve/patch', () => {
+    expect(resolveSettings({ preClose: 12.34 }).preClose).toBe(12.34)
+    const s = createSettingsState({ preClose: 12.34 })
+    expect(s.readonly.settings.peek().preClose).toBe(12.34)
+    s.actions.patch({ showGridLines: false })
+    expect(s.readonly.settings.peek().preClose).toBe(12.34)
+    expect(s.readonly.settings.peek().showGridLines).toBe(false)
+  })
 })

--- a/packages/core/src/foundation/config/chartSettings.ts
+++ b/packages/core/src/foundation/config/chartSettings.ts
@@ -158,6 +158,11 @@ export type ChartSettings = {
  * @param partial - 偏好的部分设置（通常是组件 prop 传入）
  * @returns 合并后的 ChartSettings 对象
  */
+const KNOWN_SETTING_KEYS = new Set<string>([
+  ...DEFAULT_SETTINGS.map((item) => item.key),
+  'colorPresetSettings',
+])
+
 export function resolveSettings(partial?: Partial<ChartSettings>): ChartSettings {
   // 用 Partial<_SettingByKey> 而非 ChartSettings 避免交叉类型索引赋值报错
   const result: Partial<_SettingByKey> = {}
@@ -170,6 +175,14 @@ export function resolveSettings(partial?: Partial<ChartSettings>): ChartSettings
   ;(result as ChartSettings).colorPresetSettings = normalizeColorPresetSettings(
     partial?.colorPresetSettings,
   )
+  // 保留扩展字段（如 preClose），避免业务元数据被 resolve 清掉
+  if (partial) {
+    for (const [key, value] of Object.entries(partial)) {
+      if (KNOWN_SETTING_KEYS.has(key)) continue
+      if (value === undefined) continue
+      ;(result as Record<string, unknown>)[key] = value
+    }
+  }
   return result as ChartSettings
 }
 

--- a/packages/core/src/foundation/utils/__tests__/sessionTimeLabels.test.ts
+++ b/packages/core/src/foundation/utils/__tests__/sessionTimeLabels.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ASHARE_MARKET_SESSION,
+  HK_MARKET_SESSION,
+  US_MARKET_SESSION,
+  computeSessionTimeLabels,
+  countSessionSlots,
+  minuteOfDayToTimestamp,
+  resolveMarketSessionSlots,
+  type MarketSessionConfig,
+  type OpenTimeRange,
+} from '../sessionTimeLabels'
+
+function hm(h: number, m: number): number {
+  return h * 60 + m
+}
+
+describe('countSessionSlots / resolveMarketSessionSlots', () => {
+  it('A-share is 240 one-minute slots', () => {
+    expect(countSessionSlots(ASHARE_MARKET_SESSION.sessions)).toBe(240)
+    expect(resolveMarketSessionSlots(ASHARE_MARKET_SESSION)).toBe(240)
+  })
+
+  it('HK is 330, US is 390 (not maxed to 240)', () => {
+    expect(resolveMarketSessionSlots(HK_MARKET_SESSION)).toBe(330)
+    expect(resolveMarketSessionSlots(US_MARKET_SESSION)).toBe(390)
+  })
+
+  it('respects slotMinutes (e.g. 5-min bars)', () => {
+    const cfg: MarketSessionConfig = {
+      ...ASHARE_MARKET_SESSION,
+      slotMinutes: 5,
+    }
+    // 240 分钟 / 5 = 48
+    expect(resolveMarketSessionSlots(cfg)).toBe(48)
+  })
+
+  it('does not expand slots by arrived data length (sessions are SSOT)', () => {
+    expect(resolveMarketSessionSlots(ASHARE_MARKET_SESSION, 300)).toBe(240)
+    expect(resolveMarketSessionSlots(HK_MARKET_SESSION, 100)).toBe(330)
+  })
+})
+
+describe('computeSessionTimeLabels multi-market', () => {
+  it('A-share closed-side endpoints only', () => {
+    const labels = computeSessionTimeLabels(ASHARE_MARKET_SESSION.sessions, { axisWidth: 800 })
+    expect(labels.map((l) => l.minuteOfDay)).toEqual([hm(9, 30), hm(13, 0), hm(15, 0)])
+  })
+
+  it('HK endpoints: 09:30 / 13:00 / 16:00', () => {
+    const labels = computeSessionTimeLabels(HK_MARKET_SESSION.sessions, { axisWidth: 800 })
+    expect(labels.map((l) => l.minuteOfDay)).toEqual([hm(9, 30), hm(13, 0), hm(16, 0)])
+    expect(labels.map((l) => l.slotIndex)).toEqual([0, 150, 329])
+  })
+
+  it('US single continuous session endpoints: 09:30 / 16:00', () => {
+    const labels = computeSessionTimeLabels(US_MARKET_SESSION.sessions, { axisWidth: 800 })
+    expect(labels.map((l) => l.minuteOfDay)).toEqual([hm(9, 30), hm(16, 0)])
+    expect(labels.map((l) => l.slotIndex)).toEqual([0, 389])
+  })
+
+  it('accepts arbitrary sessions via config.sessions', () => {
+    const night: OpenTimeRange[] = [
+      { open: hm(21, 0), close: hm(23, 0) },
+      { open: hm(0, 0), close: hm(2, 30) },
+    ]
+    // 两段同日分钟：21:00-23:00 (120) + 0:00-2:30 (150) = 270
+    // 闭侧端点：21:00, 0:00, 2:30
+    const labels = computeSessionTimeLabels(night, { axisWidth: 800 })
+    expect(labels.map((l) => l.minuteOfDay)).toEqual([hm(21, 0), hm(0, 0), hm(2, 30)])
+    expect(countSessionSlots(night)).toBe(270)
+  })
+})
+
+describe('minuteOfDayToTimestamp timeZone', () => {
+  it('maps wall clock in Asia/Shanghai independently of host local TZ', () => {
+    // 任意 UTC 锚点落在 2026-07-21 上海日历日
+    const base = Date.UTC(2026, 6, 21, 4, 0, 0) // 12:00 CST
+    const ts = minuteOfDayToTimestamp(base, hm(9, 30), 'Asia/Shanghai')
+    // 2026-07-21 09:30 Asia/Shanghai = 01:30 UTC
+    expect(ts).toBe(Date.UTC(2026, 6, 21, 1, 30, 0))
+  })
+
+  it('maps wall clock in America/New_York for US session open', () => {
+    // 2026-07-21 是美东夏令时 EDT (UTC-4)
+    const base = Date.UTC(2026, 6, 21, 16, 0, 0) // 12:00 EDT
+    const ts = minuteOfDayToTimestamp(base, hm(9, 30), 'America/New_York')
+    expect(ts).toBe(Date.UTC(2026, 6, 21, 13, 30, 0)) // 09:30 EDT
+  })
+})

--- a/packages/core/src/foundation/utils/kLineDraw/axis.ts
+++ b/packages/core/src/foundation/utils/kLineDraw/axis.ts
@@ -12,6 +12,14 @@ import {
   findDayBoundaries,
 } from '../dateFormat'
 import { priceToY, yToPrice } from '../priceToY'
+import {
+  ASHARE_MARKET_SESSION,
+  computeTimeShareTimeLabels,
+  minuteOfDayToTimestamp,
+  resolveMarketSessionSlots,
+  timeShareSlotCenterX,
+  type MarketSessionConfig,
+} from '../timeShareAxisLabels'
 
 const textWidthCache = new Map<string, number>()
 const TEXT_WIDTH_CACHE_LIMIT = 512
@@ -63,6 +71,8 @@ export interface TimeAxisOptions {
   monthKeys?: Int32Array
   /** 预计算的日期键值数组（year*366+dayOfYear），与 data 长度一致 */
   dayKeys?: Int32Array
+  /** 分时市场 session；默认 A 股 */
+  marketSession?: MarketSessionConfig
 }
 
 export interface LastPriceLineOptions {
@@ -362,16 +372,47 @@ export function drawTimeAxis(
   let labelFn: (ts: number) => { text: string; isYear: boolean }
 
   if (isTimeShare) {
-    const visibleCount = endIndex - startIndex
-    const maxLabels = Math.max(2, Math.min(8, Math.floor(visibleCount / 2) || 1))
-    const step = Math.max(1, Math.floor(visibleCount / maxLabels))
-    boundaries = []
-    for (let i = 0; i <= maxLabels; i++) {
-      const idx = startIndex + Math.min(i * step, Math.max(0, visibleCount - 1))
-      boundaries.push(idx)
+    // 只画各区间闭侧端点；全天首/末槽贴边 left/right 对齐
+    const market = opts.marketSession ?? ASHARE_MARKET_SESSION
+    const sessionSlots = resolveMarketSessionSlots(market)
+    const labels = computeTimeShareTimeLabels({
+      axisWidth: width,
+      marketSession: market,
+      minLabelSpacingPx: 56,
+    })
+    const baseTs = data[0]?.timestamp ?? Date.now()
+    setCanvasFont(ctx, regularFont)
+    ctx.textBaseline = 'middle'
+    const edgePad = 2
+    const lastSlot = Math.max(0, sessionSlots - 1)
+    for (const label of labels) {
+      const ts = minuteOfDayToTimestamp(baseTs, label.minuteOfDay, market.timeZone)
+      const text = formatTimeLabel(ts)
+      const isDayStart = label.slotIndex === 0
+      const isDayEnd = label.slotIndex === lastSlot
+
+      let align: CanvasTextAlign = 'center'
+      let drawX: number
+      if (isDayStart) {
+        align = 'left'
+        drawX = x + edgePad
+      } else if (isDayEnd) {
+        align = 'right'
+        drawX = x + width - edgePad
+      } else {
+        const centerX = timeShareSlotCenterX(label.slotIndex, width, sessionSlots, dpr)
+        drawX = centerX - scrollLeft
+        if (drawX < edgePad || drawX > width - edgePad) continue
+      }
+
+      ctx.textAlign = align
+      ctx.fillText(text, roundToPhysicalPixel(drawX, dpr), alignToPhysicalPixelCenter(textY, dpr))
     }
-    labelFn = (ts) => ({ text: formatTimeLabel(ts), isYear: false })
-  } else if (isMinuteData) {
+    ctx.textAlign = 'center'
+    return
+  }
+
+  if (isMinuteData) {
     boundaries = findDayBoundaries(data, opts.dayKeys)
     labelFn = formatDay
   } else {

--- a/packages/core/src/foundation/utils/sessionTimeLabels.ts
+++ b/packages/core/src/foundation/utils/sessionTimeLabels.ts
@@ -1,0 +1,237 @@
+/**
+ * 开盘时段：minuteOfDay 为自 0 点起的分钟数（交易所本地墙钟）。
+ * sessions[0..n-2] 左闭右开 [open, close)；sessions[n-1] 左闭右闭 [open, close]。
+ * 只打印闭侧端点：半开段不展示 close。
+ */
+export type OpenTimeRange = {
+  open: number
+  close: number
+}
+
+/** 市场分时 session 配置（几何 / 标签共用） */
+export type MarketSessionConfig = {
+  /** IANA 时区，如 Asia/Shanghai */
+  timeZone: string
+  sessions: ReadonlyArray<OpenTimeRange>
+  /** 每个 bar 槽对应的分钟数，默认 1 */
+  slotMinutes?: number
+}
+
+export type SessionTimeLabel = {
+  /** 自 0 点起的分钟数（交易所墙钟） */
+  minuteOfDay: number
+  /** 在展开后的槽序列中的索引（0-based） */
+  slotIndex: number
+  /** 是否为闭侧端点 */
+  isEndpoint: boolean
+}
+
+export type SessionTimeLabelOptions = {
+  axisWidth: number
+  /** 保留字段，端点-only 模式下不参与密度计算 */
+  minLabelSpacingPx?: number
+}
+
+function hm(h: number, m: number): number {
+  return h * 60 + m
+}
+
+/** A 股默认 */
+export const ASHARE_OPEN_SESSIONS: readonly OpenTimeRange[] = [
+  { open: hm(9, 30), close: hm(11, 30) },
+  { open: hm(13, 0), close: hm(15, 0) },
+]
+
+export const ASHARE_MARKET_SESSION: MarketSessionConfig = {
+  timeZone: 'Asia/Shanghai',
+  sessions: ASHARE_OPEN_SESSIONS,
+  slotMinutes: 1,
+}
+
+/** 港股 */
+export const HK_MARKET_SESSION: MarketSessionConfig = {
+  timeZone: 'Asia/Hong_Kong',
+  sessions: [
+    { open: hm(9, 30), close: hm(12, 0) },
+    { open: hm(13, 0), close: hm(16, 0) },
+  ],
+  slotMinutes: 1,
+}
+
+/** 美股（常规盘，无午休） */
+export const US_MARKET_SESSION: MarketSessionConfig = {
+  timeZone: 'America/New_York',
+  sessions: [{ open: hm(9, 30), close: hm(16, 0) }],
+  slotMinutes: 1,
+}
+
+/**
+ * 只输出各区间闭侧端点。
+ * - 非末段 [open, close)：仅 open
+ * - 末段 [open, close]：open 与 close
+ * close 标签映射到 close-1 槽（bar 序列为各段 [open, close)）。
+ */
+export function computeSessionTimeLabels(
+  sessions: ReadonlyArray<OpenTimeRange>,
+  options: SessionTimeLabelOptions,
+): SessionTimeLabel[] {
+  if (!(options.axisWidth > 0) || sessions.length === 0) return []
+
+  const labels: SessionTimeLabel[] = []
+  let slotOffset = 0
+
+  for (let s = 0; s < sessions.length; s++) {
+    const range = sessions[s]!
+    if (!(range.close > range.open)) continue
+    const slotCount = range.close - range.open
+    const isLast = s === sessions.length - 1
+
+    labels.push({
+      minuteOfDay: range.open,
+      slotIndex: slotOffset,
+      isEndpoint: true,
+    })
+
+    if (isLast) {
+      labels.push({
+        minuteOfDay: range.close,
+        slotIndex: slotOffset + slotCount - 1,
+        isEndpoint: true,
+      })
+    }
+
+    slotOffset += slotCount
+  }
+
+  const bySlot = new Map<number, SessionTimeLabel>()
+  for (const label of labels) {
+    bySlot.set(label.slotIndex, label)
+  }
+  return [...bySlot.values()].sort((a, b) => a.slotIndex - b.slotIndex)
+}
+
+/** 槽总数（各段 [open, close) 分钟数之和；未除 slotMinutes） */
+export function countSessionSlots(sessions: ReadonlyArray<OpenTimeRange>): number {
+  let n = 0
+  for (const r of sessions) {
+    if (r.close > r.open) n += r.close - r.open
+  }
+  return n
+}
+
+/**
+ * 全天 bar 槽数 = 分钟总和 / slotMinutes。
+ * sessions 为 SSOT，不因 arrivedCount 放大。
+ */
+export function resolveMarketSessionSlots(
+  config: MarketSessionConfig,
+  _arrivedCount?: number,
+): number {
+  const minutes = countSessionSlots(config.sessions)
+  const step = config.slotMinutes && config.slotMinutes > 0 ? config.slotMinutes : 1
+  return Math.max(0, Math.floor(minutes / step))
+}
+
+/**
+ * 将交易所墙钟 minuteOfDay 转为 UTC 毫秒。
+ * baseTimestamp 用于确定「哪一天」（按 timeZone 日历日）。
+ */
+export function minuteOfDayToTimestamp(
+  baseTimestamp: number,
+  minuteOfDay: number,
+  timeZone: string = 'Asia/Shanghai',
+): number {
+  const { year, month, day } = getCalendarPartsInTimeZone(baseTimestamp, timeZone)
+  return zonedWallTimeToUtc(year, month, day, minuteOfDay, timeZone)
+}
+
+/** 槽中心 X */
+export function sessionSlotCenterX(
+  slotIndex: number,
+  axisWidth: number,
+  sessionSlots: number,
+  dpr: number,
+): number {
+  if (!(axisWidth > 0) || !(sessionSlots > 0)) return 0
+  const step = axisWidth / sessionSlots
+  return Math.round((slotIndex + 0.5) * step * dpr) / dpr
+}
+
+// ── 时区工具（无第三方依赖，Intl） ──
+
+function getCalendarPartsInTimeZone(
+  timestamp: number,
+  timeZone: string,
+): { year: number; month: number; day: number } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date(timestamp))
+  let year = 0
+  let month = 1
+  let day = 1
+  for (const p of parts) {
+    if (p.type === 'year') year = Number(p.value)
+    else if (p.type === 'month') month = Number(p.value)
+    else if (p.type === 'day') day = Number(p.value)
+  }
+  return { year, month, day }
+}
+
+/**
+ * 将某时区墙钟 (y-m-d + minuteOfDay) 转为 UTC epoch。
+ * 用迭代修正 UTC 猜测，覆盖 DST。
+ */
+function zonedWallTimeToUtc(
+  year: number,
+  month: number,
+  day: number,
+  minuteOfDay: number,
+  timeZone: string,
+): number {
+  const hour = Math.floor(minuteOfDay / 60)
+  const minute = minuteOfDay % 60
+  // 初值：当作 UTC 墙钟
+  let utc = Date.UTC(year, month - 1, day, hour, minute, 0, 0)
+  for (let i = 0; i < 4; i++) {
+    const wall = getWallClockInTimeZone(utc, timeZone)
+    const desiredMin = hour * 60 + minute
+    const actualMin = wall.hour * 60 + wall.minute
+    const dayDelta =
+      Date.UTC(year, month - 1, day) - Date.UTC(wall.year, wall.month - 1, wall.day)
+    const minDelta = desiredMin - actualMin + dayDelta / 60_000
+    if (minDelta === 0) break
+    utc += minDelta * 60_000
+  }
+  return utc
+}
+
+function getWallClockInTimeZone(
+  timestamp: number,
+  timeZone: string,
+): { year: number; month: number; day: number; hour: number; minute: number } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(new Date(timestamp))
+  let year = 0
+  let month = 1
+  let day = 1
+  let hour = 0
+  let minute = 0
+  for (const p of parts) {
+    if (p.type === 'year') year = Number(p.value)
+    else if (p.type === 'month') month = Number(p.value)
+    else if (p.type === 'day') day = Number(p.value)
+    else if (p.type === 'hour') hour = Number(p.value)
+    else if (p.type === 'minute') minute = Number(p.value)
+  }
+  return { year, month, day, hour, minute }
+}

--- a/packages/core/src/foundation/utils/timeShareAxisLabels.ts
+++ b/packages/core/src/foundation/utils/timeShareAxisLabels.ts
@@ -1,0 +1,94 @@
+import {
+  ASHARE_MARKET_SESSION,
+  ASHARE_OPEN_SESSIONS,
+  computeSessionTimeLabels,
+  countSessionSlots,
+  minuteOfDayToTimestamp,
+  resolveMarketSessionSlots,
+  sessionSlotCenterX,
+  type MarketSessionConfig,
+  type SessionTimeLabel,
+} from './sessionTimeLabels'
+
+/** A 股默认全天 1 分钟槽位数（兼容旧导出） */
+export const ASHARE_TIMESHARE_SESSION_SLOTS = resolveMarketSessionSlots(ASHARE_MARKET_SESSION)
+
+/** 分时时间标签最小水平间距（逻辑像素） */
+export const TIMESHARE_MIN_LABEL_SPACING_PX = 56
+
+export type TimeShareTimeLabelInput = {
+  axisWidth: number
+  /** 市场 session；默认 A 股 */
+  marketSession?: MarketSessionConfig
+  minLabelSpacingPx?: number
+}
+
+/**
+ * 分时时间标签索引（委托 computeSessionTimeLabels）。
+ * 默认 A 股；传入 marketSession 可换港股/美股等。
+ */
+export function computeTimeShareTimeLabelIndices(input: TimeShareTimeLabelInput): number[] {
+  return computeTimeShareTimeLabels(input).map((l) => l.slotIndex)
+}
+
+/** 完整标签（含 minuteOfDay / isEndpoint） */
+export function computeTimeShareTimeLabels(input: TimeShareTimeLabelInput): SessionTimeLabel[] {
+  const market = input.marketSession ?? ASHARE_MARKET_SESSION
+  return computeSessionTimeLabels(market.sessions, {
+    axisWidth: input.axisWidth,
+    minLabelSpacingPx: input.minLabelSpacingPx ?? TIMESHARE_MIN_LABEL_SPACING_PX,
+  })
+}
+
+export function timeShareSlotCenterX(
+  slotIndex: number,
+  axisWidth: number,
+  sessionSlots: number,
+  dpr: number,
+): number {
+  return sessionSlotCenterX(slotIndex, axisWidth, sessionSlots, dpr)
+}
+
+/**
+ * 由开盘日基准时间戳 + slot 索引推算标签时间（按 market session）。
+ */
+export function resolveTimeShareSlotTimestamp(
+  baseTimestamp: number,
+  slotIndex: number,
+  marketSession: MarketSessionConfig = ASHARE_MARKET_SESSION,
+): number {
+  const step = marketSession.slotMinutes && marketSession.slotMinutes > 0 ? marketSession.slotMinutes : 1
+  let remaining = slotIndex * step
+  for (const range of marketSession.sessions) {
+    const len = range.close - range.open
+    if (remaining < len) {
+      return minuteOfDayToTimestamp(
+        baseTimestamp,
+        range.open + remaining,
+        marketSession.timeZone,
+      )
+    }
+    remaining -= len
+  }
+  const last = marketSession.sessions[marketSession.sessions.length - 1]
+  if (last) {
+    return minuteOfDayToTimestamp(baseTimestamp, last.close, marketSession.timeZone)
+  }
+  return baseTimestamp
+}
+
+export {
+  ASHARE_MARKET_SESSION,
+  ASHARE_OPEN_SESSIONS,
+  computeSessionTimeLabels,
+  countSessionSlots,
+  minuteOfDayToTimestamp,
+  resolveMarketSessionSlots,
+  sessionSlotCenterX,
+}
+export type {
+  MarketSessionConfig,
+  OpenTimeRange,
+  SessionTimeLabel,
+} from './sessionTimeLabels'
+export { HK_MARKET_SESSION, US_MARKET_SESSION } from './sessionTimeLabels'

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.9.0-alpha.3'
+export const VERSION = '0.9.0-alpha.4'

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@363045841yyt/klinechart-desktop",
-  "version": "0.9.0-alpha.3",
+  "version": "0.9.0-alpha.4",
   "private": true,
   "description": "Electron desktop shell for @363045841yyt/klinechart",
   "license": "MIT",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -180,13 +180,13 @@ Providing `#legend` fully replaces the default Canvas legend. The slot scope is 
 ```vue
 <template>
   <KlineChart>
-    <template #legend="{ ohlc, indicators, comparisons, colors }">
-      <div class="my-legend" v-if="ohlc">
-        <span :style="{ color: ohlc.color }">
-          O {{ ohlc.open.toFixed(2) }}
-          H {{ ohlc.high.toFixed(2) }}
-          L {{ ohlc.low.toFixed(2) }}
-          C {{ ohlc.close.toFixed(2) }}
+    <template #legend="{ currentBar, indicators, comparisons, colors }">
+      <div class="my-legend" v-if="currentBar">
+        <span :style="{ color: currentBar.color }">
+          O {{ currentBar.open.toFixed(2) }}
+          H {{ currentBar.high.toFixed(2) }}
+          L {{ currentBar.low.toFixed(2) }}
+          C {{ currentBar.close.toFixed(2) }}
         </span>
         <span v-for="ind in indicators" :key="ind.name" class="my-legend__ind">
           {{ ind.name }}

--- a/packages/vue/README_CN.md
+++ b/packages/vue/README_CN.md
@@ -180,13 +180,13 @@ createApp(App).mount('#app')
 ```vue
 <template>
   <KlineChart>
-    <template #legend="{ ohlc, indicators, comparisons, colors }">
-      <div class="my-legend" v-if="ohlc">
-        <span :style="{ color: ohlc.color }">
-          O {{ ohlc.open.toFixed(2) }}
-          H {{ ohlc.high.toFixed(2) }}
-          L {{ ohlc.low.toFixed(2) }}
-          C {{ ohlc.close.toFixed(2) }}
+    <template #legend="{ currentBar, indicators, comparisons, colors }">
+      <div class="my-legend" v-if="currentBar">
+        <span :style="{ color: currentBar.color }">
+          O {{ currentBar.open.toFixed(2) }}
+          H {{ currentBar.high.toFixed(2) }}
+          L {{ currentBar.low.toFixed(2) }}
+          C {{ currentBar.close.toFixed(2) }}
         </span>
         <span v-for="ind in indicators" :key="ind.name" class="my-legend__ind">
           {{ ind.name }}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@363045841yyt/klinechart",
-  "version": "0.9.0-alpha.3",
+  "version": "0.9.0-alpha.4",
   "description": "Vue 3 bindings for @363045841yyt/klinechart-core. Idiomatic composables, SFC components.",
   "license": "MIT",
   "repository": {

--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -48,42 +48,45 @@
         <!-- 自定义主图左上角图例，替换默认 Canvas 图例并由调用方组合图例数据。 -->
         <template #legend="{ index, currentBar, timeshare, indicators, comparisons, colors }">
           <div class="my-legend">
-            <template v-if="currentBar">
+            <!-- PR #98 为 KLineData[] 添加的自定义字段会展开通过 currentBar 暴露 -->
+            <div v-if="currentBar" class="my-legend__row">
               <span :style="{ color: currentBar.color }">
-                O {{ currentBar.open.toFixed(2) }} H {{ currentBar.high.toFixed(2) }} L
-                {{ currentBar.low.toFixed(2) }} C {{ currentBar.close.toFixed(2) }}
+                O {{ currentBar.open.toFixed(2) }} H {{ currentBar.high.toFixed(2) }}
+                L {{ currentBar.low.toFixed(2) }} C {{ currentBar.close.toFixed(2) }}
               </span>
               <span v-if="currentBar.volumeText">Vol {{ currentBar.volumeText }}</span>
-              <!-- currentBar 保留 KLineData 自定义字段，可直接读取 strategySignal、confidence。 -->
-              <span v-if="currentBar.strategySignal" class="my-legend__signal">
-                {{ currentBar.strategySignal }} {{ currentBar.confidence }}%
-              </span>
-            </template>
+            </div>
 
-            <template v-if="timeshare">
+            <div v-if="timeshare" class="my-legend__row">
               <span :style="{ color: timeshare.changeColor }">
                 现价 {{ timeshare.price.toFixed(2) }} 涨幅
-                {{ timeshare.changePercent.toFixed(2) }}% </span
-              >/
-            </template>
+                {{ timeshare.changePercent.toFixed(2) }}%
+              </span>
+            </div>
 
-            <span v-for="indicator in indicators" :key="indicator.name">
-              {{ indicator.name }}
+            <!-- 主图指标图例 -->
+            <div
+              v-for="indicator in indicators"
+              :key="indicator.name"
+              class="my-legend__row"
+            >
+              <span>{{ indicator.name }}</span>
               <template v-for="value in indicator.values" :key="value.label">
                 <span :style="{ color: value.color }">
                   {{ value.label }} {{ value.value.toFixed(3) }}
                 </span>
               </template>
-            </span>
+            </div>
 
-            <span
+            <div
               v-for="comparison in comparisons"
               :key="comparison.symbol"
+              class="my-legend__row"
               :style="{ color: comparison.percentColor }"
             >
               {{ comparison.symbol }}
               {{ comparison.percent > 0 ? '+' : '' }}{{ comparison.percent.toFixed(2) }}%
-            </span>
+            </div>
           </div>
         </template>
       </KlineChart>
@@ -834,10 +837,18 @@
 
   .my-legend {
     display: flex;
-    flex-wrap: wrap;
-    gap: 4px 10px;
+    flex-direction: column;
+    gap: 2px;
     max-width: min(760px, calc(100vw - 96px));
     font-variant-numeric: tabular-nums;
+    line-height: 18px;
+  }
+
+  .my-legend__row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0 10px;
+    align-items: baseline;
   }
 
   .my-legend__signal {

--- a/packages/vue/preview/App.vue
+++ b/packages/vue/preview/App.vue
@@ -28,6 +28,7 @@
         @update:is-fullscreen="isFullscreen = $event"
         @theme-change="onThemeChange"
       >
+        <!-- 自定义 Tooltip -->
         <!-- <template #kline-tooltip="{ hoverData, upColor, downColor }">
           <div class="custom-tooltip">
             <div class="custom-tooltip__title">
@@ -45,17 +46,17 @@
           </div>
         </template> -->
         <!-- 自定义主图左上角图例，替换默认 Canvas 图例并由调用方组合图例数据。 -->
-        <template #legend="{ ohlc, timeshare, indicators, comparisons, colors }">
+        <template #legend="{ index, currentBar, timeshare, indicators, comparisons, colors }">
           <div class="my-legend">
-            <template v-if="ohlc">
-              <span :style="{ color: ohlc.color }">
-                O {{ ohlc.open.toFixed(2) }} H {{ ohlc.high.toFixed(2) }} L
-                {{ ohlc.low.toFixed(2) }} C {{ ohlc.close.toFixed(2) }}
+            <template v-if="currentBar">
+              <span :style="{ color: currentBar.color }">
+                O {{ currentBar.open.toFixed(2) }} H {{ currentBar.high.toFixed(2) }} L
+                {{ currentBar.low.toFixed(2) }} C {{ currentBar.close.toFixed(2) }}
               </span>
-              <span v-if="ohlc.volumeText">Vol {{ ohlc.volumeText }}</span>
-              <!-- ohlc 保留 KLineData 自定义字段，可直接读取 strategySignal、confidence。 -->
-              <span v-if="ohlc.strategySignal" class="my-legend__signal">
-                {{ ohlc.strategySignal }} {{ ohlc.confidence }}%
+              <span v-if="currentBar.volumeText">Vol {{ currentBar.volumeText }}</span>
+              <!-- currentBar 保留 KLineData 自定义字段，可直接读取 strategySignal、confidence。 -->
+              <span v-if="currentBar.strategySignal" class="my-legend__signal">
+                {{ currentBar.strategySignal }} {{ currentBar.confidence }}%
               </span>
             </template>
 

--- a/packages/vue/src/__tests__/internalize.test.ts
+++ b/packages/vue/src/__tests__/internalize.test.ts
@@ -209,7 +209,7 @@ describe('KLineChart legend slot lifecycle', () => {
               hasCrosshair: props.hasCrosshair,
               layout: props.layout,
               colors: props.colors,
-              ohlc: props.ohlc,
+              currentBar: props.currentBar,
               timeshare: props.timeshare,
               indicators: props.indicators,
               comparisons: props.comparisons,
@@ -226,7 +226,7 @@ describe('KLineChart legend slot lifecycle', () => {
       hasCrosshair: true,
       layout: { x: 12, y: 16, lineHeight: 18, gap: 10, paneWidth: 800, compact: false },
       colors: { textPrimary: '#111111', textTertiary: '#777777', up: '#ff0000', down: '#00aa00' },
-      ohlc: {
+      currentBar: {
         open: 10,
         high: 12,
         low: 9,

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -378,6 +378,16 @@ import MarkerTooltip from './MarkerTooltip.vue'
    */
   export type LegendSlotProps = LegendTemplateContext
 
+  /**
+   * 声明命名插槽作用域类型，供 Volar 在父组件模板中做 slot props 补全。
+   * @remarks 仅类型契约，运行时仍用 useSlots() 判断插槽是否存在。
+   */
+  defineSlots<{
+    legend(props: LegendSlotProps): unknown
+    'kline-tooltip'(props: KlineTooltipSlotProps): unknown
+    'marker-tooltip'(props: MarkerTooltipSlotProps): unknown
+  }>()
+
   // ── Symbol / Comparison State ──
 
   // Default symbol catalog — registered into the controller on mount so the

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -56,6 +56,7 @@ export type {
   LegendTemplateContext,
   LegendRenderMode,
   LegendLayout,
+  LegendCurrentBar,
   LegendOhlcRow,
   LegendTimeshareRow,
   LegendIndicatorRow,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -57,7 +57,6 @@ export type {
   LegendRenderMode,
   LegendLayout,
   LegendCurrentBar,
-  LegendOhlcRow,
   LegendTimeshareRow,
   LegendIndicatorRow,
   LegendComparisonRow,


### PR DESCRIPTION
## Summary
- Fix timeshare partial-day stretch by laying out bars on full-day session slots, with right-side blank space for unarrived minutes.
- Unify preClose baseline across Y-axis, renderer, and legend; preserve settings extension keys; restore sub-pane paneId/ratios/candle visibility on mode exit.
- Draw only closed-side session endpoints (A-share: 09:30 / 13:00 / 15:00) with edge-safe left/right text alignment so labels are not clipped.
- Extract `MarketSessionConfig` with A-share/HK/US presets, timezone-aware `minuteOfDayToTimestamp`, and inject session config through mode geometry + time axis (sessions as SSOT).
- Cleanup: drop obsolete `LegendOhlcRow` re-export, tidy preview legend layout, bump packages to `0.9.0-alpha.4`.

## Test plan
- [x] `pnpm --filter @363045841yyt/klinechart-core test -- src/foundation/utils/__tests__/sessionTimeLabels.test.ts src/engine/modes/__tests__/timeShareMath.test.ts src/engine/modes/__tests__/timeShareMode.test.ts src/engine/__tests__/chart.dpr.test.ts`
- [ ] Manual: open timeshare mid-session — curve should not fill full width; axis shows 09:30 / 13:00 / 15:00
- [ ] Manual: enter/exit timeshare with MACD/RSI sub-panes — pane ids and ratios restore
- [ ] Manual: `setMarketSession(HK_MARKET_SESSION)` — bar metrics use 330 slots

## Commits
- `0f67368` fix(timeshare): fix geometry, baseline, and multi-market sessions
- `3ce96d0` refactor(legend): drop LegendOhlcRow export and tidy preview layout
- `652b544` chore: bump packages to 0.9.0-alpha.4