### PR TITLE
feat: stock search identity and aggregation source management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ When you launch a sub-agent, use codegraph MCP when prompted to explore the code
 
 - **Must use commit-message-generator skill**: When committing, always load the skill at `.opencode/skills/commit/SKILL.md` via `skill("commit-message-generator")` to generate conventional commit messages.
 - **PR descriptions should cover the entire branch**: When creating a PR, describe the full scope of changes across all commits in the branch, not just the latest commit.
+- You can **only** commit when I explicitly ask you to do it.
 
 ## Monorepo
 
@@ -24,7 +25,7 @@ pnpm workspace at `packages/*`. Published packages:
 
 **Build order matters**: `pnpm build:packages` (core → vue). Each framework package depends on core via `workspace:*`.
 
-Node: `^20.19.0 \|\| >=22.12.0`. pnpm 9.x.
+Node: `^20.19.0 \|\| >=22.12.0`. pnpm 11.x.
 
 ## README Generation
 
@@ -147,9 +148,6 @@ Never guess at Effect patterns - check the guide first.
 - Inline comments: `/** brief */` or `// brief`, no tags needed.
 - **Say what it is, not what to do with it**
 - **Never invent Chinese jargon**
-- **表述直接，不说倒装话**：说"合并后写入 X"，不说"写入 X 前先在此合并"。注释要一眼看完，不要兜圈子
+- **表述直接，不说倒装话**：说"合并后写入 X"，不说"写入 X 前先在此合并"。注释要一眼看完就能理解，不要兜圈子
 - **One sentence if possible**
 - **分支注释写在 `if` 上一行**，不要写到分支内部
-
-## ATTENTION
-- You can only commit when I explicitly ask you to do it.

--- a/docs/superpowers/plans/2026-07-23-gotdx-api-base-url.md
+++ b/docs/superpowers/plans/2026-07-23-gotdx-api-base-url.md
@@ -1,0 +1,110 @@
+# gotdx API Base URL Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make all frontend gotdx requests use `VITE_GOTDX_API_BASE_URL`, defaulting to `http://127.0.0.1:8080`.
+
+**Architecture:** Keep URL resolution local to `packages/core/src/data/gotdx.ts`. Read the Vite environment at request time so tests can override it without module reloading, normalize trailing slashes, and append the existing endpoint paths unchanged.
+
+**Tech Stack:** TypeScript, Vite `import.meta.env`, Vitest, Fetch API.
+
+## Global Constraints
+
+- Use environment variable `VITE_GOTDX_API_BASE_URL`.
+- Default to `http://127.0.0.1:8080` when the variable is absent.
+- Remove trailing slashes before appending endpoint paths.
+- Do not modify BaoStock, TradingView, Go backend, or Vite proxy targets.
+
+---
+
+### Task 1: Make gotdx base URL configurable
+
+**Files:**
+- Modify: `packages/core/src/data/gotdx.ts:34` and all gotdx fetch URL construction sites.
+- Test: `packages/core/src/data/__tests__/gotdx.test.ts`.
+
+**Interfaces:**
+- Produces a private `getBaseUrl(): string` helper that returns the normalized configured URL.
+
+- [ ] **Step 1: Add tests for default and overridden URLs**
+
+In `packages/core/src/data/__tests__/gotdx.test.ts`, add environment cleanup to the existing `beforeEach` or `afterEach`, then cover both cases through the existing fetcher:
+
+```ts
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+it('uses the default gotdx API base URL', async () => {
+  fetchMock.mockResolvedValue(jsonResponse([]))
+  const definition = getRegisteredFetcher('gotdx')
+
+  await definition?.fetcher('gotdx', {
+    symbol: '600519',
+    period: 'daily',
+    startDate: '2026-01-01',
+    endDate: '2026-01-31',
+    adjust: 'none',
+    exchange: 'SH',
+    params: { market: 1 },
+  })
+
+  expect(fetchMock.mock.calls[0]?.[0]).toBe('http://127.0.0.1:8080/api/stock/kline-by-date')
+})
+
+it('uses and normalizes VITE_GOTDX_API_BASE_URL', async () => {
+  vi.stubEnv('VITE_GOTDX_API_BASE_URL', 'http://gotdx.test:9090///')
+  fetchMock.mockResolvedValue(jsonResponse([]))
+  const definition = getRegisteredFetcher('gotdx')
+
+  await definition?.fetcher('gotdx', {
+    symbol: '600519',
+    period: 'daily',
+    startDate: '2026-01-01',
+    endDate: '2026-01-31',
+    adjust: 'none',
+    exchange: 'SH',
+    params: { market: 1 },
+  })
+
+  expect(fetchMock.mock.calls[0]?.[0]).toBe('http://gotdx.test:9090/api/stock/kline-by-date')
+})
+```
+
+- [ ] **Step 2: Run the focused tests and verify the new override test fails**
+
+Run: `pnpm --filter @363045841yyt/klinechart-core test -- gotdx.test.ts`
+
+Expected: the default test passes and the override test fails because the implementation still uses the hard-coded `http://127.0.0.1:8080` URL.
+
+- [ ] **Step 3: Implement request-time URL resolution**
+
+Replace the hard-coded constant with:
+
+```ts
+const DEFAULT_BASE_URL = 'http://127.0.0.1:8080'
+
+function getBaseUrl(): string {
+  return (import.meta.env.VITE_GOTDX_API_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '')
+}
+```
+
+Use `getBaseUrl()` for the four existing request groups: history tick, symbol search, extended K-line, and stock K-line. Preserve every endpoint path and request body.
+
+- [ ] **Step 4: Run the focused tests and verify they pass**
+
+Run: `pnpm --filter @363045841yyt/klinechart-core test -- gotdx.test.ts`
+
+Expected: all gotdx tests pass, including the default and overridden base URL tests.
+
+- [ ] **Step 5: Run the core package verification**
+
+Run: `pnpm --filter @363045841yyt/klinechart-core test`
+
+Expected: the core package test suite passes with no unrelated failures.
+
+- [ ] **Step 6: Inspect the final diff**
+
+Run: `git diff -- packages/core/src/data/gotdx.ts packages/core/src/data/__tests__/gotdx.test.ts docs/superpowers/specs/2026-07-23-gotdx-api-base-url-design.md docs/superpowers/plans/2026-07-23-gotdx-api-base-url.md`
+
+Expected: only the documented URL configuration, focused tests, design, and plan changes are present.

--- a/docs/superpowers/plans/2026-07-23-symbol-selection-identity.md
+++ b/docs/superpowers/plans/2026-07-23-symbol-selection-identity.md
@@ -1,0 +1,122 @@
+# Symbol Selection Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the chart UI independently select same-code symbols whose source, exchange, or request params differ.
+
+**Architecture:** Reuse one canonical identity function for `SymbolSpec` and `SearchableSymbol`. The core comparison state and Vue comparison selector retain and exchange identity keys, while `symbol` remains the fetch/display field.
+
+**Tech Stack:** TypeScript, Vue 3, Vitest.
+
+## Global Constraints
+
+- Identity is `[source, exchange, symbol, sorted(params)]`.
+- Do not change search APIs or data-fetch request parameters.
+- Keep source comments in Chinese when needed.
+
+---
+
+### Task 1: Define Core Symbol Identity
+
+**Files:**
+- Create: `packages/core/src/engine/data/symbolIdentity.ts`
+- Modify: `packages/core/src/engine/data/chartDataManager.ts`
+- Modify: `packages/core/src/engine/state/comparisonState.ts`
+- Test: `packages/core/src/engine/data/__tests__/comparisonManager.test.ts`
+
+**Interfaces:**
+- Produces: `symbolSpecIdentityKey(spec: Pick<SymbolSpec, 'source' | 'exchange' | 'symbol' | 'params'>): string`.
+- Consumes: `SymbolSpec` from `packages/core/src/controllers/types.ts`.
+
+- [ ] **Step 1: Write failing tests for two comparison specs with `symbol: '000001'` and different `exchange` values.**
+
+```ts
+expect(controller.symbols.peek().slice(1)).toHaveLength(2)
+expect(controller.comparisonColors.peek()).toHaveLength(2)
+```
+
+- [ ] **Step 2: Run the focused test and verify the duplicate is rejected under code-only comparison.**
+
+Run: `pnpm --filter @363045841yyt/klinechart-core test -- comparisonManager.test.ts`
+
+Expected: FAIL because only one `000001` comparison spec is retained.
+
+- [ ] **Step 3: Implement `symbolSpecIdentityKey` by JSON serializing source, exchange, symbol, and sorted params; use it for comparison duplicate detection, removal, and color keys.**
+
+```ts
+export function symbolSpecIdentityKey(spec: SymbolIdentity): string {
+  const params = Object.entries(spec.params ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )
+  return JSON.stringify([spec.source ?? '', spec.exchange ?? '', spec.symbol, params])
+}
+```
+
+- [ ] **Step 4: Run the focused core test and verify both comparisons and distinct colors are retained.**
+
+Run: `pnpm --filter @363045841yyt/klinechart-core test -- comparisonManager.test.ts`
+
+Expected: PASS.
+
+### Task 2: Carry Identity Through Vue Comparison Controls
+
+**Files:**
+- Modify: `packages/vue/src/composables/useSymbolSearch.ts`
+- Modify: `packages/vue/src/components/CompareSymbolSelector.vue`
+- Modify: `packages/vue/src/components/TopToolbar.vue`
+- Modify: `packages/vue/src/components/KLineChart.vue`
+- Test: `packages/vue/src/composables/__tests__/useSymbolSearch.test.ts`
+
+**Interfaces:**
+- Consumes: `symbolIdentityKey(item: SearchableSymbol): string`.
+- Produces: comparison selector `add` and `remove` events keyed by the canonical symbol identity.
+
+- [ ] **Step 1: Add a failing composable test proving same-code results with different exchanges remain distinct.**
+
+```ts
+expect(results.value.map(symbolIdentityKey)).toEqual([
+  symbolIdentityKey(shenzhen000001),
+  symbolIdentityKey(shanghai000001),
+])
+```
+
+- [ ] **Step 2: Run the Vue focused test and verify code-only deduplication removes one candidate.**
+
+Run: `pnpm --filter @363045841yyt/klinechart test -- useSymbolSearch.test.ts`
+
+Expected: FAIL before replacing `uniqueSymbolsByCode`.
+
+- [ ] **Step 3: Replace `uniqueSymbolsByCode` with identity-key deduplication. Use identity keys for `selected`, `comparisonColors`, display fallback filtering, selected styling, and remove events. Convert the removal key back to its matching `SymbolItem` in `KLineChart.vue`, then pass the complete `SymbolSpec` to the controller.**
+
+```ts
+const selectedSet = computed(() => new Set(props.selected ?? []))
+
+function toggleSymbol(item: SymbolItem) {
+  const key = symbolIdentityKey(item)
+  if (selectedSet.value.has(key)) emit('remove', key)
+  else emit('add', item)
+}
+```
+
+- [ ] **Step 4: Run the focused Vue test and verify both candidates are rendered and can be independently addressed.**
+
+Run: `pnpm --filter @363045841yyt/klinechart test -- useSymbolSearch.test.ts`
+
+Expected: PASS.
+
+### Task 3: Verify Cross-Package Behavior
+
+**Files:**
+- Modify: only files from Tasks 1 and 2 if verification finds type errors.
+
+- [ ] **Step 1: Run core and Vue package tests.**
+
+Run: `pnpm --filter @363045841yyt/klinechart-core test && pnpm --filter @363045841yyt/klinechart test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run package type checks.**
+
+Run: `pnpm --filter @363045841yyt/klinechart-core lint:types && pnpm --filter @363045841yyt/klinechart lint:types`
+
+Expected: PASS.

--- a/docs/superpowers/specs/2026-07-23-gotdx-api-base-url-design.md
+++ b/docs/superpowers/specs/2026-07-23-gotdx-api-base-url-design.md
@@ -1,0 +1,40 @@
+# gotdx API Base URL Configuration
+
+## Goal
+
+Allow the frontend gotdx data fetcher to target a configurable backend URL. The
+default remains `http://127.0.0.1:8080`, which preserves current development
+behavior while avoiding a hard-coded port in deployments.
+
+## Configuration
+
+Use the Vite build-time environment variable:
+
+```env
+VITE_GOTDX_API_BASE_URL=http://127.0.0.1:8080
+```
+
+If the variable is absent, the fetcher uses `http://127.0.0.1:8080`. The value
+is normalized by removing trailing slashes before endpoint paths are appended.
+
+## Scope
+
+- Update `packages/core/src/data/gotdx.ts` to read the environment variable.
+- Keep all gotdx endpoints on the same configured base URL.
+- Add tests for the default value and an overridden value.
+- Keep BaoStock and TradingView configuration unchanged.
+- Do not change the Go backend or Vite proxy targets.
+
+## Error Handling
+
+The fetcher keeps its existing HTTP status checks and JSON parsing behavior.
+Changing the base URL must not hide non-JSON responses or convert backend
+errors into successful empty results.
+
+## Verification
+
+- Run the focused gotdx tests.
+- Run the core package type check or package test command required by the
+  repository.
+- Confirm that the default URL remains `http://127.0.0.1:8080` when no variable
+  is configured.

--- a/docs/superpowers/specs/2026-07-23-symbol-selection-identity-design.md
+++ b/docs/superpowers/specs/2026-07-23-symbol-selection-identity-design.md
@@ -1,0 +1,28 @@
+# Symbol Selection Identity Design
+
+## Goal
+
+Allow search results with the same symbol code to be selected independently when their source, exchange, or request parameters differ.
+
+## Identity Contract
+
+The UI identity for a symbol is the existing `symbolIdentityKey` value:
+
+```ts
+[source, exchange, symbol, sorted(params)]
+```
+
+The key is used for Vue list keys, comparison selection, removal, color lookup, and display-item matching. `symbol` remains the display value and the value sent to data fetchers.
+
+## Scope
+
+- Replace comparison selector code-based deduplication, selection, and removal with identity-key operations.
+- Pass identity keys through toolbar comparison props and events.
+- Resolve the main selector's selected item using the selected symbol's complete identity where available.
+- Cover same-code, different-identity comparison behavior with focused tests.
+
+## Non-Goals
+
+- Add a backend-generated identifier.
+- Change search result APIs or data-fetch request parameters.
+- Migrate persisted comparison state beyond the existing in-memory contract.

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -28,6 +28,7 @@ export type {
   PaneLayoutInfo,
   SymbolSpec,
   SymbolInfo,
+  DataSourceParams,
   DataFetcher,
   CustomDataSource,
 } from './types'
@@ -78,12 +79,21 @@ export {
   hundredMockDataFetcher,
   baostockDataFetcher,
   routerDataFetcher,
+  routerSearchFetchers,
   DataBuffer,
   BinanceSSESource,
   DEFAULT_BINANCE_SSE_URL,
   DepthConnector,
 } from '../data'
-export type { DataWindow, DepthSource, DepthDelta, DepthSnapshot, DepthSourceStatus } from '../data'
+export type {
+  DataWindow,
+  DepthSource,
+  DepthDelta,
+  DepthSnapshot,
+  DepthSourceStatus,
+  SearchConfig,
+  SearchResult,
+} from '../data'
 
 // Heatmap controller (depth pipeline rendering half)
 export { createHeatmapController } from '../components/orderBookHeatmap'

--- a/packages/core/src/controllers/index.ts
+++ b/packages/core/src/controllers/index.ts
@@ -80,6 +80,12 @@ export {
   baostockDataFetcher,
   routerDataFetcher,
   routerSearchFetchers,
+  getRegisteredFetchers,
+  setFetcherBaseUrl,
+  getFetcherBaseUrl,
+  composeFetcherBaseUrl,
+  parseFetcherEndpoint,
+  clearFetcherBaseUrlsForTest,
   DataBuffer,
   BinanceSSESource,
   DEFAULT_BINANCE_SSE_URL,
@@ -93,6 +99,7 @@ export type {
   DepthSourceStatus,
   SearchConfig,
   SearchResult,
+  DataFetcherDefinition,
 } from '../data'
 
 // Heatmap controller (depth pipeline rendering half)

--- a/packages/core/src/controllers/types.ts
+++ b/packages/core/src/controllers/types.ts
@@ -88,12 +88,15 @@ export interface TimeShareData {
 export type { PaneSpec }
 
 // ---------------------------------------------------------------------------
+export type DataSourceParams = Readonly<Record<string, string | number | boolean>>
+
 /** Registered symbol metadata — for the symbol catalog/dropdown UI */
 export interface SymbolInfo {
   symbol: string
   description?: string
   exchange?: string
   source?: string
+  params?: DataSourceParams
 }
 
 // Symbol specification & DataFetcher adapter
@@ -105,6 +108,7 @@ export interface SymbolSpec {
   period?: string
   adjust?: string
   source?: string
+  params?: DataSourceParams
   startDate?: string
   endDate?: string
   /**
@@ -125,6 +129,7 @@ export type DataFetcher = (
     period: string
     adjust: string
     exchange?: string
+    params?: DataSourceParams
   },
 ) => Promise<ReadonlyArray<KLineData>>
 

--- a/packages/core/src/data/__tests__/dataBuffer.test.ts
+++ b/packages/core/src/data/__tests__/dataBuffer.test.ts
@@ -75,6 +75,16 @@ describe('DataBuffer', () => {
     expect(endDate - startDate).toBeLessThanOrEqual(366 * MS_PER_DAY)
   })
 
+  it('passes data source params to the fetcher', async () => {
+    const fetcher = vi.fn<DataFetcher>().mockResolvedValue([makeKLine(Date.now())])
+    buffer.setFetcher(fetcher)
+    buffer.setSymbol({ ...defaultSpec, params: { market: 1 } })
+
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalled())
+
+    expect(fetcher.mock.calls[0]?.[1].params).toEqual({ market: 1 })
+  })
+
   it('ensureRange triggers incremental load when visible range is before loaded window', async () => {
     const now = Date.now()
     const oneYearAgo = now - 365 * MS_PER_DAY

--- a/packages/core/src/data/__tests__/fetcherBaseUrl.test.ts
+++ b/packages/core/src/data/__tests__/fetcherBaseUrl.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  clearFetcherBaseUrlsForTest,
+  composeFetcherBaseUrl,
+  getFetcherBaseUrl,
+  normalizeFetcherBaseUrl,
+  parseFetcherEndpoint,
+  setFetcherBaseUrl,
+} from '../fetcherBaseUrl'
+
+describe('fetcherBaseUrl', () => {
+  afterEach(() => {
+    clearFetcherBaseUrlsForTest()
+  })
+
+  it('normalizes trailing slashes', () => {
+    expect(normalizeFetcherBaseUrl('http://127.0.0.1:8080///')).toBe('http://127.0.0.1:8080')
+  })
+
+  it('falls back when no override is set', () => {
+    expect(getFetcherBaseUrl('gotdx', 'http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080')
+  })
+
+  it('stores and clears runtime overrides', () => {
+    setFetcherBaseUrl('gotdx', 'http://host.test:9000/')
+    expect(getFetcherBaseUrl('gotdx', 'http://127.0.0.1:8080')).toBe('http://host.test:9000')
+
+    setFetcherBaseUrl('gotdx', '')
+    expect(getFetcherBaseUrl('gotdx', 'http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080')
+  })
+
+  it('parses host and port from a base URL', () => {
+    expect(parseFetcherEndpoint('http://127.0.0.1:8080')).toEqual({
+      host: '127.0.0.1',
+      port: '8080',
+    })
+  })
+
+  it('composes a base URL with the fallback protocol', () => {
+    expect(composeFetcherBaseUrl('192.168.1.2', '9000', 'http://127.0.0.1:8080')).toBe(
+      'http://192.168.1.2:9000',
+    )
+  })
+})

--- a/packages/core/src/data/__tests__/fetcherRegistry.test.ts
+++ b/packages/core/src/data/__tests__/fetcherRegistry.test.ts
@@ -5,11 +5,13 @@ import {
   DataFetcher,
   getRegisteredFetcher,
   getRegisteredFetcherNames,
+  fetcherHasCapability,
+  fetcherSupportsSearch,
   fetcherSupportsPeriod,
   clearRegisteredFetchersForTest,
 } from '../fetcherDefinitionRegistry'
-import { routerDataFetcher } from '../router'
-import type { DataFetcherFn } from '../types'
+import { routerDataFetcher, routerSearchFetchers } from '../router'
+import type { DataFetcherFn, SearchFetcherFn, SearchResult } from '../types'
 
 const mockFetch = vi.fn<() => Promise<ReadonlyArray<KLineData>>>()
 
@@ -234,5 +236,137 @@ describe('routerDataFetcher capability check', () => {
       /unknown source "nonexistent"/,
     )
     await expect(routerDataFetcher('nonexistent', defaultConfig)).rejects.toThrow(/baostock/)
+  })
+})
+
+describe('search fetcher registry and router', () => {
+  beforeEach(() => {
+    clearRegisteredFetchersForTest()
+  })
+
+  it('requires both the search capability and a searcher implementation', () => {
+    @DataFetcher({
+      name: 'searchable',
+      displayName: 'Searchable',
+      capabilities: ['daily', 'search'],
+    })
+    class SearchableFetcher {
+      static fetcher = fetchFn
+      static searcher: SearchFetcherFn = async () => []
+    }
+    void SearchableFetcher
+
+    @DataFetcher({ name: 'missing-capability', displayName: 'Missing capability' })
+    class MissingCapabilityFetcher {
+      static fetcher = fetchFn
+      static searcher: SearchFetcherFn = async () => []
+    }
+    void MissingCapabilityFetcher
+
+    expect(fetcherHasCapability('searchable', 'search')).toBe(true)
+    expect(fetcherSupportsSearch('searchable')).toBe(true)
+    expect(fetcherSupportsSearch('missing-capability')).toBe(false)
+  })
+
+  it('aggregates searchable fetchers and removes duplicate results', async () => {
+    @DataFetcher({ name: 'first', displayName: 'First', capabilities: ['search'] })
+    class FirstFetcher {
+      static fetcher = fetchFn
+      static searcher: SearchFetcherFn = async () =>
+        [
+          {
+            symbol: '600519',
+            description: '贵州茅台',
+            exchange: 'SH',
+            source: 'gotdx',
+            params: { market: 1 },
+          },
+        ] as SearchResult[]
+    }
+    void FirstFetcher
+
+    @DataFetcher({ name: 'second', displayName: 'Second', capabilities: ['search'] })
+    class SecondFetcher {
+      static fetcher = fetchFn
+      static searcher: SearchFetcherFn = async () =>
+        [
+          {
+            symbol: '600519',
+            description: '贵州茅台',
+            exchange: 'SH',
+            source: 'gotdx',
+            params: { market: 1 },
+          },
+          {
+            symbol: '00700',
+            description: '腾讯控股',
+            exchange: 'HK',
+            source: 'gotdx',
+            params: { category: 71 },
+          },
+        ] as SearchResult[]
+    }
+    void SecondFetcher
+
+    await expect(routerSearchFetchers({ query: '股', limit: 10 })).resolves.toEqual([
+      {
+        symbol: '600519',
+        description: '贵州茅台',
+        exchange: 'SH',
+        source: 'gotdx',
+        params: { market: 1 },
+      },
+      {
+        symbol: '00700',
+        description: '腾讯控股',
+        exchange: 'HK',
+        source: 'gotdx',
+        params: { category: 71 },
+      },
+    ])
+  })
+
+  it('returns successful results when another searcher fails', async () => {
+    @DataFetcher({ name: 'failed', displayName: 'Failed', capabilities: ['search'] })
+    class FailedFetcher {
+      static fetcher = fetchFn
+      static searcher: SearchFetcherFn = async () => Promise.reject(new Error('offline'))
+    }
+    void FailedFetcher
+
+    @DataFetcher({ name: 'working', displayName: 'Working', capabilities: ['search'] })
+    class WorkingFetcher {
+      static fetcher = fetchFn
+      static searcher: SearchFetcherFn = async () => [
+        {
+          symbol: '000001',
+          description: '平安银行',
+          exchange: 'SZ',
+          source: 'gotdx',
+        },
+      ]
+    }
+    void WorkingFetcher
+
+    await expect(routerSearchFetchers({ query: '平安' })).resolves.toHaveLength(1)
+  })
+
+  it('rejects when every searchable fetcher fails', async () => {
+    @DataFetcher({ name: 'failed', displayName: 'Failed', capabilities: ['search'] })
+    class FailedFetcher {
+      static fetcher = fetchFn
+      static searcher: SearchFetcherFn = async () => Promise.reject(new Error('offline'))
+    }
+    void FailedFetcher
+
+    await expect(routerSearchFetchers({ query: 'test' })).rejects.toThrow(
+      /all search fetchers failed/,
+    )
+  })
+
+  it('rejects when no fetcher supports search', async () => {
+    await expect(routerSearchFetchers({ query: 'test' })).rejects.toThrow(
+      /no registered fetcher supports search/,
+    )
   })
 })

--- a/packages/core/src/data/__tests__/fetcherRegistry.test.ts
+++ b/packages/core/src/data/__tests__/fetcherRegistry.test.ts
@@ -351,6 +351,37 @@ describe('search fetcher registry and router', () => {
     await expect(routerSearchFetchers({ query: '平安' })).resolves.toHaveLength(1)
   })
 
+  it('searches only the explicitly enabled fetchers', async () => {
+    const firstSearch = vi.fn<SearchFetcherFn>().mockResolvedValue([])
+    const secondSearch = vi.fn<SearchFetcherFn>().mockResolvedValue([])
+
+    @DataFetcher({ name: 'first', displayName: 'First', capabilities: ['search'] })
+    class FirstFetcher {
+      static fetcher = fetchFn
+      static searcher = firstSearch
+    }
+    void FirstFetcher
+
+    @DataFetcher({ name: 'second', displayName: 'Second', capabilities: ['search'] })
+    class SecondFetcher {
+      static fetcher = fetchFn
+      static searcher = secondSearch
+    }
+    void SecondFetcher
+
+    await routerSearchFetchers({ query: 'test', sources: ['second'] })
+
+    expect(firstSearch).not.toHaveBeenCalled()
+    expect(secondSearch).toHaveBeenCalledWith('second', {
+      query: 'test',
+      sources: ['second'],
+    })
+  })
+
+  it('returns no results when every search fetcher is disabled', async () => {
+    await expect(routerSearchFetchers({ query: 'test', sources: [] })).resolves.toEqual([])
+  })
+
   it('rejects when every searchable fetcher fails', async () => {
     @DataFetcher({ name: 'failed', displayName: 'Failed', capabilities: ['search'] })
     class FailedFetcher {

--- a/packages/core/src/data/__tests__/gotdx.test.ts
+++ b/packages/core/src/data/__tests__/gotdx.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '../gotdx'
 import { getRegisteredFetcher } from '../fetcherDefinitionRegistry'
@@ -16,6 +16,10 @@ describe('gotdx fetcher', () => {
   beforeEach(() => {
     fetchMock.mockReset()
     vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('declares and implements symbol search', async () => {
@@ -68,6 +72,43 @@ describe('gotdx fetcher', () => {
     const [url, init] = fetchMock.mock.calls[0] ?? []
     expect(url).toBe('http://127.0.0.1:8080/api/stock/kline-by-date')
     expect(JSON.parse(String(init?.body))).toMatchObject({ market: 2, code: '920001' })
+  })
+
+  it('uses the default gotdx API base URL', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+    const definition = getRegisteredFetcher('gotdx')
+
+    await definition?.fetcher('gotdx', {
+      symbol: '600519',
+      period: 'daily',
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+      adjust: 'none',
+      exchange: 'SH',
+      params: { market: 1 },
+    })
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'http://127.0.0.1:8080/api/stock/kline-by-date',
+    )
+  })
+
+  it('uses and normalizes VITE_GOTDX_API_BASE_URL', async () => {
+    vi.stubEnv('VITE_GOTDX_API_BASE_URL', 'http://gotdx.test:9090///')
+    fetchMock.mockResolvedValue(jsonResponse([]))
+    const definition = getRegisteredFetcher('gotdx')
+
+    await definition?.fetcher('gotdx', {
+      symbol: '600519',
+      period: 'daily',
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+      adjust: 'none',
+      exchange: 'SH',
+      params: { market: 1 },
+    })
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('http://gotdx.test:9090/api/stock/kline-by-date')
   })
 
   it('uses params.category for extended-market requests', async () => {

--- a/packages/core/src/data/__tests__/gotdx.test.ts
+++ b/packages/core/src/data/__tests__/gotdx.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '../gotdx'
+import { getRegisteredFetcher } from '../fetcherDefinitionRegistry'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('gotdx fetcher', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  it('declares and implements symbol search', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse([
+        {
+          symbol: '600519',
+          description: '贵州茅台',
+          exchange: 'SH',
+          source: 'gotdx',
+          params: { market: 1 },
+        },
+      ]),
+    )
+    const definition = getRegisteredFetcher('gotdx')
+
+    expect(definition?.capabilities).toContain('search')
+    await expect(definition?.searcher?.('gotdx', { query: '茅台', limit: 12 })).resolves.toEqual([
+      {
+        symbol: '600519',
+        description: '贵州茅台',
+        exchange: 'SH',
+        source: 'gotdx',
+        params: { market: 1 },
+      },
+    ])
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:8080/api/symbol/search',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ query: '茅台', limit: 12 }),
+      }),
+    )
+  })
+
+  it('uses params.market for stock requests', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+    const definition = getRegisteredFetcher('gotdx')
+
+    await definition?.fetcher('gotdx', {
+      symbol: '920001',
+      period: 'daily',
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+      adjust: 'none',
+      exchange: 'BJ',
+      params: { market: 2 },
+    })
+
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe('http://127.0.0.1:8080/api/stock/kline-by-date')
+    expect(JSON.parse(String(init?.body))).toMatchObject({ market: 2, code: '920001' })
+  })
+
+  it('uses params.category for extended-market requests', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]))
+    const definition = getRegisteredFetcher('gotdx')
+
+    await definition?.fetcher('gotdx', {
+      symbol: '00700',
+      period: 'daily',
+      startDate: '2026-01-01',
+      endDate: '2026-01-31',
+      adjust: 'none',
+      exchange: 'HK',
+      params: { category: 31 },
+    })
+
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe('http://127.0.0.1:8080/api/ex/kline-by-date')
+    expect(JSON.parse(String(init?.body))).toMatchObject({ category: 31, code: '00700' })
+  })
+
+  it('wraps search HTTP failures', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'offline' }, 503))
+    const definition = getRegisteredFetcher('gotdx')
+
+    await expect(definition?.searcher?.('gotdx', { query: 'test' })).rejects.toThrow(
+      /symbol search failed: 503/,
+    )
+  })
+})

--- a/packages/core/src/data/__tests__/gotdx.test.ts
+++ b/packages/core/src/data/__tests__/gotdx.test.ts
@@ -132,6 +132,38 @@ describe('gotdx fetcher', () => {
     expect(JSON.parse(String(init?.body))).toMatchObject({ category: 31, code: '00700' })
   })
 
+  it('rejects stock requests without params.market or params.category', async () => {
+    const definition = getRegisteredFetcher('gotdx')
+
+    await expect(
+      definition?.fetcher('gotdx', {
+        symbol: '000001',
+        period: 'daily',
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        adjust: 'none',
+        exchange: 'SZ',
+      }),
+    ).rejects.toThrow(/params\.market or params\.category/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not infer market from exchange alone', async () => {
+    const definition = getRegisteredFetcher('gotdx')
+
+    await expect(
+      definition?.fetcher('gotdx', {
+        symbol: '00700',
+        period: 'daily',
+        startDate: '2026-01-01',
+        endDate: '2026-01-31',
+        adjust: 'none',
+        exchange: 'HK',
+      }),
+    ).rejects.toThrow(/params\.market or params\.category/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('wraps search HTTP failures', async () => {
     fetchMock.mockResolvedValue(jsonResponse({ error: 'offline' }, 503))
     const definition = getRegisteredFetcher('gotdx')

--- a/packages/core/src/data/__tests__/gotdx.test.ts
+++ b/packages/core/src/data/__tests__/gotdx.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '../gotdx'
+import { clearFetcherBaseUrlsForTest, setFetcherBaseUrl } from '../fetcherBaseUrl'
 import { getRegisteredFetcher } from '../fetcherDefinitionRegistry'
 
 const fetchMock = vi.fn<typeof fetch>()
@@ -15,11 +16,12 @@ function jsonResponse(value: unknown, status = 200): Response {
 describe('gotdx fetcher', () => {
   beforeEach(() => {
     fetchMock.mockReset()
+    clearFetcherBaseUrlsForTest()
     vi.stubGlobal('fetch', fetchMock)
   })
 
   afterEach(() => {
-    vi.unstubAllEnvs()
+    clearFetcherBaseUrlsForTest()
   })
 
   it('declares and implements symbol search', async () => {
@@ -93,8 +95,8 @@ describe('gotdx fetcher', () => {
     )
   })
 
-  it('uses and normalizes VITE_GOTDX_API_BASE_URL', async () => {
-    vi.stubEnv('VITE_GOTDX_API_BASE_URL', 'http://gotdx.test:9090///')
+  it('uses runtime base URL override from aggregation source config', async () => {
+    setFetcherBaseUrl('gotdx', 'http://gotdx.test:9090///')
     fetchMock.mockResolvedValue(jsonResponse([]))
     const definition = getRegisteredFetcher('gotdx')
 

--- a/packages/core/src/data/__tests__/timeShareBuffer.test.ts
+++ b/packages/core/src/data/__tests__/timeShareBuffer.test.ts
@@ -42,4 +42,21 @@ describe('TimeShareBuffer', () => {
     expect(buf.loading.peek()).toBe(false)
     buf.dispose()
   })
+
+  it('passes data source params to the fetcher', async () => {
+    const buf = new TimeShareBuffer()
+    const fetcher = vi.fn().mockResolvedValue([point(10)])
+    buf.setFetcher(fetcher)
+    buf.load({
+      symbol: '00700',
+      period: 'timeshare',
+      source: 'gotdx',
+      params: { category: 71 },
+    })
+
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalled())
+
+    expect(fetcher.mock.calls[0]?.[1].params).toEqual({ category: 71 })
+    buf.dispose()
+  })
 })

--- a/packages/core/src/data/baostock.ts
+++ b/packages/core/src/data/baostock.ts
@@ -1,6 +1,7 @@
 import type { KLineData } from '../controllers/types'
 import { KLineChartError } from '../errors'
 
+import { getFetcherBaseUrl } from './fetcherBaseUrl'
 import { DataFetcher } from './fetcherDefinitionRegistry'
 import type { FetchConfig } from './types'
 
@@ -16,7 +17,8 @@ const PERIOD_MAP: Record<string, string> = {
   '60min': '60',
 }
 
-const BASE_URL = 'http://localhost:8000'
+/** BaoStock 本地代理默认地址；运行时由聚合源面板覆盖 */
+const DEFAULT_BASE_URL = 'http://localhost:8000'
 
 async function fetchBaoStock(
   _source: string,
@@ -25,7 +27,8 @@ async function fetchBaoStock(
   console.log(
     `[baostock] fetching ${config.symbol} ${config.period} ${config.startDate}~${config.endDate}`,
   )
-  const url = `${BASE_URL}/api/stock/kdata?stock_code=${config.symbol}&start_date=${config.startDate}&end_date=${config.endDate}&frequency=${PERIOD_MAP[config.period] ?? 'd'}&adjustflag=${ADJUST_MAP[config.adjust] ?? '3'}`
+  const baseUrl = getFetcherBaseUrl('baostock', DEFAULT_BASE_URL)
+  const url = `${baseUrl}/api/stock/kdata?stock_code=${config.symbol}&start_date=${config.startDate}&end_date=${config.endDate}&frequency=${PERIOD_MAP[config.period] ?? 'd'}&adjustflag=${ADJUST_MAP[config.adjust] ?? '3'}`
   try {
     const res = await fetch(url)
     if (!res.ok) {
@@ -61,6 +64,7 @@ async function fetchBaoStock(
   displayName: 'BaoStock',
   description: 'BaoStock data source via local proxy',
   version: '1.0.0',
+  defaultBaseUrl: DEFAULT_BASE_URL,
   capabilities: ['daily', 'weekly', 'monthly', '5min', '15min', '30min', '60min'],
 })
 class BaoStockFetcher {

--- a/packages/core/src/data/dataBuffer.ts
+++ b/packages/core/src/data/dataBuffer.ts
@@ -191,6 +191,7 @@ export class DataBuffer implements KLineBuffer {
                 period: s.period ?? 'daily',
                 adjust: s.adjust ?? 'none',
                 exchange: s.exchange,
+                params: s.params,
               })
             },
             catch: (e) => e,

--- a/packages/core/src/data/fetcherBaseUrl.ts
+++ b/packages/core/src/data/fetcherBaseUrl.ts
@@ -1,0 +1,76 @@
+/**
+ * 数据源运行时 Base URL 覆盖表
+ * 由聚合源管理面板写入，fetch 时按 source name 读取
+ * 无覆盖时回退到 DataFetcher 注册时的 defaultBaseUrl
+ */
+
+const overrides = new Map<string, string>()
+
+/**
+ * 去掉末尾斜杠，保证拼接 path 时不会出现双斜杠
+ */
+export function normalizeFetcherBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, '')
+}
+
+/**
+ * 写入或清除某个数据源的 Base URL
+ * @param name - 注册名，如 gotdx
+ * @param baseUrl - 完整 origin；空字符串表示清除覆盖
+ */
+export function setFetcherBaseUrl(name: string, baseUrl: string | undefined): void {
+  const trimmed = baseUrl?.trim()
+  if (!trimmed) {
+    overrides.delete(name)
+    return
+  }
+  overrides.set(name, normalizeFetcherBaseUrl(trimmed))
+}
+
+/**
+ * 读取数据源当前生效的 Base URL
+ * @param name - 注册名
+ * @param fallback - 无覆盖时使用的默认值（通常来自 definition.defaultBaseUrl）
+ */
+export function getFetcherBaseUrl(name: string, fallback: string): string {
+  return overrides.get(name) ?? normalizeFetcherBaseUrl(fallback)
+}
+
+/**
+ * 从 Base URL 解析 host 与 port，供 UI 分栏编辑
+ */
+export function parseFetcherEndpoint(baseUrl: string): { host: string; port: string } {
+  try {
+    const url = new URL(baseUrl.includes('://') ? baseUrl : `http://${baseUrl}`)
+    return {
+      host: url.hostname,
+      port: url.port,
+    }
+  } catch {
+    return { host: '', port: '' }
+  }
+}
+
+/**
+ * 用 host + port 拼回 Base URL，协议与 fallback 保持一致
+ * @remarks port 为空时不写端口段，由浏览器按协议默认端口处理
+ */
+export function composeFetcherBaseUrl(host: string, port: string, fallbackBaseUrl: string): string {
+  let protocol = 'http:'
+  try {
+    protocol = new URL(
+      fallbackBaseUrl.includes('://') ? fallbackBaseUrl : `http://${fallbackBaseUrl}`,
+    ).protocol
+  } catch {
+    // fallback 非法时仍用 http
+  }
+  const h = host.trim()
+  if (!h) return normalizeFetcherBaseUrl(fallbackBaseUrl)
+  const p = port.trim()
+  return normalizeFetcherBaseUrl(p ? `${protocol}//${h}:${p}` : `${protocol}//${h}`)
+}
+
+/** 测试用：清空全部运行时覆盖 */
+export function clearFetcherBaseUrlsForTest(): void {
+  overrides.clear()
+}

--- a/packages/core/src/data/fetcherDefinitionRegistry.ts
+++ b/packages/core/src/data/fetcherDefinitionRegistry.ts
@@ -4,6 +4,7 @@ import type {
   DataFetcherDefinitionConfig,
   DataFetcherDefinition,
   DataFetcherFn,
+  SearchFetcherFn,
   TimeShareFetcherFn,
 } from './types'
 
@@ -11,6 +12,7 @@ type DataFetcherClass = {
   new (...args: never[]): unknown
   fetcher: DataFetcherFn
   timeShareFetcher?: TimeShareFetcherFn
+  searcher?: SearchFetcherFn
 }
 
 const definitions = new Map<string, DataFetcherDefinition>()
@@ -37,6 +39,7 @@ export function DataFetcher(config: DataFetcherDefinitionConfig) {
         ...config,
         fetcher: this.fetcher,
         timeShareFetcher: this.timeShareFetcher,
+        searcher: this.searcher,
       })
     })
     // 返回原类，不改变类本身
@@ -56,7 +59,7 @@ function getRegisteredFetchers(): DataFetcherDefinition[] {
   return [...definitions.values()]
 }
 
-function fetcherHasCapability(name: string, capability: string): boolean {
+export function fetcherHasCapability(name: string, capability: string): boolean {
   return definitions.get(name)?.capabilities?.includes(capability) ?? false
 }
 
@@ -73,6 +76,15 @@ export function getTimeShareFetcher(name: string): TimeShareFetcherFn | undefine
 
 export function fetcherSupportsTimeShare(name: string): boolean {
   return typeof definitions.get(name)?.timeShareFetcher === 'function'
+}
+
+export function getSearchFetcher(name: string): SearchFetcherFn | undefined {
+  if (!fetcherHasCapability(name, 'search')) return undefined
+  return definitions.get(name)?.searcher
+}
+
+export function fetcherSupportsSearch(name: string): boolean {
+  return typeof getSearchFetcher(name) === 'function'
 }
 
 export function clearRegisteredFetchersForTest(): void {

--- a/packages/core/src/data/fetcherDefinitionRegistry.ts
+++ b/packages/core/src/data/fetcherDefinitionRegistry.ts
@@ -55,7 +55,7 @@ export function getRegisteredFetcherNames(): string[] {
   return [...definitions.keys()]
 }
 
-function getRegisteredFetchers(): DataFetcherDefinition[] {
+export function getRegisteredFetchers(): DataFetcherDefinition[] {
   return [...definitions.values()]
 }
 

--- a/packages/core/src/data/gotdx.ts
+++ b/packages/core/src/data/gotdx.ts
@@ -1,6 +1,7 @@
 import type { KLineData, TimeShareData } from '../controllers/types'
 import { KLineChartError } from '../errors'
 
+import { getFetcherBaseUrl } from './fetcherBaseUrl'
 import { DataFetcher } from './fetcherDefinitionRegistry'
 import type { FetchConfig, SearchConfig, SearchResult, TimeShareFetchConfig } from './types'
 
@@ -31,10 +32,11 @@ const EXCHANGE_EX_CATEGORY: Record<string, number> = {
   DE: 73,
 }
 
+/** GOTDX 本地代理默认地址；运行时由聚合源面板覆盖 */
 const DEFAULT_BASE_URL = 'http://127.0.0.1:8080'
 
 function getBaseUrl(): string {
-  return (import.meta.env.VITE_GOTDX_API_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '')
+  return getFetcherBaseUrl('gotdx', DEFAULT_BASE_URL)
 }
 
 function getShanghaiDateYYYYMMDD(): number {
@@ -245,6 +247,7 @@ async function fetchGotdx(_source: string, config: FetchConfig): Promise<Readonl
   displayName: 'GOTDX',
   description: 'TDX data source via local proxy',
   version: '1.0.0',
+  defaultBaseUrl: DEFAULT_BASE_URL,
   capabilities: [
     '1min',
     '5min',

--- a/packages/core/src/data/gotdx.ts
+++ b/packages/core/src/data/gotdx.ts
@@ -25,13 +25,6 @@ const ADJUST_MAP: Record<string, number> = {
   splits: 0,
 }
 
-const EXCHANGE_EX_CATEGORY: Record<string, number> = {
-  US: 74,
-  HK: 71,
-  SG: 78,
-  DE: 73,
-}
-
 /** GOTDX 本地代理默认地址；运行时由聚合源面板覆盖 */
 const DEFAULT_BASE_URL = 'http://127.0.0.1:8080'
 
@@ -62,14 +55,16 @@ async function fetchGotdxHistoryTick(
   _source: string,
   config: TimeShareFetchConfig,
 ): Promise<ReadonlyArray<TimeShareData>> {
+  // 分时只认搜索/目录带来的 params.market，不按代码前缀猜市场
+  if (typeof config.params?.market !== 'number') {
+    throw new KLineChartError(
+      'FETCH_FAILED',
+      `[gotdx] history-tick requires params.market for ${config.symbol}`,
+    )
+  }
   const body = {
     date: config.date ?? getShanghaiDateYYYYMMDD(),
-    market:
-      typeof config.params?.market === 'number'
-        ? config.params.market
-        : config.symbol.startsWith('6') || config.symbol.startsWith('9')
-          ? 1
-          : 0,
+    market: config.params.market,
     code: config.symbol,
   }
   const res = await fetch(`${getBaseUrl()}/api/stock/history-tick`, {
@@ -179,18 +174,12 @@ function mapExItem(item: ExKLineItem, code: string): KLineData {
 }
 
 async function fetchGotdx(_source: string, config: FetchConfig): Promise<ReadonlyArray<KLineData>> {
+  // 路由只看 params：有 category 走扩展行情，有 market 走 A 股；不做代码/exchange 猜测
   const explicitCategory = config.params?.category
-  if (
-    typeof explicitCategory === 'number' ||
-    (config.exchange && config.exchange in EXCHANGE_EX_CATEGORY)
-  ) {
-    const category =
-      typeof explicitCategory === 'number'
-        ? explicitCategory
-        : EXCHANGE_EX_CATEGORY[config.exchange as string]
+  if (typeof explicitCategory === 'number') {
     const period = PERIOD_TO_CATEGORY[config.period] ?? 4
     const body = {
-      category,
+      category: explicitCategory,
       code: config.symbol,
       period,
       start_date: config.startDate,
@@ -211,14 +200,18 @@ async function fetchGotdx(_source: string, config: FetchConfig): Promise<Readonl
     return list.map((item) => mapExItem(item, config.symbol))
   }
 
-  const market =
-    typeof config.params?.market === 'number'
-      ? config.params.market
-      : config.symbol.startsWith('6') || config.symbol.startsWith('9')
-        ? 1
-        : 0
+  if (typeof config.params?.market !== 'number') {
+    throw new KLineChartError(
+      'FETCH_FAILED',
+      `[gotdx] stock kline requires params.market or params.category for ${config.symbol}`,
+    )
+  }
+  const market = config.params.market
   const category = PERIOD_TO_CATEGORY[config.period] ?? 4
   const adjust = ADJUST_MAP[config.adjust] ?? 0
+  // kind 原样传给胶水层：index → GetIndexBars，stock → StockKLine
+  const kind =
+    typeof config.params.kind === 'string' ? config.params.kind : undefined
   const body = {
     market,
     code: config.symbol,
@@ -227,6 +220,7 @@ async function fetchGotdx(_source: string, config: FetchConfig): Promise<Readonl
     end_date: config.endDate,
     times: 1,
     adjust,
+    ...(kind ? { kind } : {}),
   }
   const res = await fetch(`${getBaseUrl()}/api/stock/kline-by-date`, {
     method: 'POST',

--- a/packages/core/src/data/gotdx.ts
+++ b/packages/core/src/data/gotdx.ts
@@ -31,7 +31,11 @@ const EXCHANGE_EX_CATEGORY: Record<string, number> = {
   DE: 73,
 }
 
-const BASE_URL = 'http://127.0.0.1:8080'
+const DEFAULT_BASE_URL = 'http://127.0.0.1:8080'
+
+function getBaseUrl(): string {
+  return (import.meta.env.VITE_GOTDX_API_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '')
+}
 
 function getShanghaiDateYYYYMMDD(): number {
   const formatter = new Intl.DateTimeFormat('zh-CN', {
@@ -66,7 +70,7 @@ async function fetchGotdxHistoryTick(
           : 0,
     code: config.symbol,
   }
-  const res = await fetch(`${BASE_URL}/api/stock/history-tick`, {
+  const res = await fetch(`${getBaseUrl()}/api/stock/history-tick`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -91,7 +95,7 @@ async function searchGotdx(
   _source: string,
   config: SearchConfig,
 ): Promise<ReadonlyArray<SearchResult>> {
-  const res = await fetch(`${BASE_URL}/api/symbol/search`, {
+  const res = await fetch(`${getBaseUrl()}/api/symbol/search`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query: config.query, limit: config.limit }),
@@ -191,7 +195,7 @@ async function fetchGotdx(_source: string, config: FetchConfig): Promise<Readonl
       end_date: config.endDate,
       times: 1,
     }
-    const res = await fetch(`${BASE_URL}/api/ex/kline-by-date`, {
+    const res = await fetch(`${getBaseUrl()}/api/ex/kline-by-date`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -222,7 +226,7 @@ async function fetchGotdx(_source: string, config: FetchConfig): Promise<Readonl
     times: 1,
     adjust,
   }
-  const res = await fetch(`${BASE_URL}/api/stock/kline-by-date`, {
+  const res = await fetch(`${getBaseUrl()}/api/stock/kline-by-date`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),

--- a/packages/core/src/data/gotdx.ts
+++ b/packages/core/src/data/gotdx.ts
@@ -2,7 +2,7 @@ import type { KLineData, TimeShareData } from '../controllers/types'
 import { KLineChartError } from '../errors'
 
 import { DataFetcher } from './fetcherDefinitionRegistry'
-import type { FetchConfig, TimeShareFetchConfig } from './types'
+import type { FetchConfig, SearchConfig, SearchResult, TimeShareFetchConfig } from './types'
 
 const PERIOD_TO_CATEGORY: Record<string, number> = {
   '1min': 8,
@@ -58,7 +58,12 @@ async function fetchGotdxHistoryTick(
 ): Promise<ReadonlyArray<TimeShareData>> {
   const body = {
     date: config.date ?? getShanghaiDateYYYYMMDD(),
-    market: config.symbol.startsWith('6') || config.symbol.startsWith('9') ? 1 : 0,
+    market:
+      typeof config.params?.market === 'number'
+        ? config.params.market
+        : config.symbol.startsWith('6') || config.symbol.startsWith('9')
+          ? 1
+          : 0,
     code: config.symbol,
   }
   const res = await fetch(`${BASE_URL}/api/stock/history-tick`, {
@@ -80,6 +85,25 @@ async function fetchGotdxHistoryTick(
     volume: item.Vol,
     amount: item.Price * item.Vol,
   }))
+}
+
+async function searchGotdx(
+  _source: string,
+  config: SearchConfig,
+): Promise<ReadonlyArray<SearchResult>> {
+  const res = await fetch(`${BASE_URL}/api/symbol/search`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: config.query, limit: config.limit }),
+    signal: config.signal,
+  })
+  if (!res.ok) {
+    throw new KLineChartError(
+      'FETCH_FAILED',
+      `[gotdx] symbol search failed: ${res.status} ${res.statusText}`,
+    )
+  }
+  return (await res.json()) as ReadonlyArray<SearchResult>
 }
 
 interface SecurityBar {
@@ -149,8 +173,15 @@ function mapExItem(item: ExKLineItem, code: string): KLineData {
 }
 
 async function fetchGotdx(_source: string, config: FetchConfig): Promise<ReadonlyArray<KLineData>> {
-  if (config.exchange && config.exchange in EXCHANGE_EX_CATEGORY) {
-    const category = EXCHANGE_EX_CATEGORY[config.exchange]
+  const explicitCategory = config.params?.category
+  if (
+    typeof explicitCategory === 'number' ||
+    (config.exchange && config.exchange in EXCHANGE_EX_CATEGORY)
+  ) {
+    const category =
+      typeof explicitCategory === 'number'
+        ? explicitCategory
+        : EXCHANGE_EX_CATEGORY[config.exchange as string]
     const period = PERIOD_TO_CATEGORY[config.period] ?? 4
     const body = {
       category,
@@ -174,7 +205,12 @@ async function fetchGotdx(_source: string, config: FetchConfig): Promise<Readonl
     return list.map((item) => mapExItem(item, config.symbol))
   }
 
-  const market = config.symbol.startsWith('6') || config.symbol.startsWith('9') ? 1 : 0
+  const market =
+    typeof config.params?.market === 'number'
+      ? config.params.market
+      : config.symbol.startsWith('6') || config.symbol.startsWith('9')
+        ? 1
+        : 0
   const category = PERIOD_TO_CATEGORY[config.period] ?? 4
   const adjust = ADJUST_MAP[config.adjust] ?? 0
   const body = {
@@ -216,9 +252,11 @@ async function fetchGotdx(_source: string, config: FetchConfig): Promise<Readonl
     'monthly',
     'quarterly',
     'yearly',
+    'search',
   ],
 })
 class GotdxFetcher {
   static fetcher = fetchGotdx
   static timeShareFetcher = fetchGotdxHistoryTick
+  static searcher = searchGotdx
 }

--- a/packages/core/src/data/index.ts
+++ b/packages/core/src/data/index.ts
@@ -8,6 +8,7 @@ export { TimeShareBuffer } from './timeShareBuffer'
 export type { DataBufferLike } from './dataBufferTypes'
 export {
   getRegisteredFetcher,
+  getRegisteredFetchers,
   getRegisteredFetcherNames,
   getTimeShareFetcher,
   getSearchFetcher,
@@ -15,12 +16,21 @@ export {
   fetcherSupportsSearch,
   fetcherSupportsTimeShare,
 } from './fetcherDefinitionRegistry'
+export {
+  clearFetcherBaseUrlsForTest,
+  composeFetcherBaseUrl,
+  getFetcherBaseUrl,
+  normalizeFetcherBaseUrl,
+  parseFetcherEndpoint,
+  setFetcherBaseUrl,
+} from './fetcherBaseUrl'
 export type {
   SearchConfig,
   SearchFetcherFn,
   SearchResult,
   TimeShareFetcherFn,
   TimeShareFetchConfig,
+  DataFetcherDefinition,
 } from './types'
 export {
   getPeriodDays,

--- a/packages/core/src/data/index.ts
+++ b/packages/core/src/data/index.ts
@@ -1,7 +1,7 @@
 export { hundredMockDataFetcher } from './hundred-mock'
 export { thousandMockDataFetcher } from './thousand-mock'
 export { baostockDataFetcher } from './baostock'
-export { routerDataFetcher, routerTimeShareFetcher } from './router'
+export { routerDataFetcher, routerSearchFetchers, routerTimeShareFetcher } from './router'
 export { DataBuffer } from './dataBuffer'
 export type { DataWindow } from './dataBufferTypes'
 export { TimeShareBuffer } from './timeShareBuffer'
@@ -10,9 +10,18 @@ export {
   getRegisteredFetcher,
   getRegisteredFetcherNames,
   getTimeShareFetcher,
+  getSearchFetcher,
+  fetcherHasCapability,
+  fetcherSupportsSearch,
   fetcherSupportsTimeShare,
 } from './fetcherDefinitionRegistry'
-export type { TimeShareFetcherFn, TimeShareFetchConfig } from './types'
+export type {
+  SearchConfig,
+  SearchFetcherFn,
+  SearchResult,
+  TimeShareFetcherFn,
+  TimeShareFetchConfig,
+} from './types'
 export {
   getPeriodDays,
   fetchKLine,

--- a/packages/core/src/data/router.ts
+++ b/packages/core/src/data/router.ts
@@ -57,10 +57,12 @@ function searchResultKey(result: SearchResult): string {
 export async function routerSearchFetchers(
   config: SearchConfig,
 ): Promise<ReadonlyArray<SearchResult>> {
-  const searchers = getRegisteredFetcherNames().flatMap((source) => {
+  const sourceNames = config.sources ? [...new Set(config.sources)] : getRegisteredFetcherNames()
+  const searchers = sourceNames.flatMap((source) => {
     const searcher = getSearchFetcher(source)
     return searcher ? [{ source, searcher }] : []
   })
+  if (config.sources && searchers.length === 0) return []
   if (searchers.length === 0) {
     throw new KLineChartError('FETCH_FAILED', '[DataFetcher] no registered fetcher supports search')
   }

--- a/packages/core/src/data/router.ts
+++ b/packages/core/src/data/router.ts
@@ -6,8 +6,9 @@ import {
   fetcherSupportsPeriod,
   getTimeShareFetcher,
   getRegisteredFetcherNames,
+  getSearchFetcher,
 } from './fetcherDefinitionRegistry'
-import type { TimeShareFetcherFn } from './types'
+import type { SearchConfig, SearchResult, TimeShareFetcherFn } from './types'
 
 export const routerDataFetcher: DataFetcher = (source, config) => {
   const def = getRegisteredFetcher(source)
@@ -44,4 +45,44 @@ export const routerTimeShareFetcher: TimeShareFetcherFn = (source, config) => {
     )
   }
   return fetcher(source, config)
+}
+
+function searchResultKey(result: SearchResult): string {
+  const params = Object.entries(result.params ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )
+  return JSON.stringify([result.source, result.exchange, result.symbol, params])
+}
+
+export async function routerSearchFetchers(
+  config: SearchConfig,
+): Promise<ReadonlyArray<SearchResult>> {
+  const searchers = getRegisteredFetcherNames().flatMap((source) => {
+    const searcher = getSearchFetcher(source)
+    return searcher ? [{ source, searcher }] : []
+  })
+  if (searchers.length === 0) {
+    throw new KLineChartError('FETCH_FAILED', '[DataFetcher] no registered fetcher supports search')
+  }
+
+  const settled = await Promise.allSettled(
+    searchers.map(({ source, searcher }) => searcher(source, config)),
+  )
+  const successful = settled.filter(
+    (result): result is PromiseFulfilledResult<ReadonlyArray<SearchResult>> =>
+      result.status === 'fulfilled',
+  )
+  if (successful.length === 0) {
+    throw new KLineChartError('FETCH_FAILED', '[DataFetcher] all search fetchers failed')
+  }
+
+  const limit = config.limit === undefined ? Number.POSITIVE_INFINITY : Math.max(0, config.limit)
+  const unique = new Map<string, SearchResult>()
+  for (const result of successful) {
+    for (const item of result.value) {
+      const key = searchResultKey(item)
+      if (!unique.has(key)) unique.set(key, item)
+    }
+  }
+  return [...unique.values()].slice(0, limit)
 }

--- a/packages/core/src/data/timeShareBuffer.ts
+++ b/packages/core/src/data/timeShareBuffer.ts
@@ -102,6 +102,7 @@ export class TimeShareBuffer implements DataBufferLike {
           return fetcher(s.source ?? 'gotdx', {
             symbol: s.symbol,
             exchange: s.exchange,
+            params: s.params,
             date,
           })
         }),

--- a/packages/core/src/data/tradingview.ts
+++ b/packages/core/src/data/tradingview.ts
@@ -1,6 +1,7 @@
 import type { KLineData } from '../controllers/types'
 import { KLineChartError } from '../errors'
 
+import { getFetcherBaseUrl } from './fetcherBaseUrl'
 import { DataFetcher } from './fetcherDefinitionRegistry'
 import type { FetchConfig } from './types'
 
@@ -20,7 +21,8 @@ const ADJUST_TO_TV: Record<string, string | undefined> = {
   none: 'none',
 }
 
-const BASE_URL = 'http://localhost:8000'
+/** TradingView 本地代理默认地址；运行时由聚合源面板覆盖 */
+const DEFAULT_BASE_URL = 'http://localhost:8000'
 
 async function fetchTradingview(
   _source: string,
@@ -32,7 +34,8 @@ async function fetchTradingview(
   const tvAdjust = ADJUST_TO_TV[config.adjust]
   const exchangeQ = config.exchange ? `&exchange=${config.exchange}` : ''
   const adjustQ = tvAdjust ? `&adjust=${tvAdjust}` : ''
-  const url = `${BASE_URL}/api/tradingview/kdata?symbol=${config.symbol}&timeframe=${timeframe}&start_date=${startDate}&end_date=${endDate}${exchangeQ}${adjustQ}`
+  const baseUrl = getFetcherBaseUrl('tradingview', DEFAULT_BASE_URL)
+  const url = `${baseUrl}/api/tradingview/kdata?symbol=${config.symbol}&timeframe=${timeframe}&start_date=${startDate}&end_date=${endDate}${exchangeQ}${adjustQ}`
   try {
     const res = await fetch(url)
     if (!res.ok) {
@@ -69,6 +72,7 @@ async function fetchTradingview(
   displayName: 'TradingView',
   description: 'TradingView-style data source via local proxy',
   version: '1.0.0',
+  defaultBaseUrl: DEFAULT_BASE_URL,
   capabilities: ['daily', 'weekly', 'monthly', '5min', '15min', '30min', '60min'],
 })
 class TradingviewFetcher {

--- a/packages/core/src/data/types.ts
+++ b/packages/core/src/data/types.ts
@@ -32,6 +32,7 @@ export interface SearchConfig {
   query: string
   limit?: number
   signal?: AbortSignal
+  sources?: ReadonlyArray<string>
 }
 
 export interface SearchResult {
@@ -53,6 +54,11 @@ export interface DataFetcherDefinitionConfig {
   description?: string
   version?: string
   capabilities?: string[]
+  /**
+   * 网络数据源的默认 Base URL
+   * 有此字段时聚合源面板可编辑地址与端口；本地 mock 等无网络源不填
+   */
+  defaultBaseUrl?: string
 }
 
 export interface DataFetcherDefinition extends DataFetcherDefinitionConfig {

--- a/packages/core/src/data/types.ts
+++ b/packages/core/src/data/types.ts
@@ -1,4 +1,4 @@
-import type { KLineData, TimeShareData } from '../controllers/types'
+import type { DataSourceParams, KLineData, TimeShareData } from '../controllers/types'
 
 export type FetchConfig = {
   symbol: string
@@ -7,11 +7,13 @@ export type FetchConfig = {
   period: string
   adjust: string
   exchange?: string
+  params?: DataSourceParams
 }
 
 export type TimeShareFetchConfig = {
   symbol: string
   exchange?: string
+  params?: DataSourceParams
   /** YYYYMMDD format query date, e.g. 20260618 */
   date?: number
 }
@@ -26,6 +28,25 @@ export type TimeShareFetcherFn = (
   config: TimeShareFetchConfig,
 ) => Promise<ReadonlyArray<TimeShareData>>
 
+export interface SearchConfig {
+  query: string
+  limit?: number
+  signal?: AbortSignal
+}
+
+export interface SearchResult {
+  symbol: string
+  description: string
+  exchange: string
+  source: string
+  params?: DataSourceParams
+}
+
+export type SearchFetcherFn = (
+  source: string,
+  config: SearchConfig,
+) => Promise<ReadonlyArray<SearchResult>>
+
 export interface DataFetcherDefinitionConfig {
   name: string
   displayName: string
@@ -37,4 +58,5 @@ export interface DataFetcherDefinitionConfig {
 export interface DataFetcherDefinition extends DataFetcherDefinitionConfig {
   fetcher: DataFetcherFn
   timeShareFetcher?: TimeShareFetcherFn
+  searcher?: SearchFetcherFn
 }

--- a/packages/core/src/engine/data/__tests__/comparisonManager.test.ts
+++ b/packages/core/src/engine/data/__tests__/comparisonManager.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { SymbolSpec } from '../../../controllers/types'
-import { ComparisonManager } from '../comparisonManager'
+import { comparisonBufferKey, ComparisonManager } from '../comparisonManager'
 
 function createHarness() {
   let specs: ReadonlyArray<SymbolSpec> = []
@@ -16,7 +16,7 @@ function createHarness() {
     }
   >()
   const createComparisonBuffer = vi.fn((spec: SymbolSpec) => {
-    const key = `cmp:${spec.symbol}:${spec.period ?? 'daily'}`
+    const key = comparisonBufferKey(spec)
     const buffer = {
       loading: { peek: () => false, subscribe: () => () => {} },
       data: { subscribe: () => () => {} },
@@ -68,7 +68,20 @@ describe('ComparisonManager runtime projection', () => {
     harness.manager.reconcile()
 
     expect(harness.createComparisonBuffer).toHaveBeenCalledTimes(1)
-    expect([...harness.buffers.keys()]).toEqual(['cmp:A:daily'])
+    expect([...harness.buffers.keys()]).toEqual([comparisonBufferKey({ symbol: 'A', period: 'daily' })])
+  })
+
+  it('keeps separate buffers for the same code from different exchanges', () => {
+    const harness = createHarness()
+    harness.setSpecs([
+      { symbol: '000001', exchange: 'SH', source: 'gotdx', period: 'daily', params: { market: 1 } },
+      { symbol: '000001', exchange: 'SZ', source: 'gotdx', period: 'daily', params: { market: 0 } },
+    ])
+
+    harness.manager.reconcile()
+
+    expect(harness.createComparisonBuffer).toHaveBeenCalledTimes(2)
+    expect(harness.buffers.size).toBe(2)
   })
 
   it('removes runtime buffers that are absent from desired specs', () => {
@@ -82,7 +95,7 @@ describe('ComparisonManager runtime projection', () => {
     harness.setSpecs([{ symbol: 'B', period: 'daily' }])
     harness.manager.reconcile()
 
-    expect([...harness.buffers.keys()]).toEqual(['cmp:B:daily'])
+    expect([...harness.buffers.keys()]).toEqual([comparisonBufferKey({ symbol: 'B', period: 'daily' })])
     expect(harness.manager.specs).toEqual([{ symbol: 'B', period: 'daily' }])
   })
 
@@ -93,7 +106,9 @@ describe('ComparisonManager runtime projection', () => {
     harness.setSpecs([{ symbol: 'A', period: 'daily' }])
     harness.manager.reconcile()
     expect(harness.manager.setData('A', [])).toBe(true)
-    expect(harness.buffers.get('cmp:A:daily')?.setInlineData).toHaveBeenCalledWith([])
+    expect(
+      harness.buffers.get(comparisonBufferKey({ symbol: 'A', period: 'daily' }))?.setInlineData,
+    ).toHaveBeenCalledWith([])
   })
 
   it('clearAll only clears runtime resources and loading', () => {

--- a/packages/core/src/engine/data/__tests__/fetchBatchScheduler.test.ts
+++ b/packages/core/src/engine/data/__tests__/fetchBatchScheduler.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { DataFetcher } from '../../../controllers/types'
+import { FetchBatchScheduler } from '../fetchBatchScheduler'
+
+describe('FetchBatchScheduler', () => {
+  it('passes data source params to the fetcher', async () => {
+    const fetcher = vi.fn<DataFetcher>().mockResolvedValue([])
+    const scheduler = new FetchBatchScheduler()
+    scheduler.setFetcher(fetcher)
+
+    await scheduler.createHandler()(
+      {
+        symbol: '00700',
+        source: 'gotdx',
+        period: 'daily',
+        params: { category: 71 },
+      },
+      Date.UTC(2026, 0, 1),
+      Date.UTC(2026, 0, 2),
+    )
+
+    expect(fetcher.mock.calls[0]?.[1].params).toEqual({ category: 71 })
+  })
+})

--- a/packages/core/src/engine/data/chartDataManager.ts
+++ b/packages/core/src/engine/data/chartDataManager.ts
@@ -14,10 +14,11 @@ import type { DataManagerStateModule } from '../state/dataManagerState'
 import type { ViewportStateModule } from '../state/viewportState'
 import type { ComparisonStateModule } from '../state/comparisonState'
 
-import { ComparisonManager } from './comparisonManager'
+import { comparisonBufferKey, ComparisonManager } from './comparisonManager'
 import { FetchBatchScheduler } from './fetchBatchScheduler'
 import { IncrementalLoadHint } from './incrementalLoadHint'
 import { ScrollCompensator } from './scrollCompensator'
+import { symbolSpecIdentityKey } from './symbolIdentity'
 
 export interface DataDependencies {
   getOption: () => { kWidth: number; kGap: number }
@@ -246,7 +247,7 @@ export class ChartDataManager {
   }
 
   private _createCmpBuffer(spec: SymbolSpec): { key: string; buffer: KLineBuffer } {
-    const key = bufKey(BUF_COMPARISON, spec.symbol, spec.period)
+    const key = comparisonBufferKey(spec)
     const buffer = this._createKLineBuffer()
     buffer.setFetcher(this._dataFetcher)
     if (this._dataFetcher) {
@@ -603,7 +604,12 @@ export class ChartDataManager {
 
   addComparisonSymbol(spec: SymbolSpec): void {
     const primary = this._dataState.readonly.symbols.peek()[0]
-    if (!primary || this.deps.comparison.readonly.specs.peek().some((item) => item.symbol === spec.symbol))
+    if (
+      !primary ||
+      this.deps.comparison.readonly.specs
+        .peek()
+        .some((item) => symbolSpecIdentityKey(item) === symbolSpecIdentityKey(spec))
+    )
       return
     this.deps.setSymbols([primary, ...this.deps.comparison.readonly.specs.peek(), spec])
   }
@@ -621,13 +627,15 @@ export class ChartDataManager {
     this._comparisonManager.setData(symbol, data)
   }
 
-  removeComparisonSymbol(symbol: string): void {
+  removeComparisonSymbol(identity: string): void {
     const primary = this._dataState.readonly.symbols.peek()[0]
-    if (!primary || !this.deps.comparison.readonly.specs.peek().some((spec) => spec.symbol === symbol))
+    const matches = (spec: SymbolSpec) =>
+      symbolSpecIdentityKey(spec) === identity || spec.symbol === identity
+    if (!primary || !this.deps.comparison.readonly.specs.peek().some(matches))
       return
     this.deps.setSymbols([
       primary,
-      ...this.deps.comparison.readonly.specs.peek().filter((spec) => spec.symbol !== symbol),
+      ...this.deps.comparison.readonly.specs.peek().filter((spec) => !matches(spec)),
     ])
     this.deps.scheduleDraw()
   }

--- a/packages/core/src/engine/data/comparisonManager.ts
+++ b/packages/core/src/engine/data/comparisonManager.ts
@@ -1,10 +1,12 @@
 import type { KLineData, SymbolSpec } from '../../controllers/types'
 import type { KLineBuffer } from '../../data/dataBufferTypes'
 
+import { symbolSpecIdentityKey } from './symbolIdentity'
+
 const BUF_COMPARISON = 'cmp:'
 
-function comparisonKey(spec: SymbolSpec): string {
-  return `cmp:${spec.symbol}:${spec.period ?? 'daily'}`
+export function comparisonBufferKey(spec: SymbolSpec): string {
+  return `cmp:${symbolSpecIdentityKey(spec)}:${spec.period ?? 'daily'}`
 }
 
 function specsEqual(left: SymbolSpec | undefined, right: SymbolSpec): boolean {
@@ -45,15 +47,15 @@ export class ComparisonManager {
   get data(): Map<string, KLineData[]> {
     const result = new Map<string, KLineData[]>()
     for (const spec of this.hooks.getSpecs()) {
-      const buffer = this.hooks.getKLineBuffer(comparisonKey(spec))
-      if (buffer) result.set(spec.symbol, [...buffer.getRawData()])
+      const buffer = this.hooks.getKLineBuffer(comparisonBufferKey(spec))
+      if (buffer) result.set(symbolSpecIdentityKey(spec), [...buffer.getRawData()])
     }
     return result
   }
 
   reconcile(mainEarliest?: number): void {
     const specs = this.hooks.getSpecs()
-    const desired = new Map(specs.map((spec) => [comparisonKey(spec), spec]))
+    const desired = new Map(specs.map((spec) => [comparisonBufferKey(spec), spec]))
 
     for (const key of this.hooks.getKLineBufferKeys()) {
       if (key.startsWith(BUF_COMPARISON) && !desired.has(key)) this.removeRuntime(key)
@@ -87,13 +89,15 @@ export class ComparisonManager {
     this.hooks.setLoading(false)
   }
 
-  setData(symbol: string, data: KLineData[]): boolean {
-    const spec = this.hooks.getSpecs().find((candidate) => candidate.symbol === symbol)
+  setData(identity: string, data: KLineData[]): boolean {
+    const spec = this.hooks
+      .getSpecs()
+      .find((candidate) => symbolSpecIdentityKey(candidate) === identity || candidate.symbol === identity)
     if (!spec) return false
-    let buffer = this.hooks.getKLineBuffer(comparisonKey(spec))
+    let buffer = this.hooks.getKLineBuffer(comparisonBufferKey(spec))
     if (!buffer) {
       this.reconcile()
-      buffer = this.hooks.getKLineBuffer(comparisonKey(spec))
+      buffer = this.hooks.getKLineBuffer(comparisonBufferKey(spec))
     }
     if (!buffer) return false
     buffer.setInlineData(data)
@@ -102,7 +106,9 @@ export class ComparisonManager {
 
   ensureRange(firstVisibleTs: number, windowEarliestTs: number): void {
     for (const spec of this.hooks.getSpecs()) {
-      this.hooks.getKLineBuffer(comparisonKey(spec))?.ensureRange(firstVisibleTs, windowEarliestTs)
+      this.hooks
+        .getKLineBuffer(comparisonBufferKey(spec))
+        ?.ensureRange(firstVisibleTs, windowEarliestTs)
     }
   }
 
@@ -123,7 +129,7 @@ export class ComparisonManager {
   private recomputeLoading(): void {
     const anyLoading = this.hooks
       .getSpecs()
-      .some((spec) => this.hooks.getKLineBuffer(comparisonKey(spec))?.loading.peek() === true)
+      .some((spec) => this.hooks.getKLineBuffer(comparisonBufferKey(spec))?.loading.peek() === true)
     this.hooks.setLoading(anyLoading)
   }
 }

--- a/packages/core/src/engine/data/fetchBatchScheduler.ts
+++ b/packages/core/src/engine/data/fetchBatchScheduler.ts
@@ -74,6 +74,7 @@ export class FetchBatchScheduler {
             period: spec.period ?? 'daily',
             adjust: spec.adjust ?? 'none',
             exchange: spec.exchange,
+            params: spec.params,
           }).then(resolve, reject),
         ),
       )

--- a/packages/core/src/engine/data/symbolIdentity.ts
+++ b/packages/core/src/engine/data/symbolIdentity.ts
@@ -1,0 +1,12 @@
+import type { DataSourceParams, SymbolSpec } from '../../controllers/types'
+
+type SymbolIdentity = Pick<SymbolSpec, 'source' | 'exchange' | 'symbol'> & {
+  params?: DataSourceParams
+}
+
+export function symbolSpecIdentityKey(spec: SymbolIdentity): string {
+  const params = Object.entries(spec.params ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )
+  return JSON.stringify([spec.source ?? '', spec.exchange ?? '', spec.symbol, params])
+}

--- a/packages/core/src/engine/renderers/comparisonLine.ts
+++ b/packages/core/src/engine/renderers/comparisonLine.ts
@@ -1,6 +1,7 @@
 import type { RendererPlugin, RenderContext } from '../../foundation/plugin/index'
 import { RENDERER_PRIORITY } from '../../foundation/plugin/index'
 import type { KLineData } from '../../foundation/types/price'
+import { symbolSpecIdentityKey } from '../data/symbolIdentity'
 
 const DEFAULT_COMPARISON_COLOR = '#f59e0b'
 
@@ -34,7 +35,8 @@ export function createComparisonLineRenderer(): RendererPlugin {
 
       for (let symbolIndex = 0; symbolIndex < comparisonSymbols.length; symbolIndex++) {
         const spec = comparisonSymbols[symbolIndex]!
-        const data = comparisonData.get(spec.symbol)
+        const identity = symbolSpecIdentityKey(spec)
+        const data = comparisonData.get(identity)
         if (!data?.length) continue
 
         const baseline = baseDate
@@ -51,7 +53,7 @@ export function createComparisonLineRenderer(): RendererPlugin {
         const colors = context.comparisonColors
 
         ctx.beginPath()
-        ctx.strokeStyle = colors?.get(spec.symbol) ?? DEFAULT_COMPARISON_COLOR
+        ctx.strokeStyle = colors?.get(identity) ?? DEFAULT_COMPARISON_COLOR
         let hasPath = false
         let previousHadPoint = false
 

--- a/packages/core/src/engine/state/__tests__/comparisonState.test.ts
+++ b/packages/core/src/engine/state/__tests__/comparisonState.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { createSignal } from '../../../foundation/reactivity/signal'
+import { symbolSpecIdentityKey } from '../../data/symbolIdentity'
 import { ChartStateKernel } from '../chartStateKernel'
 import { createComparisonState } from '../comparisonState'
 
@@ -98,7 +99,11 @@ describe('ChartStateKernel comparison selection transaction', () => {
 
     expect(snapshots.length).toBeGreaterThan(0)
     expect(snapshots).toEqual(
-      snapshots.map(() => ({ symbols: ['MAIN', 'CMP'], specs: ['CMP'], colors: ['CMP'] })),
+      snapshots.map(() => ({
+        symbols: ['MAIN', 'CMP'],
+        specs: ['CMP'],
+        colors: [symbolSpecIdentityKey({ symbol: 'CMP', period: 'daily' })],
+      })),
     )
   })
 })

--- a/packages/core/src/engine/state/comparisonState.ts
+++ b/packages/core/src/engine/state/comparisonState.ts
@@ -5,6 +5,7 @@ import {
   type ReadonlySignal,
 } from '../../foundation/reactivity/signal'
 import type { SymbolSpec } from '../../controllers/types'
+import { symbolSpecIdentityKey } from '../data/symbolIdentity'
 import { immutableMap } from './immutable'
 
 const COMPARISON_PALETTE = ['#f59e0b', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16', '#f97316']
@@ -50,8 +51,8 @@ export function createComparisonState(deps?: ComparisonStateDeps) {
         const next = new Map<string, string>()
         for (const spec of specs) {
           next.set(
-            spec.symbol,
-            prev.get(spec.symbol) ??
+            symbolSpecIdentityKey(spec),
+            prev.get(symbolSpecIdentityKey(spec)) ??
               COMPARISON_PALETTE[next.size % COMPARISON_PALETTE.length] ??
               DEFAULT_COMPARISON_COLOR,
           )

--- a/packages/vue/src/components/AggregationSourceButton.vue
+++ b/packages/vue/src/components/AggregationSourceButton.vue
@@ -1,0 +1,45 @@
+<template>
+  <button
+    type="button"
+    class="source-button"
+    title="管理聚合源"
+    aria-label="管理聚合源"
+    @click.stop="emit('click')"
+  >
+    <IconTablerAdjustmentsHorizontal aria-hidden="true" />
+  </button>
+</template>
+
+<script setup lang="ts">
+  import IconTablerAdjustmentsHorizontal from '~icons/tabler/adjustments-horizontal'
+
+  const emit = defineEmits<{ click: [] }>()
+</script>
+
+<style scoped>
+  .source-button {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--klc-color-axis-text);
+    cursor: pointer;
+  }
+
+  .source-button:hover {
+    border-color: var(--klc-color-axis-line);
+    background: var(--klc-color-grid-minor);
+    color: var(--klc-color-foreground);
+  }
+
+  .source-button svg {
+    width: 15px;
+    height: 15px;
+  }
+</style>

--- a/packages/vue/src/components/AggregationSourceDialog.vue
+++ b/packages/vue/src/components/AggregationSourceDialog.vue
@@ -1,0 +1,381 @@
+<template>
+  <BaseModal
+    :show="show"
+    title="聚合源管理"
+    subtitle="启用搜索源，并配置地址与端口"
+    width="min(92vw, 480px)"
+    body-padding="8px"
+    :z-index="zIndex"
+    transition-variant="compact"
+    @close="emit('close')"
+  >
+    <div class="source-list">
+      <div
+        v-for="source in orderedSources"
+        :key="source.name"
+        class="source-item"
+        :class="{ 'is-disabled': !supportsSearch(source) && !isConfigurable(source) }"
+      >
+        <div class="source-item__main">
+          <span class="source-item__content">
+            <span class="source-item__heading">
+              <span class="source-item__name">{{ source.displayName }}</span>
+              <span class="source-item__id">{{ source.name }}</span>
+            </span>
+            <span class="source-item__description">
+              {{ sourceDescription(source) }}
+            </span>
+          </span>
+          <span
+            v-if="supportsSearch(source)"
+            class="source-status"
+            :class="`is-${sourceStatuses[source.name] ?? 'checking'}`"
+          >
+            <span class="source-status__dot" aria-hidden="true" />
+            {{ statusText(sourceStatuses[source.name] ?? 'checking') }}
+          </span>
+          <!-- 仅支持搜索的源可参与聚合开关；无 search 的网络源只改地址 -->
+          <ToggleSwitch
+            v-if="supportsSearch(source)"
+            :model-value="enabledNames.has(source.name)"
+            :aria-label="`${source.displayName} 聚合搜索`"
+            @update:model-value="emit('toggle', source.name, $event)"
+          />
+        </div>
+
+        <!-- 地址/端口默认折叠，样式与图表设置 CollapsibleSection 共用 -->
+        <CollapsibleSection
+          v-if="isConfigurable(source)"
+          label="地址与端口"
+          :expanded="Boolean(expandedEndpoints[source.name])"
+          @toggle="toggleEndpoint(source.name)"
+        >
+          <div class="source-endpoint" @click.stop>
+            <label class="source-endpoint__field">
+              <span class="source-endpoint__label">地址</span>
+              <input
+                class="source-endpoint__input"
+                type="text"
+                :value="endpoints[source.name]?.host ?? ''"
+                :placeholder="defaultHost(source)"
+                autocomplete="off"
+                spellcheck="false"
+                :aria-label="`${source.displayName} 地址`"
+                @input="onHostInput(source.name, $event)"
+              />
+            </label>
+            <label class="source-endpoint__field source-endpoint__field--port">
+              <span class="source-endpoint__label">端口</span>
+              <input
+                class="source-endpoint__input"
+                type="text"
+                inputmode="numeric"
+                :value="endpoints[source.name]?.port ?? ''"
+                :placeholder="defaultPort(source)"
+                autocomplete="off"
+                spellcheck="false"
+                :aria-label="`${source.displayName} 端口`"
+                @input="onPortInput(source.name, $event)"
+              />
+            </label>
+          </div>
+        </CollapsibleSection>
+      </div>
+    </div>
+  </BaseModal>
+</template>
+
+<script setup lang="ts">
+  import {
+    parseFetcherEndpoint,
+    type DataFetcherDefinition,
+  } from '@363045841yyt/klinechart-core/controllers'
+  import { computed, onBeforeUnmount, ref, watch } from 'vue'
+
+  import {
+    probeAggregationSource,
+    type AggregationSourceEndpoint,
+    type AggregationSourceStatus,
+  } from '../composables/useAggregationSources'
+
+  import BaseModal from './BaseModal.vue'
+  import CollapsibleSection from './common/CollapsibleSection.vue'
+  import ToggleSwitch from './common/ToggleSwitch.vue'
+
+  const props = withDefaults(
+    defineProps<{
+      show: boolean
+      sources: ReadonlyArray<DataFetcherDefinition>
+      enabledNames: ReadonlySet<string>
+      /** source name -> host/port 草稿 */
+      endpoints: Record<string, AggregationSourceEndpoint>
+      /** 嵌套在图表设置内时抬高层级 */
+      zIndex?: number
+    }>(),
+    {
+      zIndex: 1000,
+    },
+  )
+
+  const emit = defineEmits<{
+    close: []
+    toggle: [name: string, enabled: boolean]
+    /** 地址或端口变更 */
+    updateEndpoint: [name: string, patch: Partial<AggregationSourceEndpoint>]
+  }>()
+
+  const sourceStatuses = ref<Record<string, AggregationSourceStatus>>({})
+  /** 每个源的地址区块展开状态；默认全部收起 */
+  const expandedEndpoints = ref<Record<string, boolean>>({})
+  let probeController: AbortController | undefined
+  let probeRequestId = 0
+
+  /** mock 源沉底，网络源排在前面 */
+  const orderedSources = computed(() => {
+    const list = [...props.sources]
+    return list.sort((a, b) => Number(isMockSource(a)) - Number(isMockSource(b)))
+  })
+
+  function isMockSource(source: DataFetcherDefinition): boolean {
+    return source.name.startsWith('mock-')
+  }
+
+  function supportsSearch(source: DataFetcherDefinition): boolean {
+    return source.capabilities?.includes('search') === true && typeof source.searcher === 'function'
+  }
+
+  /** 是否可在面板里改地址/端口 */
+  function isConfigurable(source: DataFetcherDefinition): boolean {
+    return Boolean(source.defaultBaseUrl)
+  }
+
+  function sourceDescription(source: DataFetcherDefinition): string {
+    if (supportsSearch(source)) return source.description || '可用于聚合搜索'
+    if (isConfigurable(source)) return source.description || '可配置地址'
+    return '不支持搜索'
+  }
+
+  function statusText(status: AggregationSourceStatus): string {
+    if (status === 'online') return '在线'
+    if (status === 'offline') return '离线'
+    return '检测中'
+  }
+
+  function defaultHost(source: DataFetcherDefinition): string {
+    return source.defaultBaseUrl ? parseFetcherEndpoint(source.defaultBaseUrl).host : ''
+  }
+
+  function defaultPort(source: DataFetcherDefinition): string {
+    return source.defaultBaseUrl ? parseFetcherEndpoint(source.defaultBaseUrl).port : ''
+  }
+
+  function toggleEndpoint(name: string) {
+    expandedEndpoints.value = {
+      ...expandedEndpoints.value,
+      [name]: !expandedEndpoints.value[name],
+    }
+  }
+
+  function onHostInput(name: string, event: Event) {
+    emit('updateEndpoint', name, { host: (event.target as HTMLInputElement).value })
+  }
+
+  function onPortInput(name: string, event: Event) {
+    emit('updateEndpoint', name, { port: (event.target as HTMLInputElement).value })
+  }
+
+  /** 弹窗打开时对可搜索源并发拨测；关闭时取消 */
+  async function probeSources() {
+    probeController?.abort()
+    const controller = new AbortController()
+    probeController = controller
+    const requestId = ++probeRequestId
+    const searchableSources = props.sources.filter(supportsSearch)
+    sourceStatuses.value = Object.fromEntries(
+      searchableSources.map((source) => [source.name, 'checking' as const]),
+    )
+    const timeout = setTimeout(() => controller.abort(), 5000)
+
+    await Promise.all(
+      searchableSources.map(async (source) => {
+        const status = await probeAggregationSource(source, controller.signal)
+        if (requestId !== probeRequestId) return
+        sourceStatuses.value = { ...sourceStatuses.value, [source.name]: status }
+      }),
+    )
+    clearTimeout(timeout)
+    if (requestId === probeRequestId) probeController = undefined
+  }
+
+  watch(
+    () => props.show,
+    (show) => {
+      if (show) {
+        // 每次打开重置为默认收起，与图表设置一致
+        expandedEndpoints.value = {}
+        void probeSources()
+      } else {
+        probeRequestId++
+        probeController?.abort()
+        probeController = undefined
+      }
+    },
+    { immediate: true },
+  )
+
+  // 地址变更后防抖拨测，避免每敲一个字符就打一次网络
+  let endpointProbeTimer: ReturnType<typeof setTimeout> | undefined
+  watch(
+    () => props.endpoints,
+    () => {
+      if (!props.show) return
+      if (endpointProbeTimer !== undefined) clearTimeout(endpointProbeTimer)
+      endpointProbeTimer = setTimeout(() => {
+        endpointProbeTimer = undefined
+        void probeSources()
+      }, 400)
+    },
+    { deep: true },
+  )
+
+  onBeforeUnmount(() => {
+    probeRequestId++
+    probeController?.abort()
+    if (endpointProbeTimer !== undefined) clearTimeout(endpointProbeTimer)
+  })
+</script>
+
+<style scoped>
+  .source-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .source-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 6px 0;
+    border-radius: 6px;
+  }
+
+  .source-item.is-disabled {
+    opacity: 0.55;
+  }
+
+  .source-item__main {
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 8px 12px;
+    border-radius: 6px;
+  }
+
+  .source-item__main:hover {
+    background: var(--klc-color-tag-bg-hover);
+  }
+
+  .source-item__content {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .source-item__heading {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .source-item__name {
+    color: var(--klc-color-foreground);
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  .source-item__id,
+  .source-item__description {
+    color: var(--klc-color-axis-text);
+    font-size: 11px;
+  }
+
+  .source-item__id {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .source-status {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--klc-color-axis-text);
+    font-size: 11px;
+    white-space: nowrap;
+  }
+
+  .source-status__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+
+  .source-status.is-online {
+    color: var(--klc-color-success, #16865c);
+  }
+
+  .source-status.is-offline {
+    color: var(--klc-color-danger, #d64545);
+  }
+
+  .source-endpoint {
+    display: flex;
+    gap: 8px;
+    padding: 0 12px 10px;
+  }
+
+  .source-endpoint__field {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .source-endpoint__field--port {
+    flex: 0 0 88px;
+  }
+
+  .source-endpoint__label {
+    color: var(--klc-color-axis-text);
+    font-size: 11px;
+  }
+
+  .source-endpoint__input {
+    height: 30px;
+    padding: 0 10px;
+    border: 1px solid var(--klc-color-border-button);
+    border-radius: 6px;
+    background: var(--klc-color-background);
+    color: var(--klc-color-foreground);
+    font: inherit;
+    font-size: 12px;
+    outline: none;
+  }
+
+  .source-endpoint__input:focus {
+    border-color: var(--klc-color-axis-text);
+  }
+
+  .source-endpoint__input::placeholder {
+    color: var(--klc-color-axis-text);
+    opacity: 0.55;
+  }
+</style>

--- a/packages/vue/src/components/AggregationSourceTabs.vue
+++ b/packages/vue/src/components/AggregationSourceTabs.vue
@@ -1,0 +1,92 @@
+<template>
+  <div v-if="tabs.length > 0" class="source-tabs" role="tablist" aria-label="聚合源">
+    <button
+      v-for="tab in tabs"
+      :key="tab.key"
+      type="button"
+      class="source-tabs__tab"
+      :class="{ 'is-active': modelValue === tab.key }"
+      role="tab"
+      :aria-selected="modelValue === tab.key"
+      @click="emit('update:modelValue', tab.key)"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+  /** 搜索弹层顶部的聚合源 Tabs，视觉参考 Ant Design line Tabs */
+  export type AggregationSourceTabKey = 'all' | string
+
+  export interface AggregationSourceTabItem {
+    key: AggregationSourceTabKey
+    label: string
+  }
+
+  defineProps<{
+    modelValue: AggregationSourceTabKey
+    tabs: ReadonlyArray<AggregationSourceTabItem>
+  }>()
+
+  const emit = defineEmits<{
+    'update:modelValue': [key: AggregationSourceTabKey]
+  }>()
+</script>
+
+<style scoped>
+  .source-tabs {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0;
+    margin: 0 -4px;
+    padding: 0 4px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-bottom: 1px solid var(--klc-color-border-button);
+    scrollbar-width: none;
+  }
+
+  .source-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .source-tabs__tab {
+    position: relative;
+    flex: 0 0 auto;
+    height: 32px;
+    padding: 0 12px;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    color: var(--klc-color-axis-text);
+    font: inherit;
+    font-size: 13px;
+    font-weight: 400;
+    line-height: 32px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: color 0.2s cubic-bezier(0.645, 0.045, 0.355, 1);
+  }
+
+  .source-tabs__tab:hover {
+    color: var(--klc-color-primary, #1677ff);
+  }
+
+  .source-tabs__tab.is-active {
+    color: var(--klc-color-primary, #1677ff);
+    font-weight: 500;
+  }
+
+  /* Ant Design ink-bar：选中项底部指示条 */
+  .source-tabs__tab.is-active::after {
+    content: '';
+    position: absolute;
+    left: 12px;
+    right: 12px;
+    bottom: 0;
+    height: 2px;
+    border-radius: 1px 1px 0 0;
+    background: var(--klc-color-primary, #1677ff);
+  }
+</style>

--- a/packages/vue/src/components/ChartSettingsDialog.vue
+++ b/packages/vue/src/components/ChartSettingsDialog.vue
@@ -15,204 +15,149 @@
     </template>
 
     <div class="settings-body">
-      <section v-if="mainSettings.length > 0" class="settings-section">
-        <button
-          type="button"
-          class="settings-section-header"
-          :aria-expanded="expandedSections.main"
-          @click="toggleSection('main')"
-        >
-          <span class="settings-section-label">主图设置</span>
-          <svg
-            class="section-chevron"
-            :class="{ expanded: expandedSections.main }"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            width="14"
-            height="14"
-            aria-hidden="true"
-          >
-            <path d="M9 18l6-6-6-6" />
-          </svg>
-        </button>
-        <div v-show="expandedSections.main" class="settings-section-body">
-          <template v-for="item in mainSettings" :key="item.key">
-            <div class="settings-item">
-              <span>{{ item.label }}</span>
-              <template v-if="item.type === 'boolean'">
-                <label class="md-switch">
-                  <input v-model="settings[item.key]" type="checkbox" />
-                  <span class="md-switch-slider"></span>
-                </label>
-              </template>
-              <template v-else-if="item.type === 'select' && item.options">
-                <Dropdown
-                  :model-value="String(settings[item.key])"
-                  :options="item.options"
-                  size="sm"
-                  min-width="100px"
-                  @update:model-value="settings[item.key] = $event"
-                />
-              </template>
-            </div>
-            <div
-              v-if="item.key === 'rendererBackend' && runtimeHint"
-              class="settings-item runtime-hint"
-            >
-              <span>{{ runtimeHint }}</span>
-            </div>
-          </template>
-        </div>
-      </section>
-
-      <section class="settings-section">
-        <button
-          type="button"
-          class="settings-section-header"
-          :aria-expanded="expandedSections.style"
-          @click="toggleSection('style')"
-        >
-          <span class="settings-section-label">样式 / 颜色</span>
-          <svg
-            class="section-chevron"
-            :class="{ expanded: expandedSections.style }"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            width="14"
-            height="14"
-            aria-hidden="true"
-          >
-            <path d="M9 18l6-6-6-6" />
-          </svg>
-        </button>
-        <div v-show="expandedSections.style" class="settings-section-body">
-          <template v-for="item in styleSettings" :key="item.key">
-            <div class="settings-item">
-              <span>{{ item.label }}</span>
-              <template v-if="item.type === 'boolean'">
-                <label class="md-switch">
-                  <input v-model="settings[item.key]" type="checkbox" />
-                  <span class="md-switch-slider"></span>
-                </label>
-              </template>
-              <template v-else-if="item.type === 'select' && item.options">
-                <Dropdown
-                  :model-value="String(settings[item.key])"
-                  :options="item.options"
-                  size="sm"
-                  min-width="100px"
-                  @update:model-value="settings[item.key] = $event"
-                />
-              </template>
-            </div>
-          </template>
-          <div class="settings-item nav-item" @click="showColorPresetModal = true">
-            <span>颜色配置</span>
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              width="16"
-              height="16"
-              class="nav-arrow"
-            >
-              <path d="M9 18l6-6-6-6" />
-            </svg>
+      <CollapsibleSection
+        v-if="mainSettings.length > 0"
+        label="主图设置"
+        :expanded="expandedSections.main"
+        @toggle="toggleSection('main')"
+      >
+        <template v-for="item in mainSettings" :key="item.key">
+          <div class="settings-item">
+            <span>{{ item.label }}</span>
+            <template v-if="item.type === 'boolean'">
+              <ToggleSwitch
+                :model-value="Boolean(settings[item.key])"
+                :aria-label="item.label"
+                @update:model-value="settings[item.key] = $event"
+              />
+            </template>
+            <template v-else-if="item.type === 'select' && item.options">
+              <Dropdown
+                :model-value="String(settings[item.key])"
+                :options="item.options"
+                size="sm"
+                min-width="100px"
+                @update:model-value="settings[item.key] = $event"
+              />
+            </template>
           </div>
-        </div>
-      </section>
+          <div
+            v-if="item.key === 'rendererBackend' && runtimeHint"
+            class="settings-item runtime-hint"
+          >
+            <span>{{ runtimeHint }}</span>
+          </div>
+        </template>
+      </CollapsibleSection>
 
-      <section v-if="experimentalSettings.length > 0" class="settings-section">
-        <button
-          type="button"
-          class="settings-section-header"
-          :aria-expanded="expandedSections.experimental"
-          @click="toggleSection('experimental')"
+      <!-- 聚合源入口：主图设置下方，与颜色配置同为 nav-item -->
+      <div class="settings-item nav-item" @click="showAggregationSourceModal = true">
+        <span>聚合源管理</span>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          width="16"
+          height="16"
+          class="nav-arrow"
         >
-          <span class="settings-section-label">实验性 / 调试设置</span>
+          <path d="M9 18l6-6-6-6" />
+        </svg>
+      </div>
+
+      <CollapsibleSection
+        label="样式 / 颜色"
+        :expanded="expandedSections.style"
+        @toggle="toggleSection('style')"
+      >
+        <template v-for="item in styleSettings" :key="item.key">
+          <div class="settings-item">
+            <span>{{ item.label }}</span>
+            <template v-if="item.type === 'boolean'">
+              <ToggleSwitch
+                :model-value="Boolean(settings[item.key])"
+                :aria-label="item.label"
+                @update:model-value="settings[item.key] = $event"
+              />
+            </template>
+            <template v-else-if="item.type === 'select' && item.options">
+              <Dropdown
+                :model-value="String(settings[item.key])"
+                :options="item.options"
+                size="sm"
+                min-width="100px"
+                @update:model-value="settings[item.key] = $event"
+              />
+            </template>
+          </div>
+        </template>
+        <div class="settings-item nav-item" @click="showColorPresetModal = true">
+          <span>颜色配置</span>
           <svg
-            class="section-chevron"
-            :class="{ expanded: expandedSections.experimental }"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
             stroke-width="2"
-            width="14"
-            height="14"
-            aria-hidden="true"
+            width="16"
+            height="16"
+            class="nav-arrow"
           >
             <path d="M9 18l6-6-6-6" />
           </svg>
-        </button>
-        <div v-show="expandedSections.experimental" class="settings-section-body">
-          <template v-for="item in experimentalSettings" :key="item.key">
-            <div class="settings-item experimental">
-              <span>{{ item.label }}</span>
-              <template v-if="item.type === 'boolean'">
-                <label class="md-switch">
-                  <input v-model="settings[item.key]" type="checkbox" />
-                  <span class="md-switch-slider"></span>
-                </label>
-              </template>
-              <template v-else-if="item.type === 'select' && item.options">
-                <Dropdown
-                  :model-value="String(settings[item.key])"
-                  :options="item.options"
-                  size="sm"
-                  min-width="100px"
-                  @update:model-value="settings[item.key] = $event"
-                />
-              </template>
-            </div>
-          </template>
         </div>
-      </section>
+      </CollapsibleSection>
 
-      <section class="settings-section">
-        <button
-          type="button"
-          class="settings-section-header"
-          :aria-expanded="expandedSections.opensource"
-          @click="toggleSection('opensource')"
-        >
-          <span class="settings-section-label">开源致谢</span>
-          <svg
-            class="section-chevron"
-            :class="{ expanded: expandedSections.opensource }"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            width="14"
-            height="14"
-            aria-hidden="true"
+      <CollapsibleSection
+        v-if="experimentalSettings.length > 0"
+        label="实验性 / 调试设置"
+        :expanded="expandedSections.experimental"
+        @toggle="toggleSection('experimental')"
+      >
+        <template v-for="item in experimentalSettings" :key="item.key">
+          <div class="settings-item experimental">
+            <span>{{ item.label }}</span>
+            <template v-if="item.type === 'boolean'">
+              <ToggleSwitch
+                :model-value="Boolean(settings[item.key])"
+                :aria-label="item.label"
+                @update:model-value="settings[item.key] = $event"
+              />
+            </template>
+            <template v-else-if="item.type === 'select' && item.options">
+              <Dropdown
+                :model-value="String(settings[item.key])"
+                :options="item.options"
+                size="sm"
+                min-width="100px"
+                @update:model-value="settings[item.key] = $event"
+              />
+            </template>
+          </div>
+        </template>
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        label="开源致谢"
+        :expanded="expandedSections.opensource"
+        @toggle="toggleSection('opensource')"
+      >
+        <template v-for="section in openSourceCredits" :key="section.id">
+          <div class="settings-subsection-label">{{ section.title }}</div>
+          <a
+            v-for="credit in section.items"
+            :key="credit.name"
+            class="settings-item credit-item"
+            :href="credit.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            :title="credit.url"
           >
-            <path d="M9 18l6-6-6-6" />
-          </svg>
-        </button>
-        <div v-show="expandedSections.opensource" class="settings-section-body">
-          <template v-for="section in openSourceCredits" :key="section.id">
-            <div class="settings-subsection-label">{{ section.title }}</div>
-            <a
-              v-for="credit in section.items"
-              :key="credit.name"
-              class="settings-item credit-item"
-              :href="credit.url"
-              target="_blank"
-              rel="noopener noreferrer"
-              :title="credit.url"
-            >
-              <span class="credit-name">{{ credit.name }}</span>
-              <span class="credit-meta">{{ credit.version }} · {{ credit.license }}</span>
-            </a>
-          </template>
-        </div>
-      </section>
+            <span class="credit-name">{{ credit.name }}</span>
+            <span class="credit-meta">{{ credit.version }} · {{ credit.license }}</span>
+          </a>
+        </template>
+      </CollapsibleSection>
     </div>
 
     <template #footer>
@@ -234,6 +179,18 @@
       </div>
     </template>
   </BaseModal>
+
+  <!-- 嵌套聚合源管理 -->
+  <AggregationSourceDialog
+    :show="showAggregationSourceModal"
+    :sources="aggregationSources"
+    :enabled-names="enabledSourceNames"
+    :endpoints="sourceEndpoints"
+    :z-index="1100"
+    @close="showAggregationSourceModal = false"
+    @toggle="onToggleAggregationSource"
+    @update-endpoint="onUpdateSourceEndpoint"
+  />
 
   <!-- 嵌套颜色预设弹窗 -->
   <BaseModal
@@ -275,24 +232,43 @@
     type ChartSettings,
     type SettingItem,
   } from '@363045841yyt/klinechart-core/config'
-  import type { RendererBackendRuntime } from '@363045841yyt/klinechart-core/controllers'
+  import type {
+    DataFetcherDefinition,
+    RendererBackendRuntime,
+  } from '@363045841yyt/klinechart-core/controllers'
   import { ref, computed, watch } from 'vue'
 
+  import type { AggregationSourceEndpoint } from '../composables/useAggregationSources'
   import { getOpenSourceCredits } from '../credits/openSourceCredits'
 
+  import AggregationSourceDialog from './AggregationSourceDialog.vue'
   import BaseModal from './BaseModal.vue'
   import ColorPresetPanel from './ColorPresetPanel.vue'
+  import CollapsibleSection from './common/CollapsibleSection.vue'
   import Dropdown from './Dropdown.vue'
+  import ToggleSwitch from './common/ToggleSwitch.vue'
 
-  const props = defineProps<{
-    show: boolean
-    initialSettings?: ChartSettings
-    rendererRuntime?: RendererBackendRuntime | null
-  }>()
+  const props = withDefaults(
+    defineProps<{
+      show: boolean
+      initialSettings?: ChartSettings
+      rendererRuntime?: RendererBackendRuntime | null
+      aggregationSources?: ReadonlyArray<DataFetcherDefinition>
+      enabledSourceNames?: ReadonlySet<string>
+      sourceEndpoints?: Record<string, AggregationSourceEndpoint>
+    }>(),
+    {
+      aggregationSources: () => [],
+      enabledSourceNames: () => new Set<string>(),
+      sourceEndpoints: () => ({}),
+    },
+  )
 
   const emit = defineEmits<{
     (e: 'close'): void
     (e: 'confirm', settings: ChartSettings): void
+    (e: 'toggleAggregationSource', name: string, enabled: boolean): void
+    (e: 'updateSourceEndpoint', name: string, patch: Partial<AggregationSourceEndpoint>): void
   }>()
 
   const mainSettings = computed(
@@ -319,6 +295,8 @@
   }
 
   const expandedSections = ref(createDefaultExpandedSections())
+  const showAggregationSourceModal = ref(false)
+  const showColorPresetModal = ref(false)
 
   function toggleSection(id: SettingsSectionId) {
     expandedSections.value = {
@@ -327,7 +305,14 @@
     }
   }
 
-  const showColorPresetModal = ref(false)
+  function onToggleAggregationSource(name: string, enabled: boolean) {
+    emit('toggleAggregationSource', name, enabled)
+  }
+
+  function onUpdateSourceEndpoint(name: string, patch: Partial<AggregationSourceEndpoint>) {
+    emit('updateSourceEndpoint', name, patch)
+  }
+
   const colorPresetPanelRef = ref<InstanceType<typeof ColorPresetPanel> | null>(null)
 
   function loadSettings(): ChartSettings {
@@ -422,65 +407,6 @@
     flex-direction: column;
   }
 
-  .settings-section {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .settings-section + .settings-section {
-    margin-top: 4px;
-  }
-
-  .settings-section-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    width: 100%;
-    min-height: 36px;
-    margin: 0;
-    padding: 8px 12px;
-    border: none;
-    border-radius: 6px;
-    background: transparent;
-    cursor: pointer;
-    text-align: left;
-    transition: background 0.15s ease;
-  }
-
-  .settings-section-header:hover {
-    background: var(--klc-color-tag-bg-hover);
-  }
-
-  .settings-section-label {
-    font-size: 12px;
-    color: var(--klc-color-axis-text);
-    font-weight: 500;
-    white-space: nowrap;
-    line-height: 1;
-    letter-spacing: 0.3px;
-  }
-
-  .section-chevron {
-    flex-shrink: 0;
-    color: var(--klc-color-axis-text);
-    transform: rotate(0deg);
-    transition: transform 0.15s ease, color 0.15s ease;
-  }
-
-  .section-chevron.expanded {
-    transform: rotate(90deg);
-  }
-
-  .settings-section-header:hover .section-chevron {
-    color: var(--klc-color-foreground);
-  }
-
-  .settings-section-body {
-    display: flex;
-    flex-direction: column;
-  }
-
   .settings-subsection-label {
     font-size: 11px;
     color: var(--klc-color-axis-text);
@@ -556,57 +482,6 @@
   .settings-item > span {
     min-width: 0;
     line-height: 1.4;
-  }
-
-  /* Material Design 风格开关 */
-  .md-switch {
-    position: relative;
-    display: inline-block;
-    width: 36px;
-    height: 20px;
-    flex: 0 0 auto;
-    margin: 0;
-  }
-
-  .md-switch input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-
-  .md-switch-slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(128, 128, 128, 0.4);
-    transition: 0.3s;
-    border-radius: 20px;
-  }
-
-  .md-switch-slider::before {
-    position: absolute;
-    content: '';
-    height: 16px;
-    width: 16px;
-    left: 2px;
-    bottom: 2px;
-    background-color: #e0e0e0;
-    transition: 0.3s;
-    border-radius: 50%;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-  }
-
-  .md-switch input:checked + .md-switch-slider {
-    background-color: #3b82f6;
-    opacity: 1;
-  }
-
-  .md-switch input:checked + .md-switch-slider::before {
-    transform: translateX(16px);
-    background-color: #ffffff;
   }
 
   /* 导航项交互优化 */

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -71,6 +71,7 @@
                 <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
               </svg>
             </button>
+            <AggregationSourceButton @click="emit('manageSources')" />
           </div>
 
           <div v-if="selected.length > 0" class="compare-selected">
@@ -186,6 +187,7 @@
   } from '../composables/useSymbolSearch'
   import { useTeleportedPopup } from '../composables/useTeleportedPopup'
 
+  import AggregationSourceButton from './AggregationSourceButton.vue'
   import type { SymbolItem } from './SymbolSelector.vue'
 
   const props = withDefaults(
@@ -206,6 +208,7 @@
   const emit = defineEmits<{
     (e: 'add', item: SymbolItem): void
     (e: 'remove', code: string): void
+    (e: 'manageSources'): void
   }>()
 
   const showPopup = ref(false)

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -78,10 +78,10 @@
               <span class="compare-selected__title">已添加商品</span>
             </div>
             <div class="compare-selected__list">
-              <div v-for="item in displayItems" :key="item.symbol" class="compare-selected__item">
+              <div v-for="item in displayItems" :key="symbolIdentityKey(item)" class="compare-selected__item">
                 <span
                   class="compare-selected__color"
-                  :style="{ background: comparisonColors?.get(item.symbol) ?? '#888' }"
+                  :style="{ background: comparisonColors?.get(symbolIdentityKey(item)) ?? '#888' }"
                 />
                 <span class="compare-selected__code">{{ item.symbol }}</span>
                 <span class="compare-selected__desc">{{ item.description }}</span>
@@ -89,7 +89,7 @@
                   type="button"
                   class="compare-selected__remove"
                   :aria-label="'移除 ' + item.symbol"
-                  @click="removeSymbol(item.symbol)"
+                  @click="removeSymbol(item)"
                 >
                   <svg
                     viewBox="0 0 24 24"
@@ -137,12 +137,12 @@
             </div>
             <button
               v-for="item in comparisonSymbols"
-              :key="item.symbol"
+              :key="symbolIdentityKey(item)"
               type="button"
               class="compare-list__item"
-              :class="{ 'is-selected': isSelected(item.symbol) }"
+              :class="{ 'is-selected': isSelected(item) }"
               role="option"
-              :aria-selected="isSelected(item.symbol)"
+              :aria-selected="isSelected(item)"
               @click="toggleSymbol(item)"
             >
               <span class="compare-list__left">
@@ -151,7 +151,7 @@
               </span>
               <span class="compare-list__right">
                 <span class="compare-list__exchange">{{ item.exchange }}</span>
-                <span v-if="isSelected(item.symbol)" class="compare-list__check" aria-hidden="true">
+                <span v-if="isSelected(item)" class="compare-list__check" aria-hidden="true">
                   <svg
                     viewBox="0 0 24 24"
                     width="16"
@@ -179,7 +179,8 @@
 
   import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
   import {
-    uniqueSymbolsByCode,
+    symbolIdentityKey,
+    uniqueSymbolsByIdentity,
     useSymbolSearch,
     type SymbolSearchFn,
   } from '../composables/useSymbolSearch'
@@ -226,7 +227,7 @@
   const displayItems = computed<SymbolItem[]>(() => {
     if (props.selectedItems.length > 0) return props.selectedItems
     const set = selectedSet.value
-    return props.symbols.filter((s) => set.has(s.symbol))
+    return props.symbols.filter((s) => set.has(symbolIdentityKey(s)))
   })
 
   const {
@@ -238,22 +239,22 @@
     symbols: computed(() => props.symbols),
     search: computed(() => props.search),
   })
-  const comparisonSymbols = computed(() => uniqueSymbolsByCode(filteredSymbols.value))
+  const comparisonSymbols = computed(() => uniqueSymbolsByIdentity(filteredSymbols.value))
 
-  function isSelected(code: string): boolean {
-    return selectedSet.value.has(code)
+  function isSelected(item: SymbolItem): boolean {
+    return selectedSet.value.has(symbolIdentityKey(item))
   }
 
   function toggleSymbol(item: SymbolItem) {
-    if (isSelected(item.symbol)) {
-      emit('remove', item.symbol)
+    if (isSelected(item)) {
+      emit('remove', symbolIdentityKey(item))
     } else {
       emit('add', item)
     }
   }
 
-  function removeSymbol(code: string) {
-    emit('remove', code)
+  function removeSymbol(item: SymbolItem) {
+    emit('remove', symbolIdentityKey(item))
   }
 
   function togglePopup() {

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -24,6 +24,11 @@
           role="dialog"
           aria-label="比较商品"
         >
+          <AggregationSourceTabs
+            v-if="sourceTabs.length > 0"
+            v-model="activeSourceTab"
+            :tabs="sourceTabs"
+          />
           <div class="compare-search">
             <span class="compare-search__icon" aria-hidden="true">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -178,6 +183,8 @@
 <script setup lang="ts">
   import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 
+  import type { DataFetcherDefinition } from '@363045841yyt/klinechart-core/controllers'
+
   import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
   import {
     symbolIdentityKey,
@@ -188,6 +195,10 @@
   import { useTeleportedPopup } from '../composables/useTeleportedPopup'
 
   import AggregationSourceButton from './AggregationSourceButton.vue'
+  import AggregationSourceTabs, {
+    type AggregationSourceTabItem,
+    type AggregationSourceTabKey,
+  } from './AggregationSourceTabs.vue'
   import type { SymbolItem } from './SymbolSelector.vue'
 
   const props = withDefaults(
@@ -198,10 +209,14 @@
       selectedItems?: SymbolItem[]
       comparisonColors?: Map<string, string>
       comparisonLoading?: boolean
+      aggregationSources?: ReadonlyArray<DataFetcherDefinition>
+      enabledSourceNames?: ReadonlySet<string>
     }>(),
     {
       selected: () => [],
       selectedItems: () => [],
+      aggregationSources: () => [],
+      enabledSourceNames: () => new Set<string>(),
     },
   )
 
@@ -213,9 +228,28 @@
 
   const showPopup = ref(false)
   const searchQuery = ref('')
+  const activeSourceTab = ref<AggregationSourceTabKey>('all')
   const searchInputRef = ref<HTMLInputElement | null>(null)
   const rootRef = ref<HTMLElement | null>(null)
   const popupRef = ref<HTMLElement | null>(null)
+
+  const sourceTabs = computed<AggregationSourceTabItem[]>(() => {
+    const enabled = props.enabledSourceNames
+    const searchable = props.aggregationSources
+      .filter(
+        (source) =>
+          enabled.has(source.name) &&
+          source.capabilities?.includes('search') &&
+          typeof source.searcher === 'function',
+      )
+      .slice()
+      .sort((a, b) => Number(a.name.startsWith('mock-')) - Number(b.name.startsWith('mock-')))
+    if (searchable.length === 0) return []
+    return [
+      { key: 'all', label: '全部' },
+      ...searchable.map((source) => ({ key: source.name, label: source.displayName })),
+    ]
+  })
 
   const teleportTarget = useFullscreenTeleportTarget()
 
@@ -241,6 +275,7 @@
     query: searchQuery,
     symbols: computed(() => props.symbols),
     search: computed(() => props.search),
+    sourceFilter: activeSourceTab,
   })
   const comparisonSymbols = computed(() => uniqueSymbolsByIdentity(filteredSymbols.value))
 
@@ -272,6 +307,13 @@
       startPositionSync()
     } else {
       stopPositionSync()
+      activeSourceTab.value = 'all'
+    }
+  })
+
+  watch(sourceTabs, (tabs) => {
+    if (!tabs.some((tab) => tab.key === activeSourceTab.value)) {
+      activeSourceTab.value = 'all'
     }
   })
 

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -156,7 +156,7 @@
                 <span class="compare-list__desc">{{ item.description }}</span>
               </span>
               <span class="compare-list__right">
-                <span class="compare-list__exchange">{{ item.exchange }}</span>
+                <span class="compare-list__exchange">{{ formatSymbolMeta(item) }}</span>
                 <span v-if="isSelected(item)" class="compare-list__check" aria-hidden="true">
                   <svg
                     viewBox="0 0 24 24"
@@ -293,6 +293,15 @@
 
   function removeSymbol(item: SymbolItem) {
     emit('remove', symbolIdentityKey(item))
+  }
+
+  /** 展示 exchange + kind + market/category，便于区分同代码多语义 */
+  function formatSymbolMeta(item: SymbolItem): string {
+    const parts = [item.exchange]
+    if (typeof item.params?.kind === 'string') parts.push(String(item.params.kind))
+    if (typeof item.params?.market === 'number') parts.push(`M${item.params.market}`)
+    if (typeof item.params?.category === 'number') parts.push(`C${item.params.category}`)
+    return parts.join(' · ')
   }
 
   function togglePopup() {

--- a/packages/vue/src/components/CompareSymbolSelector.vue
+++ b/packages/vue/src/components/CompareSymbolSelector.vue
@@ -110,7 +110,11 @@
           </div>
 
           <div class="compare-list" role="listbox" aria-label="商品列表">
-            <div v-if="filteredSymbols.length === 0" class="compare-list__empty">
+            <div v-if="searchLoading" class="compare-list__empty">
+              <span class="compare-chip__spinner" aria-hidden="true" />
+              <span>正在搜索</span>
+            </div>
+            <div v-else-if="comparisonSymbols.length === 0" class="compare-list__empty">
               <svg
                 width="32"
                 height="32"
@@ -129,10 +133,10 @@
                   stroke-linecap="round"
                 />
               </svg>
-              <span>未找到相关商品</span>
+              <span>{{ searchError ? '搜索失败' : '未找到相关商品' }}</span>
             </div>
             <button
-              v-for="item in filteredSymbols"
+              v-for="item in comparisonSymbols"
               :key="item.symbol"
               type="button"
               class="compare-list__item"
@@ -174,6 +178,11 @@
   import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 
   import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+  import {
+    uniqueSymbolsByCode,
+    useSymbolSearch,
+    type SymbolSearchFn,
+  } from '../composables/useSymbolSearch'
   import { useTeleportedPopup } from '../composables/useTeleportedPopup'
 
   import type { SymbolItem } from './SymbolSelector.vue'
@@ -181,6 +190,7 @@
   const props = withDefaults(
     defineProps<{
       symbols: SymbolItem[]
+      search?: SymbolSearchFn<SymbolItem>
       selected?: string[]
       selectedItems?: SymbolItem[]
       comparisonColors?: Map<string, string>
@@ -219,16 +229,16 @@
     return props.symbols.filter((s) => set.has(s.symbol))
   })
 
-  const filteredSymbols = computed<SymbolItem[]>(() => {
-    const q = searchQuery.value.trim().toLowerCase()
-    if (!q) return props.symbols
-    return props.symbols.filter(
-      (s) =>
-        s.symbol.toLowerCase().includes(q) ||
-        s.description.toLowerCase().includes(q) ||
-        s.exchange.toLowerCase().includes(q),
-    )
+  const {
+    results: filteredSymbols,
+    loading: searchLoading,
+    error: searchError,
+  } = useSymbolSearch<SymbolItem>({
+    query: searchQuery,
+    symbols: computed(() => props.symbols),
+    search: computed(() => props.search),
   })
+  const comparisonSymbols = computed(() => uniqueSymbolsByCode(filteredSymbols.value))
 
   function isSelected(code: string): boolean {
     return selectedSet.value.has(code)

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -533,8 +533,15 @@ import MarkerTooltip from './MarkerTooltip.vue'
     query: string,
     limit: number,
     signal: AbortSignal,
+    sources?: ReadonlyArray<string>,
   ): Promise<ReadonlyArray<SymbolItem>> {
-    return routerSearchFetchers({ query, limit, signal, sources: enabledSourceNames.value })
+    // Tab 指定单源时只查该源；否则查全部已启用源
+    return routerSearchFetchers({
+      query,
+      limit,
+      signal,
+      sources: sources ?? enabledSourceNames.value,
+    })
   }
 
   function syncSymbolsToController() {

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -13,12 +13,17 @@
       :overlay-symbol-items="overlaySymbolItems"
       :comparison-colors="comparisonColorsMap"
       :comparison-loading="comparisonLoading"
+      :aggregation-sources="aggregationSources"
+      :enabled-source-names="enabledSourceNameSet"
+      :source-endpoints="sourceEndpoints"
       :show-back-button="kLineLevel === 'timeshare'"
       @add-overlay-symbol="onAddOverlaySymbol"
       @remove-overlay-symbol="onRemoveOverlaySymbol"
       @k-line-level-change="onKLineLevelChange"
       @k-line-adjust-change="onKLineAdjustChange"
       @symbol-change="onSymbolChange"
+      @toggle-aggregation-source="setAggregationSourceEnabled"
+      @update-source-endpoint="setAggregationSourceEndpoint"
       @back="onBackFromTimeShare"
     />
     <div
@@ -39,12 +44,17 @@
         :renderer-runtime="rendererRuntime"
         :drawing-tool-id="drawingToolId"
         :is-range-select-mode="isRangeSelectMode"
+        :aggregation-sources="aggregationSources"
+        :enabled-source-names="enabledSourceNameSet"
+        :source-endpoints="sourceEndpoints"
         @select-tool="handleSelectTool"
         @toggle-indicator="onToggleIndicator"
         @toggle-fullscreen="handleToggleFullscreen"
         @zoom-in="applyZoomToLevel(zoomLevel + 1)"
         @zoom-out="applyZoomToLevel(zoomLevel - 1)"
         @settings-change="handleSettingsChange"
+        @toggle-aggregation-source="setAggregationSourceEnabled"
+        @update-source-endpoint="setAggregationSourceEndpoint"
       />
       <div ref="chartMainRef" class="chart-main">
         <div class="pane-separator-layer" aria-hidden="true">
@@ -240,6 +250,7 @@
     createChartController,
     routerDataFetcher,
     routerSearchFetchers,
+    getRegisteredFetchers,
     type ChartController,
     type InteractionSnapshot,
     type LegendTemplateContext,
@@ -263,9 +274,18 @@
     shallowRef,
     useSlots,
   } from 'vue'
+  import { useAggregationSources } from '../composables/useAggregationSources'
   import { formatTimestamp } from '@363045841yyt/klinechart-core'
 
   const slots = useSlots()
+  const aggregationSources = getRegisteredFetchers()
+  const {
+    enabledNames: enabledSourceNames,
+    enabledNameSet: enabledSourceNameSet,
+    endpoints: sourceEndpoints,
+    setEnabled: setAggregationSourceEnabled,
+    setEndpoint: setAggregationSourceEndpoint,
+  } = useAggregationSources(aggregationSources)
 
   import { useChartState } from '../composables/chart/useChartState'
   import { useChartTheme } from '../composables/chart/useChartTheme'
@@ -514,7 +534,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
     limit: number,
     signal: AbortSignal,
   ): Promise<ReadonlyArray<SymbolItem>> {
-    return routerSearchFetchers({ query, limit, signal })
+    return routerSearchFetchers({ query, limit, signal, sources: enabledSourceNames.value })
   }
 
   function syncSymbolsToController() {

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -448,11 +448,35 @@ import MarkerTooltip from './MarkerTooltip.vue'
     { symbol: 'AAPL', description: 'Apple Inc.', exchange: 'NASDAQ', source: 'tradingview' },
     { symbol: 'TSLA', description: 'Tesla, Inc.', exchange: 'NASDAQ', source: 'tradingview' },
     { symbol: '1810', description: '小米集团', exchange: 'HKEX', source: 'tradingview' },
-    // gotdx A shares
-    { symbol: '600519', description: '贵州茅台', exchange: 'SSE', source: 'gotdx' },
-    { symbol: '601360', description: '三六零', exchange: 'SSE', source: 'gotdx' },
-    { symbol: '000858', description: '五 粮 液', exchange: 'SZSE', source: 'gotdx' },
-    { symbol: '000001', description: '平安银行', exchange: 'SZSE', source: 'gotdx' },
+    // gotdx A 股：必须带 params.market，与搜索目录一致，禁止按代码猜市场
+    {
+      symbol: '600519',
+      description: '贵州茅台',
+      exchange: 'SH',
+      source: 'gotdx',
+      params: { market: 1 },
+    },
+    {
+      symbol: '601360',
+      description: '三六零',
+      exchange: 'SH',
+      source: 'gotdx',
+      params: { market: 1 },
+    },
+    {
+      symbol: '000858',
+      description: '五 粮 液',
+      exchange: 'SZ',
+      source: 'gotdx',
+      params: { market: 0 },
+    },
+    {
+      symbol: '000001',
+      description: '平安银行',
+      exchange: 'SZ',
+      source: 'gotdx',
+      params: { market: 0 },
+    },
     // Mock
     { symbol: 'MOCK-100', description: 'Mock 100 条', exchange: 'MOCK', source: 'mock-100' },
     { symbol: 'MOCK-10000', description: 'Mock 10000 条', exchange: 'MOCK', source: 'mock-10000' },

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -2,6 +2,7 @@
   <div ref="chartWrapperRef" class="chart-wrapper" :data-theme="chartTheme" :style="themeCssVars">
     <TopToolbar
       :symbol="currentSymbol"
+      :symbol-item="currentSymbolItem ?? undefined"
       :symbols="symbolPool"
       :search="searchSymbols"
       :k-line-level="kLineLevel"
@@ -271,6 +272,7 @@
   import { useDrawingManager } from '../composables/chart/useDrawingManager'
   import { useIndicatorManager } from '../composables/chart/useIndicatorManager'
   import { useRangeSelection } from '../composables/chart/useRangeSelection'
+  import { symbolIdentityKey } from '../composables/useSymbolSearch'
   import { provideFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
 
   import BatchStockDialog from './BatchStockDialog.vue'
@@ -483,15 +485,15 @@ import MarkerTooltip from './MarkerTooltip.vue'
     const ctrl = controller.value
     if (!ctrl) return
     const current = ctrl.symbols.peek()
-    const currentCodes = current.map((s) => s.symbol)
-    if (currentCodes.includes(item.symbol)) return
+    const currentKeys = current.map(symbolIdentityKey)
+    if (currentKeys.includes(symbolIdentityKey(item))) return
     ctrl.registerSymbols([item])
     forcePercentAxis()
     ctrl.addComparisonSymbol(toSymbolSpec(item))
   }
 
-  function onRemoveOverlaySymbol(code: string) {
-    controller.value?.removeComparisonSymbol(code)
+  function onRemoveOverlaySymbol(identity: string) {
+    controller.value?.removeComparisonSymbol(identity)
   }
 
   function toSymbolSpec(item: SymbolItem): SymbolSpec {
@@ -1479,7 +1481,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
       if (primary.adjust) kLineAdjust.value = primary.adjust as 'qfq' | 'hfq' | 'splits' | 'none'
 
       const comparisonSpecs = specs.slice(1)
-      overlaySymbols.value = comparisonSpecs.map((s) => s.symbol)
+      overlaySymbols.value = comparisonSpecs.map(symbolIdentityKey)
       overlaySymbolItems.value = comparisonSpecs.map((s) => {
         const info = ctrl.symbolCatalog
           .peek()

--- a/packages/vue/src/components/KLineChart.vue
+++ b/packages/vue/src/components/KLineChart.vue
@@ -3,6 +3,7 @@
     <TopToolbar
       :symbol="currentSymbol"
       :symbols="symbolPool"
+      :search="searchSymbols"
       :k-line-level="kLineLevel"
       :k-line-adjust="kLineAdjust"
       :symbol-loading="symbolStatus === 'loading'"
@@ -237,6 +238,7 @@
   import {
     createChartController,
     routerDataFetcher,
+    routerSearchFetchers,
     type ChartController,
     type InteractionSnapshot,
     type LegendTemplateContext,
@@ -471,6 +473,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
     const ctrl = controller.value
     if (!ctrl) return
     ctrl.setDataFetcher(effectiveDataFetcher.value)
+    ctrl.registerSymbols([item])
     const current = ctrl.symbols.peek() ?? []
     const comparisonSpecs = current.slice(1)
     ctrl.setSymbols([toSymbolSpec(item), ...comparisonSpecs])
@@ -482,6 +485,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
     const current = ctrl.symbols.peek()
     const currentCodes = current.map((s) => s.symbol)
     if (currentCodes.includes(item.symbol)) return
+    ctrl.registerSymbols([item])
     forcePercentAxis()
     ctrl.addComparisonSymbol(toSymbolSpec(item))
   }
@@ -496,10 +500,19 @@ import MarkerTooltip from './MarkerTooltip.vue'
       exchange: item.exchange,
       period: kLineLevel.value,
       source: item.source,
+      params: item.params,
       startDate: props.semanticConfig?.data?.startDate ?? '',
       endDate: props.semanticConfig?.data?.endDate ?? '',
       adjust: kLineAdjust.value,
     }
+  }
+
+  async function searchSymbols(
+    query: string,
+    limit: number,
+    signal: AbortSignal,
+  ): Promise<ReadonlyArray<SymbolItem>> {
+    return routerSearchFetchers({ query, limit, signal })
   }
 
   function syncSymbolsToController() {
@@ -1429,6 +1442,7 @@ import MarkerTooltip from './MarkerTooltip.vue'
         description: info.description ?? info.symbol,
         exchange: info.exchange ?? '',
         source: info.source ?? '',
+        params: info.params,
       }))
     })
     // 立即同步当前值，确保 dropdown 在 subscribe 创建后立即拿到数据，
@@ -1438,30 +1452,49 @@ import MarkerTooltip from './MarkerTooltip.vue'
       description: info.description ?? info.symbol,
       exchange: info.exchange ?? '',
       source: info.source ?? '',
+      params: info.params,
     }))
 
     const unsubscribeSymbols = ctrl.symbols.subscribe(() => {
       const specs = ctrl.symbols.peek()
       if (specs.length === 0) return
       const primary = specs[0]
+      const primaryInfo = ctrl.symbolCatalog
+        .peek()
+        .find(
+          (info) =>
+            info.symbol === primary.symbol &&
+            info.source === primary.source &&
+            info.exchange === primary.exchange,
+        )
       currentSymbol.value = primary.symbol
       currentSymbolItem.value = {
         symbol: primary.symbol,
-        description: primary.symbol,
+        description: primaryInfo?.description ?? primary.symbol,
         exchange: primary.exchange ?? '',
         source: primary.source ?? '',
+        params: primary.params,
       }
       if (primary.period) kLineLevel.value = primary.period
       if (primary.adjust) kLineAdjust.value = primary.adjust as 'qfq' | 'hfq' | 'splits' | 'none'
 
       const comparisonSpecs = specs.slice(1)
       overlaySymbols.value = comparisonSpecs.map((s) => s.symbol)
-      overlaySymbolItems.value = comparisonSpecs.map((s) => ({
-        symbol: s.symbol,
-        description: s.symbol,
-        exchange: s.exchange ?? '',
-        source: s.source ?? '',
-      }))
+      overlaySymbolItems.value = comparisonSpecs.map((s) => {
+        const info = ctrl.symbolCatalog
+          .peek()
+          .find(
+            (item) =>
+              item.symbol === s.symbol && item.source === s.source && item.exchange === s.exchange,
+          )
+        return {
+          symbol: s.symbol,
+          description: info?.description ?? s.symbol,
+          exchange: s.exchange ?? '',
+          source: s.source ?? '',
+          params: s.params,
+        }
+      })
     })
 
     return () => {

--- a/packages/vue/src/components/LeftToolbar.vue
+++ b/packages/vue/src/components/LeftToolbar.vue
@@ -157,8 +157,13 @@
     :show="showSettings"
     :initial-settings="appliedSettings"
     :renderer-runtime="rendererRuntime"
+    :aggregation-sources="aggregationSources"
+    :enabled-source-names="enabledSourceNames"
+    :source-endpoints="sourceEndpoints"
     @close="showSettings = false"
     @confirm="handleConfirmSettings"
+    @toggle-aggregation-source="onToggleAggregationSource"
+    @update-source-endpoint="onUpdateSourceEndpoint"
   />
 
   <AlertDialog
@@ -175,9 +180,13 @@
     resolveRuntimeSettings,
     type ChartSettings,
   } from '@363045841yyt/klinechart-core/config'
-  import type { RendererBackendRuntime } from '@363045841yyt/klinechart-core/controllers'
+  import type {
+    DataFetcherDefinition,
+    RendererBackendRuntime,
+  } from '@363045841yyt/klinechart-core/controllers'
   import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 
+  import type { AggregationSourceEndpoint } from '../composables/useAggregationSources'
   import { useAlerts } from '../composables/useAlerts'
   import { setCanvasProfilerEnabled } from '../debug/canvasProfiler'
 
@@ -248,18 +257,30 @@
     (e: 'zoomIn'): void
     (e: 'zoomOut'): void
     (e: 'settingsChange', settings: ChartSettings): void
+    (e: 'toggleAggregationSource', name: string, enabled: boolean): void
+    (e: 'updateSourceEndpoint', name: string, patch: Partial<AggregationSourceEndpoint>): void
   }>()
 
-  const props = defineProps<{
-    isFullscreen?: boolean
-    alertController?: ChartController | null
-    effectiveSettings?: ChartSettings
-    rendererRuntime?: RendererBackendRuntime | null
-    /** kernel drawingTool 镜像；高亮以它为准 */
-    drawingToolId?: string
-    /** range-select 本地模式 */
-    isRangeSelectMode?: boolean
-  }>()
+  const props = withDefaults(
+    defineProps<{
+      isFullscreen?: boolean
+      alertController?: ChartController | null
+      effectiveSettings?: ChartSettings
+      rendererRuntime?: RendererBackendRuntime | null
+      /** kernel drawingTool 镜像；高亮以它为准 */
+      drawingToolId?: string
+      /** range-select 本地模式 */
+      isRangeSelectMode?: boolean
+      aggregationSources?: ReadonlyArray<DataFetcherDefinition>
+      enabledSourceNames?: ReadonlySet<string>
+      sourceEndpoints?: Record<string, AggregationSourceEndpoint>
+    }>(),
+    {
+      aggregationSources: () => [],
+      enabledSourceNames: () => new Set<string>(),
+      sourceEndpoints: () => ({}),
+    },
+  )
 
   const { unreadCount } = useAlerts(() => props.alertController ?? null)
 
@@ -336,6 +357,14 @@
 
   function openSettings() {
     showSettings.value = true
+  }
+
+  function onToggleAggregationSource(name: string, enabled: boolean) {
+    emit('toggleAggregationSource', name, enabled)
+  }
+
+  function onUpdateSourceEndpoint(name: string, patch: Partial<AggregationSourceEndpoint>) {
+    emit('updateSourceEndpoint', name, patch)
   }
 
   function getCurrentSettings(): ChartSettings {

--- a/packages/vue/src/components/SymbolSelector.vue
+++ b/packages/vue/src/components/SymbolSelector.vue
@@ -47,7 +47,6 @@
               autocomplete="off"
               spellcheck="false"
               aria-label="搜索商品"
-              @input="onSearchInput"
             />
             <button
               v-if="searchQuery"
@@ -74,7 +73,11 @@
           </div>
 
           <div class="symbol-list" role="listbox" aria-label="商品列表">
-            <div v-if="filteredSymbols.length === 0" class="symbol-list__empty">
+            <div v-if="searchLoading" class="symbol-list__empty">
+              <span class="symbol-chip__spinner" aria-hidden="true" />
+              <span>正在搜索</span>
+            </div>
+            <div v-else-if="filteredSymbols.length === 0" class="symbol-list__empty">
               <svg
                 width="32"
                 height="32"
@@ -93,11 +96,11 @@
                   stroke-linecap="round"
                 />
               </svg>
-              <span>未找到相关商品</span>
+              <span>{{ searchError ? '搜索失败' : '未找到相关商品' }}</span>
             </div>
             <button
               v-for="item in filteredSymbols"
-              :key="item.symbol"
+              :key="symbolIdentityKey(item)"
               type="button"
               class="symbol-list__item"
               :class="{ 'is-active': item.symbol === symbol }"
@@ -122,20 +125,22 @@
   import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 
   import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
+  import {
+    useSymbolSearch,
+    symbolIdentityKey,
+    type SearchableSymbol,
+    type SymbolSearchFn,
+  } from '../composables/useSymbolSearch'
   import { useTeleportedPopup } from '../composables/useTeleportedPopup'
 
   import IconTablerAlertTriangle from '~icons/tabler/alert-triangle'
 
-  export interface SymbolItem {
-    symbol: string
-    description: string
-    exchange: string
-    source: string
-  }
+  export interface SymbolItem extends SearchableSymbol {}
 
   const props = defineProps<{
     symbol: string
     symbols: SymbolItem[]
+    search?: SymbolSearchFn<SymbolItem>
     loading?: boolean
     error?: boolean
   }>()
@@ -168,15 +173,14 @@
     return props.symbol
   })
 
-  const filteredSymbols = computed<SymbolItem[]>(() => {
-    const q = searchQuery.value.trim().toLowerCase()
-    if (!q) return props.symbols
-    return props.symbols.filter(
-      (s) =>
-        s.symbol.toLowerCase().includes(q) ||
-        s.description.toLowerCase().includes(q) ||
-        s.exchange.toLowerCase().includes(q),
-    )
+  const {
+    results: filteredSymbols,
+    loading: searchLoading,
+    error: searchError,
+  } = useSymbolSearch<SymbolItem>({
+    query: searchQuery,
+    symbols: computed(() => props.symbols),
+    search: computed(() => props.search),
   })
 
   function togglePopup() {
@@ -198,8 +202,6 @@
     searchQuery.value = ''
     searchInputRef.value?.focus()
   }
-
-  function onSearchInput() {}
 
   function selectSymbol(item: SymbolItem) {
     emit('change', item)

--- a/packages/vue/src/components/SymbolSelector.vue
+++ b/packages/vue/src/components/SymbolSelector.vue
@@ -70,6 +70,7 @@
                 <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
               </svg>
             </button>
+            <AggregationSourceButton @click="emit('manageSources')" />
           </div>
 
           <div class="symbol-list" role="listbox" aria-label="商品列表">
@@ -133,6 +134,7 @@
   } from '../composables/useSymbolSearch'
   import { useTeleportedPopup } from '../composables/useTeleportedPopup'
 
+  import AggregationSourceButton from './AggregationSourceButton.vue'
   import IconTablerAlertTriangle from '~icons/tabler/alert-triangle'
 
   export interface SymbolItem extends SearchableSymbol {}
@@ -148,6 +150,7 @@
 
   const emit = defineEmits<{
     (e: 'change', symbol: SymbolItem): void
+    (e: 'manageSources'): void
   }>()
 
   const showPopup = ref(false)

--- a/packages/vue/src/components/SymbolSelector.vue
+++ b/packages/vue/src/components/SymbolSelector.vue
@@ -103,9 +103,9 @@
               :key="symbolIdentityKey(item)"
               type="button"
               class="symbol-list__item"
-              :class="{ 'is-active': item.symbol === symbol }"
+              :class="{ 'is-active': symbolIdentityKey(item) === selectedKey }"
               role="option"
-              :aria-selected="item.symbol === symbol"
+              :aria-selected="symbolIdentityKey(item) === selectedKey"
               @click="selectSymbol(item)"
             >
               <span class="symbol-list__left">
@@ -139,6 +139,7 @@
 
   const props = defineProps<{
     symbol: string
+    selectedItem?: SymbolItem
     symbols: SymbolItem[]
     search?: SymbolSearchFn<SymbolItem>
     loading?: boolean
@@ -163,8 +164,14 @@
     8,
   )
 
+  const selectedKey = computed(() =>
+    props.selectedItem ? symbolIdentityKey(props.selectedItem) : undefined,
+  )
+
   const currentSymbol = computed<SymbolItem | undefined>(() =>
-    props.symbols.find((s) => s.symbol === props.symbol),
+    selectedKey.value
+      ? props.symbols.find((s) => symbolIdentityKey(s) === selectedKey.value)
+      : props.symbols.find((s) => s.symbol === props.symbol),
   )
 
   const displayText = computed(() => {

--- a/packages/vue/src/components/SymbolSelector.vue
+++ b/packages/vue/src/components/SymbolSelector.vue
@@ -23,6 +23,11 @@
           role="dialog"
           aria-label="切换合约"
         >
+          <AggregationSourceTabs
+            v-if="sourceTabs.length > 0"
+            v-model="activeSourceTab"
+            :tabs="sourceTabs"
+          />
           <div class="symbol-search">
             <span class="symbol-search__icon" aria-hidden="true">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -123,6 +128,7 @@
 </template>
 
 <script setup lang="ts">
+  import type { DataFetcherDefinition } from '@363045841yyt/klinechart-core/controllers'
   import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 
   import { useFullscreenTeleportTarget } from '../composables/useFullscreenTeleportTarget'
@@ -135,18 +141,32 @@
   import { useTeleportedPopup } from '../composables/useTeleportedPopup'
 
   import AggregationSourceButton from './AggregationSourceButton.vue'
+  import AggregationSourceTabs, {
+    type AggregationSourceTabItem,
+    type AggregationSourceTabKey,
+  } from './AggregationSourceTabs.vue'
   import IconTablerAlertTriangle from '~icons/tabler/alert-triangle'
 
   export interface SymbolItem extends SearchableSymbol {}
 
-  const props = defineProps<{
-    symbol: string
-    selectedItem?: SymbolItem
-    symbols: SymbolItem[]
-    search?: SymbolSearchFn<SymbolItem>
-    loading?: boolean
-    error?: boolean
-  }>()
+  const props = withDefaults(
+    defineProps<{
+      symbol: string
+      selectedItem?: SymbolItem
+      symbols: SymbolItem[]
+      search?: SymbolSearchFn<SymbolItem>
+      loading?: boolean
+      error?: boolean
+      /** 已注册数据源，用于 Tabs 展示名 */
+      aggregationSources?: ReadonlyArray<DataFetcherDefinition>
+      /** 已启用的搜索源名称 */
+      enabledSourceNames?: ReadonlySet<string>
+    }>(),
+    {
+      aggregationSources: () => [],
+      enabledSourceNames: () => new Set<string>(),
+    },
+  )
 
   const emit = defineEmits<{
     (e: 'change', symbol: SymbolItem): void
@@ -155,9 +175,29 @@
 
   const showPopup = ref(false)
   const searchQuery = ref('')
+  const activeSourceTab = ref<AggregationSourceTabKey>('all')
   const searchInputRef = ref<HTMLInputElement | null>(null)
   const chipWrapRef = ref<HTMLElement | null>(null)
   const popupRef = ref<HTMLElement | null>(null)
+
+  /** 全部 + 已启用且可搜索的源；mock 沉底 */
+  const sourceTabs = computed<AggregationSourceTabItem[]>(() => {
+    const enabled = props.enabledSourceNames
+    const searchable = props.aggregationSources
+      .filter(
+        (source) =>
+          enabled.has(source.name) &&
+          source.capabilities?.includes('search') &&
+          typeof source.searcher === 'function',
+      )
+      .slice()
+      .sort((a, b) => Number(a.name.startsWith('mock-')) - Number(b.name.startsWith('mock-')))
+    if (searchable.length === 0) return []
+    return [
+      { key: 'all', label: '全部' },
+      ...searchable.map((source) => ({ key: source.name, label: source.displayName })),
+    ]
+  })
 
   const teleportTarget = useFullscreenTeleportTarget()
 
@@ -191,6 +231,7 @@
     query: searchQuery,
     symbols: computed(() => props.symbols),
     search: computed(() => props.search),
+    sourceFilter: activeSourceTab,
   })
 
   function togglePopup() {
@@ -205,6 +246,14 @@
       startPositionSync()
     } else {
       stopPositionSync()
+      activeSourceTab.value = 'all'
+    }
+  })
+
+  // 启用列表变化时，若当前 Tab 已不存在则回到全部
+  watch(sourceTabs, (tabs) => {
+    if (!tabs.some((tab) => tab.key === activeSourceTab.value)) {
+      activeSourceTab.value = 'all'
     }
   })
 

--- a/packages/vue/src/components/SymbolSelector.vue
+++ b/packages/vue/src/components/SymbolSelector.vue
@@ -118,7 +118,7 @@
                 <span class="symbol-list__code">{{ item.symbol }}</span>
                 <span class="symbol-list__desc">{{ item.description }}</span>
               </span>
-              <span class="symbol-list__exchange">{{ item.exchange }}</span>
+              <span class="symbol-list__exchange">{{ formatSymbolMeta(item) }}</span>
             </button>
           </div>
         </div>
@@ -266,6 +266,15 @@
     emit('change', item)
     showPopup.value = false
     searchQuery.value = ''
+  }
+
+  /** 展示 exchange + kind + market/category，便于区分同代码多语义 */
+  function formatSymbolMeta(item: SymbolItem): string {
+    const parts = [item.exchange]
+    if (typeof item.params?.kind === 'string') parts.push(String(item.params.kind))
+    if (typeof item.params?.market === 'number') parts.push(`M${item.params.market}`)
+    if (typeof item.params?.category === 'number') parts.push(`C${item.params.category}`)
+    return parts.join(' · ')
   }
 
   function onDocumentClick(e: MouseEvent) {

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -16,6 +16,7 @@
       :loading="symbolLoading"
       :error="symbolError"
       @change="onSymbolSelectorChange"
+      @manage-sources="showSourceDialog = true"
     />
     <CompareSymbolSelector
       :symbols="symbolPool"
@@ -26,6 +27,7 @@
       :comparison-loading="comparisonLoading"
       @add="emit('addOverlaySymbol', $event)"
       @remove="emit('removeOverlaySymbol', $event)"
+      @manage-sources="showSourceDialog = true"
     />
     <KLineLevelDropdown
       :model-value="kLineLevel"
@@ -45,22 +47,36 @@
     >
       ← 返回
     </button>
+    <AggregationSourceDialog
+      :show="showSourceDialog"
+      :sources="aggregationSources"
+      :enabled-names="enabledSourceNames"
+      :endpoints="sourceEndpoints"
+      @close="showSourceDialog = false"
+      @toggle="onToggleAggregationSource"
+      @update-endpoint="onUpdateSourceEndpoint"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+  import type { DataFetcherDefinition } from '@363045841yyt/klinechart-core/controllers'
   import { computed, ref } from 'vue'
 
+  import type { AggregationSourceEndpoint } from '../composables/useAggregationSources'
+  import type { SymbolSearchFn } from '../composables/useSymbolSearch'
+
+  import AggregationSourceDialog from './AggregationSourceDialog.vue'
   import CompareSymbolSelector from './CompareSymbolSelector.vue'
   import KLineAdjustmentDropdown, { type KLineAdjustment } from './KLineAdjustmentDropdown.vue'
   import KLineLevelDropdown, { type KLineLevel } from './KLineLevelDropdown.vue'
   import SymbolSelector from './SymbolSelector.vue'
   import type { SymbolItem } from './SymbolSelector.vue'
-  import type { SymbolSearchFn } from '../composables/useSymbolSearch'
 
   export type { SymbolItem }
 
   const toolbarRef = ref<HTMLElement | null>(null)
+  const showSourceDialog = ref(false)
 
   let isDown = false
   let startX = 0
@@ -95,21 +111,31 @@
     el.style.userSelect = ''
   }
 
-  const props = defineProps<{
-    symbol?: string
-    symbolItem?: SymbolItem
-    kLineLevel?: string
-    kLineAdjust?: string
-    symbols?: SymbolItem[]
-    search?: SymbolSearchFn<SymbolItem>
-    symbolLoading?: boolean
-    symbolError?: boolean
-    overlaySymbols?: string[]
-    overlaySymbolItems?: SymbolItem[]
-    comparisonColors?: Map<string, string>
-    comparisonLoading?: boolean
-    showBackButton?: boolean
-  }>()
+  const props = withDefaults(
+    defineProps<{
+      symbol?: string
+      symbolItem?: SymbolItem
+      kLineLevel?: string
+      kLineAdjust?: string
+      symbols?: SymbolItem[]
+      search?: SymbolSearchFn<SymbolItem>
+      symbolLoading?: boolean
+      symbolError?: boolean
+      overlaySymbols?: string[]
+      overlaySymbolItems?: SymbolItem[]
+      comparisonColors?: Map<string, string>
+      comparisonLoading?: boolean
+      showBackButton?: boolean
+      aggregationSources?: ReadonlyArray<DataFetcherDefinition>
+      enabledSourceNames?: ReadonlySet<string>
+      sourceEndpoints?: Record<string, AggregationSourceEndpoint>
+    }>(),
+    {
+      aggregationSources: () => [],
+      enabledSourceNames: () => new Set<string>(),
+      sourceEndpoints: () => ({}),
+    },
+  )
 
   const emit = defineEmits<{
     (e: 'addOverlaySymbol', item: SymbolItem): void
@@ -117,6 +143,8 @@
     (e: 'kLineLevelChange', level: KLineLevel): void
     (e: 'kLineAdjustChange', adjust: KLineAdjustment): void
     (e: 'symbolChange', symbol: SymbolItem): void
+    (e: 'toggleAggregationSource', name: string, enabled: boolean): void
+    (e: 'updateSourceEndpoint', name: string, patch: Partial<AggregationSourceEndpoint>): void
     (e: 'back'): void
   }>()
 
@@ -128,6 +156,14 @@
 
   function onSymbolSelectorChange(item: SymbolItem) {
     emit('symbolChange', item)
+  }
+
+  function onToggleAggregationSource(name: string, enabled: boolean) {
+    emit('toggleAggregationSource', name, enabled)
+  }
+
+  function onUpdateSourceEndpoint(name: string, patch: Partial<AggregationSourceEndpoint>) {
+    emit('updateSourceEndpoint', name, patch)
   }
 </script>
 

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -15,6 +15,8 @@
       :search="search"
       :loading="symbolLoading"
       :error="symbolError"
+      :aggregation-sources="aggregationSources"
+      :enabled-source-names="enabledSourceNames"
       @change="onSymbolSelectorChange"
       @manage-sources="showSourceDialog = true"
     />
@@ -25,6 +27,8 @@
       :selected-items="overlaySymbolItems"
       :comparison-colors="comparisonColors"
       :comparison-loading="comparisonLoading"
+      :aggregation-sources="aggregationSources"
+      :enabled-source-names="enabledSourceNames"
       @add="emit('addOverlaySymbol', $event)"
       @remove="emit('removeOverlaySymbol', $event)"
       @manage-sources="showSourceDialog = true"

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -10,6 +10,7 @@
     <SymbolSelector
       v-if="displaySymbol"
       :symbol="displaySymbol"
+      :selected-item="symbolItem"
       :symbols="symbolPool"
       :search="search"
       :loading="symbolLoading"
@@ -96,6 +97,7 @@
 
   const props = defineProps<{
     symbol?: string
+    symbolItem?: SymbolItem
     kLineLevel?: string
     kLineAdjust?: string
     symbols?: SymbolItem[]

--- a/packages/vue/src/components/TopToolbar.vue
+++ b/packages/vue/src/components/TopToolbar.vue
@@ -11,12 +11,14 @@
       v-if="displaySymbol"
       :symbol="displaySymbol"
       :symbols="symbolPool"
+      :search="search"
       :loading="symbolLoading"
       :error="symbolError"
       @change="onSymbolSelectorChange"
     />
     <CompareSymbolSelector
       :symbols="symbolPool"
+      :search="search"
       :selected="overlaySymbols"
       :selected-items="overlaySymbolItems"
       :comparison-colors="comparisonColors"
@@ -53,6 +55,7 @@
   import KLineLevelDropdown, { type KLineLevel } from './KLineLevelDropdown.vue'
   import SymbolSelector from './SymbolSelector.vue'
   import type { SymbolItem } from './SymbolSelector.vue'
+  import type { SymbolSearchFn } from '../composables/useSymbolSearch'
 
   export type { SymbolItem }
 
@@ -96,6 +99,7 @@
     kLineLevel?: string
     kLineAdjust?: string
     symbols?: SymbolItem[]
+    search?: SymbolSearchFn<SymbolItem>
     symbolLoading?: boolean
     symbolError?: boolean
     overlaySymbols?: string[]

--- a/packages/vue/src/components/alert/AlertDialog.vue
+++ b/packages/vue/src/components/alert/AlertDialog.vue
@@ -76,14 +76,12 @@
                 <span class="rule-item-predicate">{{ describePredicate(rule) }}</span>
               </div>
               <div class="rule-item-actions">
-                <label class="rule-toggle" :title="rule.enabled ? '禁用' : '启用'">
-                  <input
-                    type="checkbox"
-                    :checked="rule.enabled"
-                    @change="toggleRule(rule.id, !rule.enabled)"
-                  />
-                  <span class="rule-toggle-slider"></span>
-                </label>
+                <ToggleSwitch
+                  :model-value="rule.enabled"
+                  :title="rule.enabled ? '禁用' : '启用'"
+                  :aria-label="`${rule.name}启用状态`"
+                  @update:model-value="toggleRule(rule.id, $event)"
+                />
                 <button class="rule-item-btn" title="编辑" @click="startEditRule(rule)">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M4 20h4L18.5 9.5a2 2 0 0 0-3-3L4 16v4" />
@@ -222,6 +220,7 @@
 
   import { useAlerts } from '../../composables/useAlerts'
   import BaseModal from '../BaseModal.vue'
+  import ToggleSwitch from '../common/ToggleSwitch.vue'
 
   import AlertRuleForm from './AlertRuleForm.vue'
 
@@ -687,58 +686,6 @@
   .rule-meta-icon {
     width: 10px;
     height: 10px;
-  }
-
-  /* ══════════════════════════════════════════
-   Toggle Switch
-══════════════════════════════════════════ */
-  .rule-toggle {
-    position: relative;
-    display: inline-block;
-    width: 32px;
-    height: 18px;
-    cursor: pointer;
-    flex-shrink: 0;
-  }
-
-  .rule-toggle input {
-    position: absolute;
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-
-  .rule-toggle-slider {
-    position: absolute;
-    inset: 0;
-    background: var(--klc-color-border-button);
-    border-radius: 999px;
-    transition: background 0.2s;
-  }
-
-  .rule-toggle-slider::before {
-    content: '';
-    position: absolute;
-    left: 2px;
-    top: 2px;
-    width: 14px;
-    height: 14px;
-    background: #fff;
-    border-radius: 50%;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-
-  .rule-toggle input:checked + .rule-toggle-slider {
-    background: #3b82f6;
-  }
-
-  .rule-toggle input:checked + .rule-toggle-slider::before {
-    transform: translateX(14px);
-  }
-
-  .rule-toggle:hover .rule-toggle-slider {
-    filter: brightness(1.08);
   }
 
   /* ══════════════════════════════════════════

--- a/packages/vue/src/components/alert/AlertRuleForm.vue
+++ b/packages/vue/src/components/alert/AlertRuleForm.vue
@@ -186,10 +186,7 @@
           <span class="rule-form-advanced-label">单次触发</span>
           <span class="rule-form-advanced-hint">触发后自动禁用本规则</span>
         </div>
-        <label class="rule-toggle">
-          <input v-model="draftOneShot" type="checkbox" />
-          <span class="rule-toggle-slider"></span>
-        </label>
+        <ToggleSwitch v-model="draftOneShot" aria-label="单次触发" />
       </div>
 
       <div class="rule-form-advanced-divider"></div>
@@ -240,6 +237,8 @@
     IndicatorCrossPairDirection,
   } from '@363045841yyt/klinechart-core'
   import { ref, computed, reactive } from 'vue'
+
+  import ToggleSwitch from '../common/ToggleSwitch.vue'
 
   const props = defineProps<{ rule?: AlertRule }>()
 
@@ -649,54 +648,6 @@
     width: 88px;
     text-align: right;
     padding-right: 30px;
-  }
-
-  /* ══════════════════════════════════════════
-   Toggle Switch
-══════════════════════════════════════════ */
-  .rule-toggle {
-    position: relative;
-    display: inline-block;
-    width: 34px;
-    height: 20px;
-    cursor: pointer;
-    flex-shrink: 0;
-  }
-
-  .rule-toggle input {
-    position: absolute;
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-
-  .rule-toggle-slider {
-    position: absolute;
-    inset: 0;
-    background: var(--klc-color-border-button);
-    border-radius: 999px;
-    transition: background 0.2s;
-  }
-
-  .rule-toggle-slider::before {
-    content: '';
-    position: absolute;
-    left: 3px;
-    top: 3px;
-    width: 14px;
-    height: 14px;
-    background: #fff;
-    border-radius: 50%;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.22);
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-
-  .rule-toggle input:checked + .rule-toggle-slider {
-    background: #3b82f6;
-  }
-
-  .rule-toggle input:checked + .rule-toggle-slider::before {
-    transform: translateX(14px);
   }
 
   /* ══════════════════════════════════════════

--- a/packages/vue/src/components/common/CollapsibleSection.vue
+++ b/packages/vue/src/components/common/CollapsibleSection.vue
@@ -1,0 +1,110 @@
+<template>
+  <section class="collapsible-section">
+    <button
+      type="button"
+      class="collapsible-section__header"
+      :aria-expanded="expanded"
+      @click="emit('toggle')"
+    >
+      <span class="collapsible-section__label">
+        <slot name="label">{{ label }}</slot>
+      </span>
+      <svg
+        class="collapsible-section__chevron"
+        :class="{ 'is-expanded': expanded }"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        width="14"
+        height="14"
+        aria-hidden="true"
+      >
+        <path d="M9 18l6-6-6-6" />
+      </svg>
+    </button>
+    <div v-show="expanded" class="collapsible-section__body">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+  /**
+   * 可折叠分区
+   * 与图表设置同一套 header / chevron / body 视觉
+   */
+  defineProps<{
+    /** 是否展开 */
+    expanded: boolean
+    /** 标题文案；也可用 #label 插槽 */
+    label?: string
+  }>()
+
+  const emit = defineEmits<{
+    toggle: []
+  }>()
+</script>
+
+<style scoped>
+  .collapsible-section {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .collapsible-section + .collapsible-section {
+    margin-top: 4px;
+  }
+
+  .collapsible-section__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+    min-height: 36px;
+    margin: 0;
+    padding: 8px 12px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.15s ease;
+  }
+
+  .collapsible-section__header:hover {
+    background: var(--klc-color-tag-bg-hover);
+  }
+
+  .collapsible-section__label {
+    font-size: 12px;
+    color: var(--klc-color-axis-text);
+    font-weight: 500;
+    white-space: nowrap;
+    line-height: 1;
+    letter-spacing: 0.3px;
+  }
+
+  .collapsible-section__chevron {
+    flex-shrink: 0;
+    color: var(--klc-color-axis-text);
+    transform: rotate(0deg);
+    transition:
+      transform 0.15s ease,
+      color 0.15s ease;
+  }
+
+  .collapsible-section__chevron.is-expanded {
+    transform: rotate(90deg);
+  }
+
+  .collapsible-section__header:hover .collapsible-section__chevron {
+    color: var(--klc-color-foreground);
+  }
+
+  .collapsible-section__body {
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/packages/vue/src/components/common/ToggleSwitch.vue
+++ b/packages/vue/src/components/common/ToggleSwitch.vue
@@ -1,0 +1,87 @@
+<template>
+  <label class="toggle-switch" :class="{ 'is-disabled': disabled }">
+    <input
+      type="checkbox"
+      :checked="modelValue"
+      :disabled="disabled"
+      :aria-label="ariaLabel"
+      @change="emit('update:modelValue', ($event.target as HTMLInputElement).checked)"
+    />
+    <span class="toggle-switch__track" aria-hidden="true">
+      <span class="toggle-switch__thumb" />
+    </span>
+  </label>
+</template>
+
+<script setup lang="ts">
+  defineProps<{
+    modelValue: boolean
+    disabled?: boolean
+    ariaLabel?: string
+  }>()
+
+  const emit = defineEmits<{
+    'update:modelValue': [value: boolean]
+  }>()
+</script>
+
+<style scoped>
+  .toggle-switch {
+    position: relative;
+    flex: 0 0 auto;
+    display: inline-block;
+    width: 34px;
+    height: 20px;
+    margin: 0;
+    cursor: pointer;
+  }
+
+  .toggle-switch.is-disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+
+  .toggle-switch input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    opacity: 0;
+    cursor: inherit;
+  }
+
+  .toggle-switch__track {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border-radius: 10px;
+    background: var(--klc-color-border-button);
+    transition: background 0.15s ease;
+  }
+
+  .toggle-switch__thumb {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--klc-color-background);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transition: transform 0.15s ease;
+  }
+
+  .toggle-switch input:checked + .toggle-switch__track {
+    background: var(--klc-color-primary, #2962ff);
+  }
+
+  .toggle-switch input:checked + .toggle-switch__track .toggle-switch__thumb {
+    transform: translateX(14px);
+  }
+
+  .toggle-switch input:focus-visible + .toggle-switch__track {
+    outline: 2px solid var(--klc-color-axis-text);
+    outline-offset: 2px;
+  }
+</style>

--- a/packages/vue/src/composables/__tests__/useAggregationSources.test.ts
+++ b/packages/vue/src/composables/__tests__/useAggregationSources.test.ts
@@ -1,0 +1,124 @@
+import {
+  clearFetcherBaseUrlsForTest,
+  getFetcherBaseUrl,
+  type DataFetcherDefinition,
+} from '@363045841yyt/klinechart-core/controllers'
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  AGGREGATION_SOURCES_STORAGE_KEY,
+  applyAggregationSourceBaseUrls,
+  probeAggregationSource,
+  resolveAggregationSourceEndpoints,
+  resolveEnabledAggregationSources,
+  useAggregationSources,
+} from '../useAggregationSources'
+
+const fetcher = async () => []
+const searcher = async () => []
+
+function source(
+  name: string,
+  options: { searchable?: boolean; defaultBaseUrl?: string } = {},
+): DataFetcherDefinition {
+  const searchable = options.searchable ?? true
+  return {
+    name,
+    displayName: name.toUpperCase(),
+    capabilities: searchable ? ['search'] : ['daily'],
+    defaultBaseUrl: options.defaultBaseUrl,
+    fetcher,
+    searcher: searchable ? searcher : undefined,
+  }
+}
+
+describe('useAggregationSources', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    clearFetcherBaseUrlsForTest()
+  })
+
+  afterEach(() => {
+    clearFetcherBaseUrlsForTest()
+  })
+
+  it('enables every searchable fetcher on first use', () => {
+    expect(
+      resolveEnabledAggregationSources([source('first'), source('chart-only', { searchable: false })]),
+    ).toEqual(['first'])
+  })
+
+  it('keeps disabled fetchers disabled and enables newly registered fetchers', () => {
+    expect(
+      resolveEnabledAggregationSources([source('first'), source('second')], {
+        known: ['first'],
+        enabled: [],
+      }),
+    ).toEqual(['second'])
+  })
+
+  it('restores host and port from stored base URLs', () => {
+    expect(
+      resolveAggregationSourceEndpoints(
+        [source('gotdx', { defaultBaseUrl: 'http://127.0.0.1:8080' })],
+        {
+          known: ['gotdx'],
+          enabled: ['gotdx'],
+          baseUrls: { gotdx: 'http://192.168.1.8:9090' },
+        },
+      ),
+    ).toEqual({
+      gotdx: { host: '192.168.1.8', port: '9090' },
+    })
+  })
+
+  it('applies endpoint edits to the core runtime base URL', () => {
+    applyAggregationSourceBaseUrls(
+      [source('gotdx', { defaultBaseUrl: 'http://127.0.0.1:8080' })],
+      { gotdx: { host: '10.0.0.2', port: '7000' } },
+    )
+
+    expect(getFetcherBaseUrl('gotdx', 'http://127.0.0.1:8080')).toBe('http://10.0.0.2:7000')
+  })
+
+  it('persists toggle and endpoint changes', async () => {
+    const state = useAggregationSources([
+      source('first', { defaultBaseUrl: 'http://127.0.0.1:8080' }),
+      source('second'),
+    ])
+
+    state.setEnabled('first', false)
+    state.setEndpoint('first', { host: '192.168.0.10', port: '18080' })
+    await nextTick()
+
+    expect(JSON.parse(window.localStorage.getItem(AGGREGATION_SOURCES_STORAGE_KEY) ?? '')).toEqual({
+      known: ['first', 'second'],
+      enabled: ['second'],
+      baseUrls: {
+        first: 'http://192.168.0.10:18080',
+      },
+    })
+  })
+
+  it('marks a fetcher online when its search probe succeeds', async () => {
+    const search = vi.fn().mockResolvedValue([])
+    const definition = { ...source('first'), searcher: search }
+    const controller = new AbortController()
+
+    await expect(probeAggregationSource(definition, controller.signal)).resolves.toBe('online')
+    expect(search).toHaveBeenCalledWith('first', {
+      query: '0',
+      limit: 1,
+      signal: controller.signal,
+    })
+  })
+
+  it('marks a fetcher offline when its search probe fails', async () => {
+    const definition = { ...source('first'), searcher: vi.fn().mockRejectedValue(new Error('down')) }
+
+    await expect(probeAggregationSource(definition, new AbortController().signal)).resolves.toBe(
+      'offline',
+    )
+  })
+})

--- a/packages/vue/src/composables/__tests__/useSymbolSearch.test.ts
+++ b/packages/vue/src/composables/__tests__/useSymbolSearch.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   symbolIdentityKey,
-  uniqueSymbolsByCode,
+  uniqueSymbolsByIdentity,
   useSymbolSearch,
   type SearchableSymbol,
   type SymbolSearchFn,
@@ -100,11 +100,11 @@ describe('useSymbolSearch', () => {
     expect(symbolIdentityKey(main)).not.toBe(symbolIdentityKey(extended))
   })
 
-  it('keeps one comparison candidate per symbol code', () => {
+  it('keeps comparison candidates with the same code but distinct identities', () => {
     const first = { ...catalog[0]!, params: { market: 1 } }
     const duplicate = { ...catalog[0]!, exchange: 'CN', params: { category: 1 } }
 
-    expect(uniqueSymbolsByCode([first, duplicate])).toEqual([first])
+    expect(uniqueSymbolsByIdentity([first, duplicate])).toEqual([first, duplicate])
   })
 
   it('keeps local results and exposes an error when remote search fails', async () => {

--- a/packages/vue/src/composables/__tests__/useSymbolSearch.test.ts
+++ b/packages/vue/src/composables/__tests__/useSymbolSearch.test.ts
@@ -60,9 +60,30 @@ describe('useSymbolSearch', () => {
 
     await vi.advanceTimersByTimeAsync(250)
 
-    expect(search).toHaveBeenCalledWith('600', 20, expect.any(AbortSignal))
+    expect(search).toHaveBeenCalledWith('600', 20, expect.any(AbortSignal), undefined)
     expect(state.results.value.map((item) => item.symbol)).toEqual(['600519', '600036'])
     expect(state.loading.value).toBe(false)
+  })
+
+  it('filters local catalog and remote search by the selected source tab', async () => {
+    const query = ref('A')
+    const sourceFilter = ref<'all' | string>('tradingview')
+    const search = vi.fn<SymbolSearchFn<SearchableSymbol>>().mockResolvedValue([
+      { symbol: 'AMZN', description: 'Amazon', exchange: 'NASDAQ', source: 'tradingview' },
+    ])
+    const state = useSymbolSearch({
+      query,
+      symbols: ref(catalog),
+      search: ref(search),
+      sourceFilter,
+    })
+
+    expect(state.results.value.map((item) => item.symbol)).toEqual(['AAPL'])
+
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(search).toHaveBeenCalledWith('A', 20, expect.any(AbortSignal), ['tradingview'])
+    expect(state.results.value.map((item) => item.symbol)).toEqual(['AAPL', 'AMZN'])
   })
 
   it('ignores an older response that resolves after a newer query', async () => {

--- a/packages/vue/src/composables/__tests__/useSymbolSearch.test.ts
+++ b/packages/vue/src/composables/__tests__/useSymbolSearch.test.ts
@@ -1,0 +1,132 @@
+import { computed, nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  symbolIdentityKey,
+  uniqueSymbolsByCode,
+  useSymbolSearch,
+  type SearchableSymbol,
+  type SymbolSearchFn,
+} from '../useSymbolSearch'
+
+const catalog: SearchableSymbol[] = [
+  {
+    symbol: '600519',
+    description: '贵州茅台',
+    exchange: 'SH',
+    source: 'gotdx',
+    params: { market: 1 },
+  },
+  { symbol: 'AAPL', description: 'Apple Inc.', exchange: 'NASDAQ', source: 'tradingview' },
+]
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+describe('useSymbolSearch', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('debounces remote search and merges it with local matches', async () => {
+    const symbols = ref(catalog)
+    const search = vi.fn<SymbolSearchFn<SearchableSymbol>>().mockResolvedValue([
+      catalog[0],
+      {
+        symbol: '600036',
+        description: '招商银行',
+        exchange: 'SH',
+        source: 'gotdx',
+        params: { market: 1 },
+      },
+    ])
+    const query = ref('')
+    const state = useSymbolSearch({
+      query,
+      symbols: computed(() => symbols.value),
+      search: computed(() => search),
+    })
+
+    query.value = '600'
+    await nextTick()
+    expect(state.results.value.map((item) => item.symbol)).toEqual(['600519'])
+    expect(search).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(search).toHaveBeenCalledWith('600', 20, expect.any(AbortSignal))
+    expect(state.results.value.map((item) => item.symbol)).toEqual(['600519', '600036'])
+    expect(state.loading.value).toBe(false)
+  })
+
+  it('ignores an older response that resolves after a newer query', async () => {
+    const first = deferred<ReadonlyArray<SearchableSymbol>>()
+    const second = deferred<ReadonlyArray<SearchableSymbol>>()
+    const signals: AbortSignal[] = []
+    const search = vi.fn((...args: unknown[]) => {
+      signals.push(args[2] as AbortSignal)
+      return signals.length === 1 ? first.promise : second.promise
+    }) as unknown as SymbolSearchFn<SearchableSymbol>
+    const query = ref('first')
+    const state = useSymbolSearch({
+      query,
+      symbols: ref<ReadonlyArray<SearchableSymbol>>([]),
+      search: ref(search),
+    })
+
+    await vi.advanceTimersByTimeAsync(250)
+    query.value = 'second'
+    await nextTick()
+    expect(signals[0]?.aborted).toBe(true)
+    await vi.advanceTimersByTimeAsync(250)
+    second.resolve([{ symbol: 'SECOND', description: 'Second', exchange: 'TEST', source: 'test' }])
+    await Promise.resolve()
+    first.resolve([{ symbol: 'FIRST', description: 'First', exchange: 'TEST', source: 'test' }])
+    await Promise.resolve()
+
+    expect(state.results.value.map((item) => item.symbol)).toEqual(['SECOND'])
+  })
+
+  it('builds distinct identities for the same code in different markets', () => {
+    const main = { ...catalog[0]!, params: { market: 1 } }
+    const extended = { ...catalog[0]!, params: { category: 31 } }
+
+    expect(symbolIdentityKey(main)).not.toBe(symbolIdentityKey(extended))
+  })
+
+  it('keeps one comparison candidate per symbol code', () => {
+    const first = { ...catalog[0]!, params: { market: 1 } }
+    const duplicate = { ...catalog[0]!, exchange: 'CN', params: { category: 1 } }
+
+    expect(uniqueSymbolsByCode([first, duplicate])).toEqual([first])
+  })
+
+  it('keeps local results and exposes an error when remote search fails', async () => {
+    const query = ref('Apple')
+    const search = vi.fn().mockRejectedValue(new Error('offline'))
+    const state = useSymbolSearch({ query, symbols: ref(catalog), search: ref(search) })
+
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(state.results.value.map((item) => item.symbol)).toEqual(['AAPL'])
+    expect(state.error.value).toBe(true)
+    expect(state.loading.value).toBe(false)
+  })
+
+  it('shows the full local catalog without calling search for an empty query', async () => {
+    const query = ref('')
+    const search = vi.fn()
+    const state = useSymbolSearch({ query, symbols: ref(catalog), search: ref(search) })
+
+    await vi.advanceTimersByTimeAsync(250)
+
+    expect(state.results.value).toEqual(catalog)
+    expect(search).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vue/src/composables/useAggregationSources.ts
+++ b/packages/vue/src/composables/useAggregationSources.ts
@@ -1,0 +1,187 @@
+import {
+  composeFetcherBaseUrl,
+  parseFetcherEndpoint,
+  setFetcherBaseUrl,
+  type DataFetcherDefinition,
+} from '@363045841yyt/klinechart-core/controllers'
+import { computed, ref, watch } from 'vue'
+
+/** localStorage 键：启用列表 + 各源地址覆盖 */
+export const AGGREGATION_SOURCES_STORAGE_KEY = 'klinechart.aggregation-sources'
+
+/** 单个数据源的地址编辑草稿 */
+export interface AggregationSourceEndpoint {
+  host: string
+  port: string
+}
+
+interface StoredAggregationSources {
+  known: string[]
+  enabled: string[]
+  /** source name -> 完整 Base URL */
+  baseUrls?: Record<string, string>
+}
+
+export type AggregationSourceStatus = 'checking' | 'online' | 'offline'
+
+/**
+ * 对支持搜索的数据源做一次轻量拨测
+ * @remarks 查询 "0"、limit 1；只关心请求成败，不要求返回结果
+ */
+export async function probeAggregationSource(
+  source: DataFetcherDefinition,
+  signal: AbortSignal,
+): Promise<Exclude<AggregationSourceStatus, 'checking'>> {
+  if (!source.capabilities?.includes('search') || typeof source.searcher !== 'function') {
+    return 'offline'
+  }
+  try {
+    await source.searcher(source.name, { query: '0', limit: 1, signal })
+    return 'online'
+  } catch {
+    return 'offline'
+  }
+}
+
+function readStoredSources(): StoredAggregationSources | undefined {
+  if (typeof window === 'undefined') return undefined
+  try {
+    const value = JSON.parse(window.localStorage.getItem(AGGREGATION_SOURCES_STORAGE_KEY) ?? '')
+    if (!Array.isArray(value?.known) || !Array.isArray(value?.enabled)) return undefined
+    return value
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * 根据注册表与已存配置，算出应启用的搜索源
+ * 首次：全部可搜索源启用；已有配置：新注册源默认启用，旧源沿用开关
+ */
+export function resolveEnabledAggregationSources(
+  sources: ReadonlyArray<DataFetcherDefinition>,
+  stored = readStoredSources(),
+): string[] {
+  const searchable = sources.filter(
+    (source) => source.capabilities?.includes('search') && typeof source.searcher === 'function',
+  )
+  if (!stored) return searchable.map((source) => source.name)
+
+  const known = new Set(stored.known)
+  const enabled = new Set(stored.enabled)
+  return searchable
+    .filter((source) => !known.has(source.name) || enabled.has(source.name))
+    .map((source) => source.name)
+}
+
+/**
+ * 从 definition.defaultBaseUrl 与 localStorage 合并出每个可配置源的 host/port
+ */
+export function resolveAggregationSourceEndpoints(
+  sources: ReadonlyArray<DataFetcherDefinition>,
+  stored = readStoredSources(),
+): Record<string, AggregationSourceEndpoint> {
+  const result: Record<string, AggregationSourceEndpoint> = {}
+  for (const source of sources) {
+    if (!source.defaultBaseUrl) continue
+    const baseUrl = stored?.baseUrls?.[source.name] ?? source.defaultBaseUrl
+    result[source.name] = parseFetcherEndpoint(baseUrl)
+  }
+  return result
+}
+
+/**
+ * 将 UI 上的 host/port 写回 core 运行时覆盖表
+ * 与默认相同则清除覆盖，避免多余状态
+ */
+export function applyAggregationSourceBaseUrls(
+  sources: ReadonlyArray<DataFetcherDefinition>,
+  endpoints: Record<string, AggregationSourceEndpoint>,
+): void {
+  for (const source of sources) {
+    if (!source.defaultBaseUrl) continue
+    const ep = endpoints[source.name]
+    if (!ep?.host.trim()) {
+      setFetcherBaseUrl(source.name, undefined)
+      continue
+    }
+    const next = composeFetcherBaseUrl(ep.host, ep.port, source.defaultBaseUrl)
+    const sameAsDefault =
+      next === source.defaultBaseUrl.replace(/\/+$/, '') ||
+      next === composeFetcherBaseUrl(
+        parseFetcherEndpoint(source.defaultBaseUrl).host,
+        parseFetcherEndpoint(source.defaultBaseUrl).port,
+        source.defaultBaseUrl,
+      )
+    setFetcherBaseUrl(source.name, sameAsDefault ? undefined : next)
+  }
+}
+
+/**
+ * 聚合源启用状态 + 地址端口
+ * 变更会同步到 localStorage 与 core setFetcherBaseUrl
+ */
+export function useAggregationSources(sources: ReadonlyArray<DataFetcherDefinition>) {
+  const enabledNames = ref(resolveEnabledAggregationSources(sources))
+  const enabledNameSet = computed(() => new Set(enabledNames.value))
+  const endpoints = ref(resolveAggregationSourceEndpoints(sources))
+
+  // 启动时立刻把已存地址灌进 core，保证首轮搜索/K 线就走用户配置
+  applyAggregationSourceBaseUrls(sources, endpoints.value)
+
+  function setEnabled(name: string, enabled: boolean) {
+    const next = new Set(enabledNames.value)
+    if (enabled) next.add(name)
+    else next.delete(name)
+    enabledNames.value = sources.filter((source) => next.has(source.name)).map((source) => source.name)
+  }
+
+  /**
+   * 更新某个源的 host 或 port
+   * 立即写回 core 覆盖，并触发持久化 watch
+   */
+  function setEndpoint(name: string, patch: Partial<AggregationSourceEndpoint>) {
+    const current = endpoints.value[name] ?? { host: '', port: '' }
+    endpoints.value = {
+      ...endpoints.value,
+      [name]: {
+        host: patch.host ?? current.host,
+        port: patch.port ?? current.port,
+      },
+    }
+    applyAggregationSourceBaseUrls(sources, endpoints.value)
+  }
+
+  watch(
+    [enabledNames, endpoints],
+    () => {
+      if (typeof window === 'undefined') return
+      const baseUrls: Record<string, string> = {}
+      for (const source of sources) {
+        if (!source.defaultBaseUrl) continue
+        const ep = endpoints.value[source.name]
+        if (!ep?.host.trim()) continue
+        baseUrls[source.name] = composeFetcherBaseUrl(ep.host, ep.port, source.defaultBaseUrl)
+      }
+      const value: StoredAggregationSources = {
+        known: sources.map((source) => source.name),
+        enabled: enabledNames.value,
+        baseUrls,
+      }
+      try {
+        window.localStorage.setItem(AGGREGATION_SOURCES_STORAGE_KEY, JSON.stringify(value))
+      } catch {
+        // localStorage 不可用时保留当前会话状态
+      }
+    },
+    { deep: true, immediate: true },
+  )
+
+  return {
+    enabledNames,
+    enabledNameSet,
+    endpoints,
+    setEnabled,
+    setEndpoint,
+  }
+}

--- a/packages/vue/src/composables/useSymbolSearch.ts
+++ b/packages/vue/src/composables/useSymbolSearch.ts
@@ -18,6 +18,13 @@ export interface SearchableSymbol {
   params?: Readonly<Record<string, string | number | boolean>>
 }
 
+export type SymbolIdentity = {
+  symbol: string
+  exchange?: string
+  source?: string
+  params?: Readonly<Record<string, string | number | boolean>>
+}
+
 export type SymbolSearchFn<T extends SearchableSymbol = SearchableSymbol> = (
   query: string,
   limit: number,
@@ -40,18 +47,18 @@ function matchesQuery(item: SearchableSymbol, query: string): boolean {
   )
 }
 
-export function symbolIdentityKey(item: SearchableSymbol): string {
+export function symbolIdentityKey(item: SymbolIdentity): string {
   const params = Object.entries(item.params ?? {}).sort(([left], [right]) =>
     left.localeCompare(right),
   )
-  return JSON.stringify([item.source, item.exchange, item.symbol, params])
+  return JSON.stringify([item.source ?? '', item.exchange ?? '', item.symbol, params])
 }
 
-/** Comparison 当前以 symbol 作为唯一标识，同代码候选保留搜索排序最靠前的一项。 */
-export function uniqueSymbolsByCode<T extends SearchableSymbol>(symbols: ReadonlyArray<T>): T[] {
+export function uniqueSymbolsByIdentity<T extends SearchableSymbol>(symbols: ReadonlyArray<T>): T[] {
   const unique = new Map<string, T>()
   for (const item of symbols) {
-    if (!unique.has(item.symbol)) unique.set(item.symbol, item)
+    const key = symbolIdentityKey(item)
+    if (!unique.has(key)) unique.set(key, item)
   }
   return [...unique.values()]
 }

--- a/packages/vue/src/composables/useSymbolSearch.ts
+++ b/packages/vue/src/composables/useSymbolSearch.ts
@@ -1,0 +1,131 @@
+import {
+  computed,
+  getCurrentScope,
+  onScopeDispose,
+  ref,
+  shallowRef,
+  toValue,
+  watch,
+  type MaybeRefOrGetter,
+  type Ref,
+} from 'vue'
+
+export interface SearchableSymbol {
+  symbol: string
+  description: string
+  exchange: string
+  source: string
+  params?: Readonly<Record<string, string | number | boolean>>
+}
+
+export type SymbolSearchFn<T extends SearchableSymbol = SearchableSymbol> = (
+  query: string,
+  limit: number,
+  signal: AbortSignal,
+) => Promise<ReadonlyArray<T>>
+
+interface UseSymbolSearchOptions<T extends SearchableSymbol> {
+  query: Ref<string>
+  symbols: MaybeRefOrGetter<ReadonlyArray<T>>
+  search: MaybeRefOrGetter<SymbolSearchFn<T> | undefined>
+  limit?: number
+  debounceMs?: number
+}
+
+function matchesQuery(item: SearchableSymbol, query: string): boolean {
+  return (
+    item.symbol.toLowerCase().includes(query) ||
+    item.description.toLowerCase().includes(query) ||
+    item.exchange.toLowerCase().includes(query)
+  )
+}
+
+export function symbolIdentityKey(item: SearchableSymbol): string {
+  const params = Object.entries(item.params ?? {}).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )
+  return JSON.stringify([item.source, item.exchange, item.symbol, params])
+}
+
+/** Comparison 当前以 symbol 作为唯一标识，同代码候选保留搜索排序最靠前的一项。 */
+export function uniqueSymbolsByCode<T extends SearchableSymbol>(symbols: ReadonlyArray<T>): T[] {
+  const unique = new Map<string, T>()
+  for (const item of symbols) {
+    if (!unique.has(item.symbol)) unique.set(item.symbol, item)
+  }
+  return [...unique.values()]
+}
+
+export function useSymbolSearch<T extends SearchableSymbol>(options: UseSymbolSearchOptions<T>) {
+  const remoteResults = shallowRef<ReadonlyArray<T>>([])
+  const loading = ref(false)
+  const error = ref(false)
+  const limit = options.limit ?? 20
+  const debounceMs = options.debounceMs ?? 250
+  let requestId = 0
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let activeController: AbortController | undefined
+
+  const localResults = computed<ReadonlyArray<T>>(() => {
+    const query = options.query.value.trim().toLowerCase()
+    const symbols = toValue(options.symbols)
+    return query ? symbols.filter((item) => matchesQuery(item, query)) : symbols
+  })
+
+  const results = computed<ReadonlyArray<T>>(() => {
+    if (!options.query.value.trim()) return localResults.value
+    const unique = new Map<string, T>()
+    for (const item of [...localResults.value, ...remoteResults.value]) {
+      const key = symbolIdentityKey(item)
+      if (!unique.has(key)) unique.set(key, item)
+    }
+    return [...unique.values()]
+  })
+
+  function scheduleSearch() {
+    requestId++
+    const currentRequest = requestId
+    if (timer !== undefined) clearTimeout(timer)
+    activeController?.abort()
+    activeController = undefined
+    remoteResults.value = []
+    loading.value = false
+    error.value = false
+
+    const query = options.query.value.trim()
+    const search = toValue(options.search)
+    if (!query || !search) return
+
+    timer = setTimeout(async () => {
+      const controller = new AbortController()
+      activeController = controller
+      loading.value = true
+      try {
+        const found = await search(query, limit, controller.signal)
+        if (currentRequest !== requestId) return
+        remoteResults.value = found
+      } catch {
+        if (currentRequest !== requestId) return
+        error.value = true
+        remoteResults.value = []
+      } finally {
+        if (currentRequest === requestId) {
+          activeController = undefined
+          loading.value = false
+        }
+      }
+    }, debounceMs)
+  }
+
+  watch([options.query, () => toValue(options.search)], scheduleSearch, { immediate: true })
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      requestId++
+      if (timer !== undefined) clearTimeout(timer)
+      activeController?.abort()
+    })
+  }
+
+  return { results, loading, error }
+}

--- a/packages/vue/src/composables/useSymbolSearch.ts
+++ b/packages/vue/src/composables/useSymbolSearch.ts
@@ -29,12 +29,16 @@ export type SymbolSearchFn<T extends SearchableSymbol = SearchableSymbol> = (
   query: string,
   limit: number,
   signal: AbortSignal,
+  /** 限定搜索的数据源；省略则使用调用方默认启用列表 */
+  sources?: ReadonlyArray<string>,
 ) => Promise<ReadonlyArray<T>>
 
 interface UseSymbolSearchOptions<T extends SearchableSymbol> {
   query: Ref<string>
   symbols: MaybeRefOrGetter<ReadonlyArray<T>>
   search: MaybeRefOrGetter<SymbolSearchFn<T> | undefined>
+  /** 当前选中的聚合源；all 或未传表示不过滤 */
+  sourceFilter?: MaybeRefOrGetter<string | 'all' | undefined>
   limit?: number
   debounceMs?: number
 }
@@ -73,9 +77,17 @@ export function useSymbolSearch<T extends SearchableSymbol>(options: UseSymbolSe
   let timer: ReturnType<typeof setTimeout> | undefined
   let activeController: AbortController | undefined
 
+  function activeSourceFilter(): string | undefined {
+    const filter = options.sourceFilter === undefined ? 'all' : toValue(options.sourceFilter)
+    if (!filter || filter === 'all') return undefined
+    return filter
+  }
+
   const localResults = computed<ReadonlyArray<T>>(() => {
     const query = options.query.value.trim().toLowerCase()
-    const symbols = toValue(options.symbols)
+    const source = activeSourceFilter()
+    let symbols = toValue(options.symbols)
+    if (source) symbols = symbols.filter((item) => item.source === source)
     return query ? symbols.filter((item) => matchesQuery(item, query)) : symbols
   })
 
@@ -103,12 +115,15 @@ export function useSymbolSearch<T extends SearchableSymbol>(options: UseSymbolSe
     const search = toValue(options.search)
     if (!query || !search) return
 
+    const source = activeSourceFilter()
+    const sources = source ? [source] : undefined
+
     timer = setTimeout(async () => {
       const controller = new AbortController()
       activeController = controller
       loading.value = true
       try {
-        const found = await search(query, limit, controller.signal)
+        const found = await search(query, limit, controller.signal, sources)
         if (currentRequest !== requestId) return
         remoteResults.value = found
       } catch {
@@ -124,7 +139,11 @@ export function useSymbolSearch<T extends SearchableSymbol>(options: UseSymbolSe
     }, debounceMs)
   }
 
-  watch([options.query, () => toValue(options.search)], scheduleSearch, { immediate: true })
+  watch(
+    [options.query, () => toValue(options.search), () => toValue(options.sourceFilter)],
+    scheduleSearch,
+    { immediate: true },
+  )
 
   if (getCurrentScope()) {
     onScopeDispose(() => {


### PR DESCRIPTION
## Summary

- Add aggregation source management UI (enable/disable, host/port, online probe, localStorage)
- Add search-bar source tabs to filter multi-source results
- Stop guessing gotdx market/category from code/exchange; require search-provided params
- Forward params.kind so index symbols route to GetIndexBars on tdx-api
- Disambiguate same-code symbols (e.g. 000001) via exchange / kind / market / category meta

Related to #105

## Test plan

- [ ] Open aggregation source panel from search bar and chart settings
- [ ] Toggle sources; verify search only hits enabled sources
- [ ] Search `000001` and select 平安银行 vs 上证指数 with distinct params
- [ ] Verify daily K-line loads for both stock and index via gotdx
- [ ] Core/Vue unit tests: `pnpm --filter @363045841yyt/klinechart-core test` and package Vue tests
